### PR TITLE
Fix gas requirements for log_metadata

### DIFF
--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -19,7 +19,7 @@ mod types;
 use types::*;
 
 const LOG_METADATA_GAS: Gas = Gas::from_tgas(10);
-const LOG_METADATA_CALLBCAK_GAS: Gas = Gas::from_tgas(30);
+const LOG_METADATA_CALLBCAK_GAS: Gas = Gas::from_tgas(260);
 const MPC_SIGNING_GAS: Gas = Gas::from_tgas(250);
 const SIGN_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(5);
 const VERIFY_POOF_GAS: Gas = Gas::from_tgas(50);


### PR DESCRIPTION
log_metadata calls MPC signing service which requires 250 tgas