### PR TITLE
NEP141-Locker: implement storage deposit

### DIFF
--- a/near/nep141-locker/src/errors.rs
+++ b/near/nep141-locker/src/errors.rs
@@ -1,0 +1,39 @@
+use near_sdk::env::panic_str;
+
+const INVALID_UTF8_ERR_STRING: &str = "INVALID_UTF8_ERR_STRING";
+
+pub trait SdkExpect<T> {
+    fn sdk_expect(self, msg: &str) -> T;
+}
+
+impl<T> SdkExpect<T> for Option<T> {
+    fn sdk_expect(self, msg: &str) -> T {
+        self.unwrap_or_else(|| panic_str(msg))
+    }
+}
+
+impl<T, E> SdkExpect<T> for Result<T, E> {
+    fn sdk_expect(self, msg: &str) -> T {
+        self.unwrap_or_else(|_| panic_str(msg))
+    }
+}
+
+pub trait SdkUnwrap<T> {
+    fn sdk_unwrap(self) -> T;
+}
+
+impl<T> SdkUnwrap<T> for Option<T> {
+    fn sdk_unwrap(self) -> T {
+        self.unwrap_or_else(|| panic_str("ERR_UNWRAP"))
+    }
+}
+
+impl<T, E: AsRef<[u8]>> SdkUnwrap<T> for Result<T, E> {
+    fn sdk_unwrap(self) -> T {
+        self.unwrap_or_else(|e| panic_str(err_to_str(&e)))
+    }
+}
+
+fn err_to_str<E: AsRef<[u8]>>(err: &E) -> &str {
+    std::str::from_utf8(err.as_ref()).unwrap_or(INVALID_UTF8_ERR_STRING)
+}

--- a/near/nep141-locker/src/errors.rs
+++ b/near/nep141-locker/src/errors.rs
@@ -1,7 +1,5 @@
 use near_sdk::env::panic_str;
 
-const INVALID_UTF8_ERR_STRING: &str = "INVALID_UTF8_ERR_STRING";
-
 pub trait SdkExpect<T> {
     fn sdk_expect(self, msg: &str) -> T;
 }
@@ -16,24 +14,4 @@ impl<T, E> SdkExpect<T> for Result<T, E> {
     fn sdk_expect(self, msg: &str) -> T {
         self.unwrap_or_else(|_| panic_str(msg))
     }
-}
-
-pub trait SdkUnwrap<T> {
-    fn sdk_unwrap(self) -> T;
-}
-
-impl<T> SdkUnwrap<T> for Option<T> {
-    fn sdk_unwrap(self) -> T {
-        self.unwrap_or_else(|| panic_str("ERR_UNWRAP"))
-    }
-}
-
-impl<T, E: AsRef<[u8]>> SdkUnwrap<T> for Result<T, E> {
-    fn sdk_unwrap(self) -> T {
-        self.unwrap_or_else(|e| panic_str(err_to_str(&e)))
-    }
-}
-
-fn err_to_str<E: AsRef<[u8]>>(err: &E) -> &str {
-    std::str::from_utf8(err.as_ref()).unwrap_or(INVALID_UTF8_ERR_STRING)
 }

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -144,6 +144,7 @@ impl FungibleTokenReceiver for Contract {
             sender: OmniAddress::Near(sender_id.to_string()),
         };
 
+        // TODO: add native token as fee attachment
         let required_storage_balance =
             self.add_transfer_message(self.current_nonce, &transfer_message, &sender_id);
         self.update_storage_balance(

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -1,4 +1,4 @@
-use errors::{SdkExpect, SdkUnwrap};
+use errors::SdkExpect;
 use near_plugins::{
     access_control, access_control_any, pause, AccessControlRole, AccessControllable, Pausable,
     Upgradable,
@@ -140,7 +140,7 @@ impl FungibleTokenReceiver for Contract {
             origin_nonce: U128(self.current_nonce),
             token: env::predecessor_account_id(),
             amount,
-            recipient: msg.parse().sdk_unwrap(),
+            recipient: msg.parse().sdk_expect("ERR_PARSE_MSG"),
             fee: U128(0), // TODO get fee from msg
             sender: OmniAddress::Near(sender_id.to_string()),
         };
@@ -614,8 +614,7 @@ impl Contract {
         message_owner: &AccountId,
     ) -> NearToken {
         let storage_usage = env::storage_usage();
-        self.insert_raw_transfer(nonce, transfer_message, message_owner)
-            .sdk_unwrap();
+        self.insert_raw_transfer(nonce, transfer_message, message_owner);
         env::storage_byte_cost().saturating_mul((env::storage_usage() - storage_usage).into())
     }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -638,7 +638,7 @@ impl Contract {
             .get(&owner)
             .sdk_expect("ERR_ACCOUNT_NOT_REGISTERED");
 
-        storage.available = storage.available.saturating_sub(refund);
+        storage.available = storage.available.saturating_add(refund);
         self.accounts_balances.insert(&owner, &storage);
 
         transfer_message

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -22,8 +22,9 @@ use omni_types::prover_args::VerifyProofArgs;
 use omni_types::prover_result::ProverResult;
 use omni_types::{
     ChainKind, MetadataPayload, NearRecipient, Nonce, OmniAddress, SignRequest, TransferMessage,
-    TransferMessagePayload, TransferMessageStorage, UpdateFee,
+    TransferMessagePayload, UpdateFee,
 };
+use storage::TransferMessageStorage;
 
 mod errors;
 mod storage;

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -614,7 +614,11 @@ impl Contract {
         message_owner: &AccountId,
     ) -> NearToken {
         let storage_usage = env::storage_usage();
-        self.insert_raw_transfer(nonce, transfer_message, message_owner);
+        require!(
+            self.insert_raw_transfer(nonce, transfer_message, message_owner)
+                .is_some(),
+            "ERR_KEY_EXIST"
+        );
         env::storage_byte_cost().saturating_mul((env::storage_usage() - storage_usage).into())
     }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -598,11 +598,11 @@ impl Contract {
         &mut self,
         nonce: u128,
         transfer_message: &TransferMessage,
-        sender_id: &AccountId,
+        message_owner: &AccountId,
     ) -> Option<Vec<u8>> {
         self.pending_transfers.insert_raw(
             &borsh::to_vec(&nonce).sdk_expect("ERR_BORSH"),
-            &TransferMessageStorage::encode_borsh(transfer_message, sender_id)
+            &TransferMessageStorage::encode_borsh(transfer_message, message_owner)
                 .sdk_expect("ERR_BORSH"),
         )
     }

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -4,13 +4,15 @@ use near_sdk::{env, near_bindgen, AccountId, NearToken};
 
 use crate::*;
 
+pub type TransferMessageStorageValue = (TransferMessage, AccountId);
+
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub enum TransferMessageStorage {
-    V0((TransferMessage, AccountId)),
+    V0(TransferMessageStorageValue),
 }
 
 impl TransferMessageStorage {
-    pub fn into_main(self) -> (TransferMessage, AccountId) {
+    pub fn into_main(self) -> TransferMessageStorageValue {
         match self {
             TransferMessageStorage::V0(m) => m,
         }

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -1,0 +1,68 @@
+use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
+use near_sdk::{env, near_bindgen, AccountId, NearToken};
+
+use crate::*;
+
+#[near_bindgen]
+impl Contract {
+    #[payable]
+    pub fn storage_deposit(&mut self, account_id: Option<AccountId>) -> StorageBalance {
+        let account_id = account_id.unwrap_or_else(env::predecessor_account_id);
+        let amount = env::attached_deposit();
+        let storage = if let Some(mut storage) = self.accounts.get(&account_id) {
+            storage.total = storage.total.saturating_add(amount);
+            storage.available = storage.available.saturating_add(amount);
+            storage
+        } else {
+            let min_required_storage_balance =
+                env::storage_byte_cost().saturating_mul(self.account_storage_usage.into());
+            let total = amount
+                .checked_sub(min_required_storage_balance)
+                .sdk_expect("The attached deposit is less than the minimum storage balance");
+            StorageBalance {
+                total,
+                available: total,
+            }
+        };
+
+        self.accounts.insert(&account_id, &storage);
+        storage
+    }
+
+    pub fn storage_withdraw(&mut self, amount: Option<NearToken>) -> StorageBalance {
+        let account_id = env::predecessor_account_id();
+        let mut storage = self
+            .storage_balance_of(&account_id)
+            .sdk_expect("The account is not registered");
+        let to_withdraw = amount.unwrap_or(storage.available);
+        storage.total = storage
+            .total
+            .checked_sub(to_withdraw)
+            .sdk_expect("The amount is greater than the total storage balance");
+        storage.available = storage
+            .available
+            .checked_sub(to_withdraw)
+            .sdk_expect("The amount is greater than the available storage balance");
+
+        if storage.total == NearToken::from_yoctonear(0) {
+            self.accounts.remove(&account_id);
+        } else {
+            self.accounts.insert(&account_id, &storage);
+        }
+
+        storage
+    }
+
+    pub fn storage_balance_bounds(&self) -> StorageBalanceBounds {
+        let required_storage_balance =
+            env::storage_byte_cost().saturating_mul(self.account_storage_usage.into());
+        StorageBalanceBounds {
+            min: required_storage_balance,
+            max: None,
+        }
+    }
+
+    pub fn storage_balance_of(&self, account_id: &AccountId) -> Option<StorageBalance> {
+        self.accounts.get(&account_id)
+    }
+}

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -1,4 +1,5 @@
 use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
+use near_sdk::{assert_one_yocto, borsh};
 use near_sdk::{env, near_bindgen, AccountId, NearToken};
 
 use crate::*;
@@ -9,27 +10,28 @@ impl Contract {
     pub fn storage_deposit(&mut self, account_id: Option<AccountId>) -> StorageBalance {
         let account_id = account_id.unwrap_or_else(env::predecessor_account_id);
         let amount = env::attached_deposit();
-        let storage = if let Some(mut storage) = self.accounts.get(&account_id) {
+        let storage = if let Some(mut storage) = self.accounts_balances.get(&account_id) {
             storage.total = storage.total.saturating_add(amount);
             storage.available = storage.available.saturating_add(amount);
             storage
         } else {
-            let min_required_storage_balance =
-                env::storage_byte_cost().saturating_mul(self.account_storage_usage.into());
-            let total = amount
+            let min_required_storage_balance = self.required_balance_for_account();
+            let available = amount
                 .checked_sub(min_required_storage_balance)
                 .sdk_expect("The attached deposit is less than the minimum storage balance");
             StorageBalance {
-                total,
-                available: total,
+                total: amount,
+                available,
             }
         };
 
-        self.accounts.insert(&account_id, &storage);
+        self.accounts_balances.insert(&account_id, &storage);
         storage
     }
 
+    #[payable]
     pub fn storage_withdraw(&mut self, amount: Option<NearToken>) -> StorageBalance {
+        assert_one_yocto();
         let account_id = env::predecessor_account_id();
         let mut storage = self
             .storage_balance_of(&account_id)
@@ -44,25 +46,67 @@ impl Contract {
             .checked_sub(to_withdraw)
             .sdk_expect("The amount is greater than the available storage balance");
 
-        if storage.total == NearToken::from_yoctonear(0) {
-            self.accounts.remove(&account_id);
-        } else {
-            self.accounts.insert(&account_id, &storage);
-        }
-
+        self.accounts_balances.insert(&account_id, &storage);
         storage
     }
 
     pub fn storage_balance_bounds(&self) -> StorageBalanceBounds {
-        let required_storage_balance =
-            env::storage_byte_cost().saturating_mul(self.account_storage_usage.into());
         StorageBalanceBounds {
-            min: required_storage_balance,
+            min: self.required_balance_for_account(),
             max: None,
         }
     }
 
     pub fn storage_balance_of(&self, account_id: &AccountId) -> Option<StorageBalance> {
-        self.accounts.get(&account_id)
+        self.accounts_balances.get(&account_id)
+    }
+
+    pub fn required_balance_for_account(&self) -> NearToken {
+        let key_len = 68;
+        let value_len = borsh::to_vec(&StorageBalance {
+            total: NearToken::from_yoctonear(0),
+            available: NearToken::from_yoctonear(0),
+        })
+        .sdk_expect("ERR_BORSH")
+        .len() as u64;
+
+        env::storage_byte_cost()
+            .saturating_mul((Self::get_basic_storage() + key_len + value_len).into())
+    }
+
+    pub fn required_balance_for_init_transfer(
+        &self,
+        token: AccountId,
+        recipient: OmniAddress,
+        sender: OmniAddress,
+    ) -> NearToken {
+        let key_len = borsh::to_vec(&0_u128).sdk_expect("ERR_BORSH").len() as u64;
+        let value_len = borsh::to_vec(&TransferMessage {
+            origin_nonce: U128(0),
+            token,
+            amount: U128(0),
+            recipient,
+            fee: U128(0),
+            sender,
+        })
+        .sdk_expect("ERR_BORSH")
+        .len() as u64;
+
+        env::storage_byte_cost()
+            .saturating_mul((Self::get_basic_storage() + key_len + value_len).into())
+    }
+
+    pub fn required_balance_for_fin_transfer(&self) -> NearToken {
+        let key_len = borsh::to_vec(&(ChainKind::Eth, 0_u128))
+            .sdk_expect("ERR_BORSH")
+            .len() as u64;
+
+        env::storage_byte_cost().saturating_mul((Self::get_basic_storage() + key_len).into())
+    }
+
+    fn get_basic_storage() -> u64 {
+        const EXTRA_BYTES_RECORD: u64 = 40;
+        const EXTRA_KEY_PREFIX_LEN: u64 = 1;
+        EXTRA_BYTES_RECORD + EXTRA_KEY_PREFIX_LEN
     }
 }

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -87,7 +87,7 @@ impl Contract {
     }
 
     pub fn required_balance_for_account(&self) -> NearToken {
-        let key_len = 68;
+        let key_len = 64 + 4;
         let value_len = borsh::to_vec(&StorageBalance {
             total: NearToken::from_yoctonear(0),
             available: NearToken::from_yoctonear(0),

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -203,31 +203,6 @@ pub struct TransferMessage {
     pub sender: OmniAddress,
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
-pub enum TransferMessageStorage {
-    V0((TransferMessage, AccountId)),
-}
-
-impl TransferMessageStorage {
-    pub fn into_main(self) -> (TransferMessage, AccountId) {
-        match self {
-            TransferMessageStorage::V0(m) => m,
-        }
-    }
-
-    pub fn encode_borsh(
-        message: &TransferMessage,
-        account: &AccountId,
-    ) -> Result<Vec<u8>, std::io::Error> {
-        #[derive(BorshSerialize)]
-        enum RefTransferMessageStorage<'a> {
-            V0((&'a TransferMessage, &'a AccountId)),
-        }
-
-        borsh::to_vec(&RefTransferMessageStorage::V0((message, account)))
-    }
-}
-
 impl TransferMessage {
     pub fn get_origin_chain(&self) -> ChainKind {
         self.sender.get_chain()

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -203,6 +203,31 @@ pub struct TransferMessage {
     pub sender: OmniAddress,
 }
 
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+pub enum TransferMessageStorage {
+    V0((TransferMessage, AccountId)),
+}
+
+impl TransferMessageStorage {
+    pub fn into_main(self) -> (TransferMessage, AccountId) {
+        match self {
+            TransferMessageStorage::V0(m) => m,
+        }
+    }
+
+    pub fn encode_borsh(
+        message: &TransferMessage,
+        account: &AccountId,
+    ) -> Result<Vec<u8>, std::io::Error> {
+        #[derive(BorshSerialize)]
+        enum RefTransferMessageStorage<'a> {
+            V0((&'a TransferMessage, &'a AccountId)),
+        }
+
+        borsh::to_vec(&RefTransferMessageStorage::V0((message, account)))
+    }
+}
+
 impl TransferMessage {
     pub fn get_origin_chain(&self) -> ChainKind {
         self.sender.get_chain()


### PR DESCRIPTION
- Make the storage upgradable by introducing `TransferMessageStorage` type.
- Replace `unwrap_or_else` with `SdkExpect`
- Introduce storage management.
- Add API to retrieve required storage deposits for different actions.