### PR TITLE
fix: typo

### DIFF
--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -142,7 +142,7 @@ impl FungibleTokenReceiver for Contract {
             origin_nonce: U128(self.current_nonce),
             token: env::predecessor_account_id(),
             amount,
-            recipient: parsed_msg.recip,
+            recipient: parsed_msg.recipient,
             fee: parsed_msg.fee,
             sender: OmniAddress::Near(sender_id.to_string()),
         };


### PR DESCRIPTION
Renamed `recip` -> `recipient`