### PR TITLE
Fix: make MPC Signature serialization consistent with parsing on Ethereum

### DIFF
--- a/near/omni-types/src/mpc_types.rs
+++ b/near/omni-types/src/mpc_types.rs
@@ -21,13 +21,8 @@ pub struct SignatureResponse {
 impl SignatureResponse {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
-
         bytes.extend_from_slice(&hex::decode(&self.big_r.affine_point).expect("Incorrect Signature")[1..]);
-        bytes.push(0);
-
         bytes.extend_from_slice(&hex::decode(&self.s.scalar).expect("Incorrect Signature"));
-        bytes.push(0);
-
         bytes.push(self.recovery_id + 27);
 
         bytes

--- a/near/omni-types/src/mpc_types.rs
+++ b/near/omni-types/src/mpc_types.rs
@@ -22,10 +22,10 @@ impl SignatureResponse {
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
 
-        bytes.extend_from_slice(&self.big_r.affine_point.as_bytes()[1..]);
+        bytes.extend_from_slice(&hex::decode(&self.big_r.affine_point).expect("Incorrect Signature")[1..]);
         bytes.push(0);
 
-        bytes.extend_from_slice(self.s.scalar.as_bytes());
+        bytes.extend_from_slice(&hex::decode(&self.s.scalar).expect("Incorrect Signature"));
         bytes.push(0);
 
         bytes.push(self.recovery_id + 27);


### PR DESCRIPTION
Signature parsing on Eth: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol#L56