### PR TITLE
Add OmniBridge chain id to properly validate omnichain recipient address

### DIFF
--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -36,6 +36,7 @@ contract BridgeTokenFactory is
 
     address public tokenImplementationAddress;
     address public nearBridgeDerivedAddress;
+    uint8 private _omniBridgeChainId;
 
     mapping(uint128 => bool) public completedTransfers;
     uint128 public initTransferNonce; 
@@ -99,11 +100,13 @@ contract BridgeTokenFactory is
     error NonceAlreadyUsed(uint256 nonce);
 
     function initialize(
-        address _tokenImplementationAddress,
-        address _nearBridgeDerivedAddress
+        address tokenImplementationAddress_,
+        address nearBridgeDerivedAddress_,
+        uint8 omniBridgeChainId
     ) public initializer {
-        tokenImplementationAddress = _tokenImplementationAddress;
-        nearBridgeDerivedAddress = _nearBridgeDerivedAddress;
+        tokenImplementationAddress = tokenImplementationAddress_;
+        nearBridgeDerivedAddress = nearBridgeDerivedAddress_;
+        _omniBridgeChainId = omniBridgeChainId;
 
         __UUPSUpgradeable_init();
         __AccessControl_init();
@@ -201,7 +204,7 @@ contract BridgeTokenFactory is
             Borsh.encodeUint128(payload.nonce),
             Borsh.encodeString(payload.token),
             Borsh.encodeUint128(payload.amount),
-            bytes1(0x00), // variant 1 in rust enum
+            bytes1(_omniBridgeChainId),
             Borsh.encodeAddress(payload.recipient),
             bytes(payload.feeRecipient).length == 0  // None or Some(String) in rust
                 ? bytes("\x00") 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -25,12 +25,13 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
     uint32 public wormholeNonce;
 
     function initializeWormhole(
-        address _tokenImplementationAddress,
-        address _nearBridgeDerivedAddress,
+        address tokenImplementationAddress,
+        address nearBridgeDerivedAddress,
+        uint8 omniBridgeChainId,
         address wormholeAddress,
         uint8 consistencyLevel
     ) external initializer {
-        initialize(_tokenImplementationAddress, _nearBridgeDerivedAddress);
+        initialize(tokenImplementationAddress, nearBridgeDerivedAddress, omniBridgeChainId);
         _wormhole = IWormhole(wormholeAddress);
         _consistencyLevel = consistencyLevel;
     }

--- a/evm/bridge-token-factory/hardhat.config.js
+++ b/evm/bridge-token-factory/hardhat.config.js
@@ -52,6 +52,7 @@ task('add-account-to-whitelist-eth', 'Add an account to whitelist')
 task("deploy-bridge-token-factory", "Deploys the BridgeTokenFactory contract")
   .addParam("bridgeTokenImpl", "The address of the bridge token implementation")
   .addParam("nearBridgeDerivedAddress", "The derived EVM address of the Near's OmniBridge")
+  .addParam("omniBridgeChainId", "Chain Id of the network in the OmniBridge")
   .setAction(async (taskArgs, hre) => {
     const { ethers, upgrades } = hre;
 
@@ -61,7 +62,8 @@ task("deploy-bridge-token-factory", "Deploys the BridgeTokenFactory contract")
       BridgeTokenFactoryContract,
       [
         taskArgs.bridgeTokenImpl,
-        taskArgs.nearBridgeDerivedAddress
+        taskArgs.nearBridgeDerivedAddress,
+        taskArgs.omniBridgeChainId
       ],
       {
         initializer: "initialize",

--- a/evm/bridge-token-factory/test/BridgeToken.js
+++ b/evm/bridge-token-factory/test/BridgeToken.js
@@ -38,11 +38,13 @@ describe('BridgeToken', () => {
     await bridgeToken.waitForDeployment()
 
     const nearBridgeDeriveAddress = await deriveEthereumAddress('omni-locker.test1-dev.testnet', 'bridge-1');
+    const omniBridgeChainId = 0;
 
     BridgeTokenFactory = await ethers.getContractFactory('BridgeTokenFactory')
     BridgeTokenFactory = await upgrades.deployProxy(BridgeTokenFactory, [
       await bridgeToken.getAddress(),
-      nearBridgeDeriveAddress
+      nearBridgeDeriveAddress,
+      omniBridgeChainId,
     ], { initializer: 'initialize' });
     await BridgeTokenFactory.waitForDeployment();
   })

--- a/evm/bridge-token-factory/test/BridgeTokenWormhole.js
+++ b/evm/bridge-token-factory/test/BridgeTokenWormhole.js
@@ -27,11 +27,13 @@ describe('BridgeTokenWormhole', () => {
     await TestWormhole.waitForDeployment();
 
     const nearBridgeDeriveAddress = await deriveEthereumAddress('omni-locker.test1-dev.testnet', 'bridge-1');
+    const omniBridgeChainId = 0;
 
     BridgeTokenFactory = await ethers.getContractFactory('BridgeTokenFactoryWormhole');
     BridgeTokenFactory = await upgrades.deployProxy(BridgeTokenFactory, [
       await bridgeToken.getAddress(),
       nearBridgeDeriveAddress,
+      omniBridgeChainId,
       await TestWormhole.getAddress(),
       consistencyLevel
     ], { initializer: 'initializeWormhole' });


### PR DESCRIPTION
Currently tokens are only minted for Ethereum signature because we hardcoded 0 as OmniAddress enum variant