### PR TITLE
feat: EVM locker implementation

### DIFF
--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -18,6 +18,9 @@ contract BridgeTokenFactory is
     AccessControlUpgradeable,
     SelectivePausableUpgradable
 {
+    // We removed ProofConsumer from the list of parent contracts and added this gap
+    // to preserve storage layout when upgrading to the new contract version.
+    uint256[54] private __gap;
     using SafeERC20 for IERC20;
     mapping(address => string) public ethToNearToken;
     mapping(string => address) public nearToEthToken;
@@ -27,6 +30,7 @@ contract BridgeTokenFactory is
     address public nearBridgeDerivedAddress;
     uint8 public omniBridgeChainId;
 
+    uint256[3] private __gapForRemovedFields;
     mapping(uint128 => bool) public completedTransfers;
     mapping(uint128 => bool) public claimedFee;
     uint128 public currentNonce; 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -27,7 +27,6 @@ contract BridgeTokenFactory is
     address public nearBridgeDerivedAddress;
     uint8 public omniBridgeChainId;
 
-    uint256[3] private __gapForRemovedFields;
     mapping(uint128 => bool) public completedTransfers;
     mapping(uint128 => bool) public claimedFee;
     uint128 public currentNonce; 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -33,10 +33,8 @@ contract BridgeTokenFactory is
 
     bytes32 public constant PAUSABLE_ADMIN_ROLE = keccak256("PAUSABLE_ADMIN_ROLE");
     uint constant UNPAUSED_ALL = 0;
-    uint constant PAUSED_BURN_TOKEN = 1 << 0;
-    uint constant PAUSED_MINT_TOKEN = 1 << 1;
-    uint constant PAUSED_LOCK_TOKEN = 1 << 2;
-    uint constant PAUSED_UNLOCK_TOKEN = 1 << 3;
+    uint constant PAUSED_INIT_TRANSFER = 1 << 0;
+    uint constant PAUSED_FIN_TRANSFER = 1 << 1;
 
     error InvalidSignature();
     error NonceAlreadyUsed(uint256 nonce);
@@ -125,10 +123,10 @@ contract BridgeTokenFactory is
         );
     }
 
-    function mintToken(
+    function finTransfer(
         bytes calldata signatureData, 
         BridgeTypes.FinTransferPayload calldata payload
-    ) payable external whenNotPaused(PAUSED_MINT_TOKEN) {
+    ) payable external whenNotPaused(PAUSED_FIN_TRANSFER) {
         if (completedTransfers[payload.nonce]) {
             revert NonceAlreadyUsed(payload.nonce);
         }
@@ -179,7 +177,7 @@ contract BridgeTokenFactory is
         uint128 nativeFee,
         string calldata recipient,
         string calldata message
-    ) payable external whenNotPaused(PAUSED_BURN_TOKEN) {
+    ) payable external whenNotPaused(PAUSED_INIT_TRANSFER) {
         currentNonce += 1;
         if (fee >= amount) {
             revert InvalidFee();
@@ -247,7 +245,7 @@ contract BridgeTokenFactory is
     }
 
     function pauseAll() external onlyRole(PAUSABLE_ADMIN_ROLE) {
-        uint flags = PAUSED_MINT_TOKEN | PAUSED_BURN_TOKEN | PAUSED_LOCK_TOKEN | PAUSED_UNLOCK_TOKEN;
+        uint flags = PAUSED_FIN_TRANSFER | PAUSED_INIT_TRANSFER;
         _pause(flags);
     }
  

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -191,19 +191,20 @@ contract BridgeTokenFactory is
             IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
         }
 
-        initTransferExtension(initTransferNonce, tokenAddress, amount, fee, nativeFee, recipient, msg.sender, extensionValue);
+        initTransferExtension(msg.sender, tokenAddress, initTransferNonce, amount, fee, nativeFee, recipient, message, extensionValue);
 
         emit BridgeTypes.InitTransfer(msg.sender, tokenAddress, initTransferNonce, amount, fee, nativeFee, recipient, message);
     }
 
     function initTransferExtension(
-        uint128 nonce,
+        address sender,
         address tokenAddress,
+        uint128 nonce,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
         string calldata recipient,
-        address sender,
+        string calldata message,
         uint256 value
     ) internal virtual {}
 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -250,11 +250,11 @@ contract BridgeTokenFactory is
     }
  
     function upgradeToken(
-        string calldata nearTokenId,
+        address tokenAddress,
         address implementation
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(isBridgeToken[nearToEthToken[nearTokenId]], "ERR_NOT_BRIDGE_TOKEN");
-        BridgeToken proxy = BridgeToken(payable(nearToEthToken[nearTokenId]));
+        require(isBridgeToken[tokenAddress], "ERR_NOT_BRIDGE_TOKEN");
+        BridgeToken proxy = BridgeToken(tokenAddress);
         proxy.upgradeToAndCall(implementation, bytes(""));
     }
 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -148,14 +148,14 @@ contract BridgeTokenFactory is
             revert InvalidSignature();
         }
 
+        completedTransfers[payload.nonce] = true;
         address tokenAddress = nearToEthToken[payload.token];
+        
         if (tokenAddress != address(0)) {
             BridgeToken(tokenAddress).mint(payload.recipient, payload.amount);
         } else {
             IERC20(tokenAddress).safeTransfer(payload.recipient, payload.amount);
         }
- 
-        completedTransfers[payload.nonce] = true;
 
         finTransferExtension(payload);
 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -318,7 +318,7 @@ contract BridgeTokenFactory is
         uint flags = PAUSED_MINT_TOKEN | PAUSED_BURN_TOKEN | PAUSED_LOCK_TOKEN | PAUSED_UNLOCK_TOKEN;
         _pause(flags);
     }
-
+ 
     function upgradeToken(
         string calldata nearTokenId,
         address implementation

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -207,7 +207,7 @@ contract BridgeTokenFactory is
     ) internal virtual {}
 
     function lockToken(
-        address ethToken,
+        address tokenAddress,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
@@ -219,11 +219,11 @@ contract BridgeTokenFactory is
         }
 
         currentNonce += 1;
-        IERC20(ethToken).safeTransferFrom(msg.sender, address(this), amount);
+        IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
         uint256 extensionValue = msg.value - nativeFee;
-        lockTokenExtension(currentNonce, ethToken, msg.sender, amount, fee, nativeFee, recipient, message, extensionValue);
+        lockTokenExtension(currentNonce, tokenAddress, msg.sender, amount, fee, nativeFee, recipient, message, extensionValue);
 
-        emit BridgeTypes.Locked(currentNonce, ethToken, msg.sender, amount, fee, nativeFee, recipient, message);
+        emit BridgeTypes.Locked(currentNonce, tokenAddress, msg.sender, amount, fee, nativeFee, recipient, message);
     }
 
     function lockTokenExtension(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -18,9 +18,6 @@ contract BridgeTokenFactory is
     AccessControlUpgradeable,
     SelectivePausableUpgradable
 {
-    // We removed ProofConsumer from the list of parent contracts and added this gap
-    // to preserve storage layout when upgrading to the new contract version.
-    uint256[54] private __gap;
     using SafeERC20 for IERC20;
     mapping(address => string) public ethToNearToken;
     mapping(string => address) public nearToEthToken;

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -29,7 +29,7 @@ contract BridgeTokenFactory is
 
     mapping(uint128 => bool) public completedTransfers;
     mapping(uint128 => bool) public claimedFee;
-    uint128 public currentNonce; 
+    uint128 public initTransferNonce; 
 
     bytes32 public constant PAUSABLE_ADMIN_ROLE = keccak256("PAUSABLE_ADMIN_ROLE");
     uint constant UNPAUSED_ALL = 0;
@@ -178,7 +178,7 @@ contract BridgeTokenFactory is
         string calldata recipient,
         string calldata message
     ) payable external whenNotPaused(PAUSED_INIT_TRANSFER) {
-        currentNonce += 1;
+        initTransferNonce += 1;
         if (fee >= amount) {
             revert InvalidFee();
         }
@@ -191,9 +191,9 @@ contract BridgeTokenFactory is
             IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
         }
 
-        initTransferExtension(currentNonce, tokenAddress, amount, fee, nativeFee, recipient, msg.sender, extensionValue);
+        initTransferExtension(initTransferNonce, tokenAddress, amount, fee, nativeFee, recipient, msg.sender, extensionValue);
 
-        emit BridgeTypes.InitTransfer(msg.sender, tokenAddress, currentNonce, amount, fee, nativeFee, recipient, message);
+        emit BridgeTypes.InitTransfer(msg.sender, tokenAddress, initTransferNonce, amount, fee, nativeFee, recipient, message);
     }
 
     function initTransferExtension(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -47,7 +47,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
         wormholeNonce++;
     }
 
-function mintTokenExtension(BridgeTypes.MintTokenPayload memory payload) internal override {
+    function mintTokenExtension(BridgeTypes.MintTokenPayload memory payload) internal override {
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
             abi.encode(MessageType.FinTransfer, payload.token, payload.amount, payload.feeRecipient, payload.nonce),

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -47,7 +47,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
         wormholeNonce++;
     }
 
-    function finTransferExtension(BridgeTypes.FinTransferPayload memory payload) internal override {
+function mintTokenExtension(BridgeTypes.MintTokenPayload memory payload) internal override {
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
             abi.encode(MessageType.FinTransfer, payload.token, payload.amount, payload.feeRecipient, payload.nonce),
@@ -58,7 +58,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
 
     }
 
-    function initTransferExtension(
+    function burnTokenExtension(
         uint128 nonce,
         string calldata token,
         uint128 amount,

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -58,26 +58,28 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
     }
 
     function initTransferExtension(
-        uint128 nonce,
+        address sender,
         address tokenAddress,
+        uint128 nonce,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
         string calldata recipient,
-        address sender,
+        string calldata message,
         uint256 value
     ) internal override {
         _wormhole.publishMessage{value: value}(
             wormholeNonce,
             abi.encode(
                 MessageType.InitTransfer,
-                nonce,
+                sender,
                 tokenAddress,
+                nonce,
                 amount,
                 fee,
                 nativeFee,
                 recipient,
-                sender
+                message
             ),
             _consistencyLevel
         );

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -47,7 +47,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
         wormholeNonce++;
     }
 
-    function mintTokenExtension(BridgeTypes.MintTokenPayload memory payload) internal override {
+    function finTransferExtension(BridgeTypes.FinTransferPayload memory payload) internal override {
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
             abi.encode(MessageType.FinTransfer, payload.token, payload.amount, payload.feeRecipient, payload.nonce),
@@ -55,12 +55,11 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
         );
 
         wormholeNonce++;
-
     }
 
-    function burnTokenExtension(
+    function initTransferExtension(
         uint128 nonce,
-        string calldata token,
+        address tokenAddress,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
@@ -73,7 +72,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             abi.encode(
                 MessageType.InitTransfer,
                 nonce,
-                token,
+                tokenAddress,
                 amount,
                 fee,
                 nativeFee,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 library BridgeTypes {
-    struct MintTokenPayload {
+    struct FinTransferPayload {
         uint128 nonce;
         string token;
         uint128 amount;
@@ -31,18 +31,18 @@ library BridgeTypes {
         string feeRecipient;
     }
 
-    event BurnToken(
+    event InitTransfer(
         address indexed sender,
         address indexed tokenAddress,
         uint128 indexed nonce,
-        string token,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
-        string recipient
+        string recipient,
+        string message
     );
 
-    event MintToken(
+    event FinTransfer(
         uint128 indexed nonce,
         string token,
         uint128 amount,
@@ -71,23 +71,4 @@ library BridgeTypes {
         Metadata,
         ClaimNativeFee
     }
-
-    event Locked(
-        uint128 indexed nonce,
-        address indexed tokenAddress,
-        address indexed sender,
-        uint128 amount,
-        uint128 fee,
-        uint128 nativeFee,
-        string recipient,
-        string message
-    );
-
-    event Unlocked(
-        uint128 indexed nonce,
-        address indexed tokenAddress,
-        uint128 amount,
-        address recipient,
-        string feeRecipient
-    );
 }

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 library BridgeTypes {
     struct FinTransferPayload {
         uint128 nonce;
-        string token;
+        address tokenAddress;
         uint128 amount;
         address recipient;
         string feeRecipient;
@@ -36,7 +36,7 @@ library BridgeTypes {
 
     event FinTransfer(
         uint128 indexed nonce,
-        string token,
+        address tokenAddress,
         uint128 amount,
         address recipient,
         string feeRecipient

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -23,14 +23,6 @@ library BridgeTypes {
         address recipient;
     }
 
-    struct UnlockTokenPayload {
-        uint128 nonce;
-        address token;
-        uint128 amount;
-        address recipient;
-        string feeRecipient;
-    }
-
     event InitTransfer(
         address indexed sender,
         address indexed tokenAddress,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -73,19 +73,19 @@ library BridgeTypes {
     }
 
     event Locked(
-        uint128 nonce,
-        address indexed token,
+        uint128 indexed nonce,
+        address indexed tokenAddress,
         address indexed sender,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
-        string accountId,
-        string msg
+        string recipient,
+        string message
     );
 
     event Unlocked(
         uint128 indexed nonce,
-        address indexed token,
+        address indexed tokenAddress,
         uint128 amount,
         address recipient,
         string feeRecipient

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 library BridgeTypes {
-    struct FinTransferPayload {
+    struct MintTokenPayload {
         uint128 nonce;
         string token;
         uint128 amount;
@@ -23,7 +23,15 @@ library BridgeTypes {
         address recipient;
     }
 
-    event InitTransfer(
+    struct UnlockTokenPayload {
+        uint128 nonce;
+        address token;
+        uint128 amount;
+        address recipient;
+        string feeRecipient;
+    }
+
+    event BurnToken(
         address indexed sender,
         address indexed tokenAddress,
         uint128 indexed nonce,
@@ -34,7 +42,7 @@ library BridgeTypes {
         string recipient
     );
 
-    event FinTransfer(
+    event MintToken(
         uint128 indexed nonce,
         string token,
         uint128 amount,
@@ -63,4 +71,23 @@ library BridgeTypes {
         Metadata,
         ClaimNativeFee
     }
+
+    event Locked(
+        uint128 nonce,
+        address indexed token,
+        address indexed sender,
+        uint128 amount,
+        uint128 fee,
+        uint128 nativeFee,
+        string accountId,
+        string msg
+    );
+
+    event Unlocked(
+        uint128 indexed nonce,
+        address indexed token,
+        uint128 amount,
+        address recipient,
+        string feeRecipient
+    );
 }

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -397,10 +397,17 @@ impl Contract {
             require!(&transfer_message.fee == fee, "Invalid fee");
         }
 
+        let token_address = self
+            .get_token_address(
+                transfer_message.get_destination_chain(),
+                self.get_token_id(&transfer_message.token),
+            )
+            .unwrap_or_else(|| env::panic_str("ERR_FAILED_TO_GET_TOKEN_ADDRESS"));
+
         let transfer_payload = TransferMessagePayload {
             prefix: PayloadType::TransferMessage,
             nonce,
-            token: self.get_token_id(&transfer_message.token),
+            token_address,
             amount: U128(transfer_message.amount.0 - transfer_message.fee.fee.0),
             recipient: transfer_message.recipient,
             fee_recipient,

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -130,21 +130,18 @@ impl Contract {
             .saturating_mul((Self::get_basic_storage() + key_len + value_len).into())
     }
 
-    pub fn required_balance_for_init_transfer(
-        &self,
-        recipient: OmniAddress,
-        sender: OmniAddress,
-    ) -> NearToken {
+    pub fn required_balance_for_init_transfer(&self) -> NearToken {
         let key_len = borsh::to_vec(&0_u128).sdk_expect("ERR_BORSH").len() as u64;
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&TransferMessageStorage::V0(TransferMessageStorageValue {
             message: TransferMessage {
                 origin_nonce: U128(0),
-                token: max_account_id.clone(),
+                token: OmniAddress::Near(max_account_id.clone()),
                 amount: U128(0),
-                recipient,
+                recipient: OmniAddress::Near(max_account_id.clone()),
                 fee: Fee::default(),
-                sender,
+                sender: OmniAddress::Near(max_account_id.clone()),
+                msg: String::new(),
             },
             owner: max_account_id,
         }))
@@ -163,16 +160,18 @@ impl Contract {
         env::storage_byte_cost().saturating_mul((Self::get_basic_storage() + key_len).into())
     }
 
-    pub fn required_balance_for_bind_token(&self, deploy_token_address: &OmniAddress) -> NearToken {
+    pub fn required_balance_for_bind_token(&self) -> NearToken {
         let max_token_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
 
-        let key_len = borsh::to_vec(&(deploy_token_address.get_chain(), max_token_id))
+        let key_len = borsh::to_vec(&(ChainKind::Near, &max_token_id))
             .sdk_expect("ERR_BORSH")
-            .len() as u64;
+            .len() as u64
+            * 2;
 
-        let value_len = borsh::to_vec(deploy_token_address)
+        let value_len = borsh::to_vec(&OmniAddress::Near(max_token_id))
             .sdk_expect("ERR_BORSH")
-            .len() as u64;
+            .len() as u64
+            * 2;
 
         env::storage_byte_cost()
             .saturating_mul((Self::get_basic_storage() + key_len + value_len).into())

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -3,9 +3,10 @@
 use {
     crate::byte_utils::ByteUtils,
     alloy_sol_types::{sol, SolType},
-    near_sdk::{bs58, env},
+    near_sdk::env,
     omni_types::{
         prover_result::{DeployTokenMessage, FinTransferMessage, InitTransferMessage},
+        sol_address::SolAddress,
         stringify, EvmAddress, Fee, OmniAddress, TransferMessage, H160,
     },
 };
@@ -119,6 +120,7 @@ sol! {
         uint128 nativeFee;
         string recipient;
         address sender;
+        string message;
     }
 
     struct FinTransferWh {
@@ -152,6 +154,7 @@ impl TryInto<InitTransferMessage> for ParsedVAA {
                 recipient: transfer.recipient.parse().map_err(stringify)?,
                 origin_nonce: transfer.nonce.into(),
                 sender: to_omni_address(self.emitter_chain, &transfer.sender.0 .0),
+                msg: transfer.message,
             },
             emitter_address: to_omni_address(self.emitter_chain, &self.emitter_address),
         })
@@ -191,7 +194,7 @@ impl TryInto<DeployTokenMessage> for ParsedVAA {
 
 fn to_omni_address(emitter_chain: u16, address: &[u8]) -> OmniAddress {
     match emitter_chain {
-        1 => OmniAddress::Sol(bs58::encode(address).into_string()),
+        1 => OmniAddress::Sol(to_sol_address(address)),
         2 => OmniAddress::Eth(to_evm_address(address)),
         23 => OmniAddress::Arb(to_evm_address(address)),
         30 => OmniAddress::Base(to_evm_address(address)),
@@ -203,5 +206,12 @@ fn to_evm_address(address: &[u8]) -> EvmAddress {
     match address.try_into() {
         Ok(bytes) => H160(bytes),
         Err(_) => env::panic_str("Invalid EVM address"),
+    }
+}
+
+fn to_sol_address(address: &[u8]) -> SolAddress {
+    match address.try_into() {
+        Ok(bytes) => SolAddress(bytes),
+        Err(_) => env::panic_str("Invalid SOL address"),
     }
 }

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -113,13 +113,13 @@ impl ParsedVAA {
 
 sol! {
     struct InitTransferWh {
+        address sender;
+        address tokenAddress;
         uint128 nonce;
-        string token;
         uint128 amount;
         uint128 fee;
         uint128 nativeFee;
         string recipient;
-        address sender;
         string message;
     }
 
@@ -145,7 +145,7 @@ impl TryInto<InitTransferMessage> for ParsedVAA {
 
         Ok(InitTransferMessage {
             transfer: TransferMessage {
-                token: transfer.token.parse().map_err(stringify)?,
+                token: to_omni_address(self.emitter_chain, &transfer.tokenAddress.0 .0),
                 amount: transfer.amount.into(),
                 fee: Fee {
                     fee: transfer.fee.into(),

--- a/near/omni-tests/src/lib.rs
+++ b/near/omni-tests/src/lib.rs
@@ -228,7 +228,7 @@ mod tests {
             .call(locker_contract.id(), "fin_transfer")
             .args_borsh(FinTransferArgs {
                 chain_kind: omni_types::ChainKind::Eth,
-                native_fee_recipient: Some(OmniAddress::Near(account_1().to_string())),
+                native_fee_recipient: Some(OmniAddress::Near(account_1())),
                 storage_deposit_args: StorageDepositArgs {
                     token: token_contract.id().clone(),
                     accounts: storage_deposit_accounts,
@@ -237,14 +237,15 @@ mod tests {
                     emitter_address: eth_factory_address(),
                     transfer: TransferMessage {
                         origin_nonce: U128(1),
-                        token: token_contract.id().clone(),
-                        recipient: OmniAddress::Near(account_1().to_string()),
+                        token: OmniAddress::Near(token_contract.id().clone()),
+                        recipient: OmniAddress::Near(account_1()),
                         amount: U128(amount),
                         fee: Fee {
                             fee: U128(fee),
                             native_fee: U128(0),
                         },
                         sender: eth_eoa_address(),
+                        msg: String::default(),
                     },
                 }))
                 .unwrap(),

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -23,7 +23,7 @@ sol! {
 
     event FinTransfer(
         uint128 indexed nonce,
-        string token,
+        address tokenAddress,
         uint128 amount,
         address recipient,
         string feeRecipient

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -129,7 +129,7 @@ mod tests {
     sol! {
         event TestFinTransfer(
             uint128 indexed nonce,
-            string token,
+            address tokenAddress,
             uint128 amount,
             address recipient,
             string feeRecipient
@@ -141,14 +141,14 @@ mod tests {
         let event = FinTransfer {
             nonce: 55,
             amount: 100,
-            token: "some_token".to_owned(),
+            tokenAddress: [0; 20].into(),
             recipient: [0; 20].into(),
             feeRecipient: "some_fee_recipient".to_owned(),
         };
         let test_event = TestFinTransfer {
             nonce: event.nonce,
             amount: event.amount,
-            token: event.token.clone(),
+            tokenAddress: event.tokenAddress,
             recipient: event.recipient,
             feeRecipient: event.feeRecipient.clone(),
         };

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -14,11 +14,11 @@ sol! {
         address indexed sender,
         address indexed tokenAddress,
         uint128 indexed nonce,
-        string token,
         uint128 amount,
         uint128 fee,
         uint128 nativeTokenFee,
-        string recipient
+        string recipient,
+        string message
     );
 
     event FinTransfer(
@@ -88,7 +88,7 @@ impl TryFromLog<Log<InitTransfer>> for InitTransferMessage {
             emitter_address: OmniAddress::from_evm_address(chain_kind, H160(event.address.into()))?,
             transfer: TransferMessage {
                 origin_nonce: near_sdk::json_types::U128(event.data.nonce),
-                token: event.data.token.parse().map_err(stringify)?,
+                token: OmniAddress::from_evm_address(chain_kind, H160(event.tokenAddress.into()))?,
                 amount: near_sdk::json_types::U128(event.data.amount),
                 recipient: event.data.recipient.parse().map_err(stringify)?,
                 fee: Fee {
@@ -96,6 +96,7 @@ impl TryFromLog<Log<InitTransfer>> for InitTransferMessage {
                     native_fee: near_sdk::json_types::U128(event.data.nativeTokenFee),
                 },
                 sender: OmniAddress::from_evm_address(chain_kind, H160(event.data.sender.into()))?,
+                msg: event.data.message,
             },
         })
     }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -295,6 +295,10 @@ impl TransferMessage {
     pub fn get_transfer_id(&self) -> TransferId {
         (self.get_origin_chain(), self.origin_nonce.0)
     }
+
+    pub fn get_destination_chain(&self) -> ChainKind {
+        self.recipient.get_chain()
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
@@ -308,7 +312,7 @@ pub enum PayloadType {
 pub struct TransferMessagePayload {
     pub prefix: PayloadType,
     pub nonce: U128,
-    pub token: AccountId,
+    pub token_address: OmniAddress,
     pub amount: U128,
     pub recipient: OmniAddress,
     pub fee_recipient: Option<AccountId>,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -242,6 +242,38 @@ impl<'de> Deserialize<'de> for OmniAddress {
     }
 }
 
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+pub struct NearRecipient {
+    pub target: AccountId,
+    pub message: Option<String>,
+}
+
+impl FromStr for NearRecipient {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (target, message) = input.split_once(':').map_or_else(
+            || (input, None),
+            |(recipient, msg)| (recipient, Some(msg.to_owned())),
+        );
+
+        Ok(Self {
+            target: target.parse().map_err(stringify)?,
+            message,
+        })
+    }
+}
+
+impl fmt::Display for NearRecipient {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(message) = &self.message {
+            write!(f, "{}:{}", self.target, message)
+        } else {
+            write!(f, "{}", self.target)
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMsg {
     pub recipient: OmniAddress,

--- a/near/omni-types/src/sol_address.rs
+++ b/near/omni-types/src/sol_address.rs
@@ -1,0 +1,67 @@
+use core::fmt;
+use core::str::FromStr;
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::bs58;
+use near_sdk::serde::{Deserialize, Serialize};
+use serde::de::Visitor;
+
+#[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq, Eq)]
+pub struct SolAddress(pub [u8; 32]);
+
+impl FromStr for SolAddress {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let result = bs58::decode(s).into_vec().map_err(|err| err.to_string())?;
+
+        Ok(SolAddress(
+            result
+                .try_into()
+                .map_err(|err| format!("Invalid length: {err:?}"))?,
+        ))
+    }
+}
+
+impl fmt::Display for SolAddress {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", bs58::encode(self.0).into_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SolAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Base58Visitor;
+
+        impl<'de> Visitor<'de> for Base58Visitor {
+            type Value = SolAddress;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a base58 string")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                s.parse().map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_str(Base58Visitor)
+    }
+}
+
+impl Serialize for SolAddress {
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -158,12 +158,12 @@ fn test_chain_kind_from_omni_address() {
 
     test_chain_kind(OmniAddress::Eth(evm_address.clone()), ChainKind::Eth, "ETH");
     test_chain_kind(
-        OmniAddress::Near("alice.near".to_string()),
+        OmniAddress::Near("alice.near".parse().unwrap()),
         ChainKind::Near,
         "NEAR",
     );
     test_chain_kind(
-        OmniAddress::Sol("SoLaddr123".to_string()),
+        OmniAddress::Sol("11111111111111111111111111111111".parse().unwrap()),
         ChainKind::Sol,
         "SOL",
     );
@@ -206,12 +206,12 @@ fn test_omni_address_from_str() {
         ),
         (
             "near:alice.near".to_string(),
-            Ok(OmniAddress::Near("alice.near".to_string())),
+            Ok(OmniAddress::Near("alice.near".parse().unwrap())),
             "Should parse NEAR address",
         ),
         (
-            "sol:solana123".to_string(),
-            Ok(OmniAddress::Sol("solana123".to_string())),
+            "sol:11111111111111111111111111111111".to_string(),
+            Ok(OmniAddress::Sol("11111111111111111111111111111111".parse().unwrap())),
             "Should parse SOL address",
         ),
         (
@@ -253,13 +253,13 @@ fn test_omni_address_display() {
             "ETH address should format as eth:0x...",
         ),
         (
-            OmniAddress::Near("alice.near".to_string()),
+            OmniAddress::Near("alice.near".parse().unwrap()),
             "near:alice.near".to_string(),
             "NEAR address should format as near:account",
         ),
         (
-            OmniAddress::Sol("solana123".to_string()),
-            "sol:solana123".to_string(),
+            OmniAddress::Sol("11111111111111111111111111111111".parse().unwrap()),
+            "sol:11111111111111111111111111111111".to_string(),
             "SOL address should format as sol:address",
         ),
         (
@@ -431,11 +431,12 @@ fn test_transfer_message_getters() {
         (
             TransferMessage {
                 origin_nonce: U128(123),
-                token: "token.near".parse().unwrap(),
+                token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(1000),
-                recipient: OmniAddress::Near("bob.near".to_string()),
+                recipient: OmniAddress::Near("bob.near".parse().unwrap()),
                 fee: Fee::default(),
                 sender: OmniAddress::Eth(evm_addr.clone()),
+                msg: "".to_string(),
             },
             ChainKind::Eth,
             (ChainKind::Eth, 123),
@@ -444,11 +445,12 @@ fn test_transfer_message_getters() {
         (
             TransferMessage {
                 origin_nonce: U128(456),
-                token: "token.near".parse().unwrap(),
+                token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(2000),
                 recipient: OmniAddress::Eth(evm_addr.clone()),
                 fee: Fee::default(),
-                sender: OmniAddress::Near("alice.near".to_string()),
+                sender: OmniAddress::Near("alice.near".parse().unwrap()),
+                msg: "".to_string(),
             },
             ChainKind::Near,
             (ChainKind::Near, 456),
@@ -457,11 +459,12 @@ fn test_transfer_message_getters() {
         (
             TransferMessage {
                 origin_nonce: U128(789),
-                token: "token.near".parse().unwrap(),
+                token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(3000),
-                recipient: OmniAddress::Near("carol.near".to_string()),
+                recipient: OmniAddress::Near("carol.near".parse().unwrap()),
                 fee: Fee::default(),
-                sender: OmniAddress::Sol("solana123".to_string()),
+                sender: OmniAddress::Sol("11111111111111111111111111111111".parse().unwrap()),
+                msg: "".to_string(),
             },
             ChainKind::Sol,
             (ChainKind::Sol, 789),

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -211,7 +211,9 @@ fn test_omni_address_from_str() {
         ),
         (
             "sol:11111111111111111111111111111111".to_string(),
-            Ok(OmniAddress::Sol("11111111111111111111111111111111".parse().unwrap())),
+            Ok(OmniAddress::Sol(
+                "11111111111111111111111111111111".parse().unwrap(),
+            )),
             "Should parse SOL address",
         ),
         (


### PR DESCRIPTION
- Implemented EVM locker
- Changed the interface of the `EVM::initTransfer`, so it now accepts the token address instead of the token ID and message instead of `near_account_id:msg`.
- Map the token address and ID in both directions on the Near side to get the token ID by the address.
- Added the `SolAddress` type with validation.

Todo in follow-up PRs:
- Rename the factory contract and move the hardhat project to evm dir.
- Implement factory on Near