### PR TITLE
feat: implement NEAR token factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 **/target
+.history

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OMNI_RELAYER_MANIFEST = ./omni-relayer/Cargo.toml
 
 clippy: clippy-near #clippy-relayer
 
-clippy-near:
+clippy-near: rust-build-token
 	cargo clippy --manifest-path $(NEAR_MANIFEST) -- $(LINT_OPTIONS)
 
 fmt-near:
@@ -20,7 +20,10 @@ fmt-omni-relayer:
 clippy-omni-relayer:
 	cargo clippy --manifest-path $(OMNI_RELAYER_MANIFEST) -- $(LINT_OPTIONS)
 
-rust-build-near:
+rust-build-token:
+	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target wasm32-unknown-unknown --release --manifest-path $(NEAR_MANIFEST) --package omni-token
+
+rust-build-near: rust-build-token
 	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target wasm32-unknown-unknown --release --manifest-path $(NEAR_MANIFEST)
 
 test-near: rust-build-near

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -7,6 +7,7 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import "./BridgeToken.sol";
 import "./SelectivePausableUpgradable.sol";
@@ -122,6 +123,30 @@ contract BridgeTokenFactory is
             bridgeToken.decimals()
         );
     }
+
+    function logMetadata(
+        address tokenAddress
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        string memory name = IERC20Metadata(tokenAddress).name();
+        string memory symbol = IERC20Metadata(tokenAddress).symbol();
+        uint8 decimals = IERC20Metadata(tokenAddress).decimals();
+
+      logMetadataExtension(tokenAddress, name, symbol, decimals);
+       
+        emit BridgeTypes.LogMetadata(
+            tokenAddress,
+            name,
+            symbol,
+            decimals
+        );
+    }
+
+    function logMetadataExtension(
+        address tokenAddress,
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) internal virtual {}
 
     function finTransfer(
         bytes calldata signatureData, 

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -183,12 +183,20 @@ contract BridgeTokenFactory is
             revert InvalidFee();
         }
 
-        uint256 extensionValue = msg.value - nativeFee;
+        uint256 extensionValue;
 
-        if (isBridgeToken[tokenAddress]) {
-            BridgeToken(tokenAddress).burn(msg.sender, amount);
+        if (tokenAddress == address(0)) {
+            if (fee != 0) {
+                revert InvalidFee();
+            }
+            extensionValue = msg.value - amount - nativeFee;
         } else {
-            IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
+            extensionValue = msg.value - nativeFee;
+            if (isBridgeToken[tokenAddress]) {
+                BridgeToken(tokenAddress).burn(msg.sender, amount);
+            } else {
+                IERC20(tokenAddress).safeTransferFrom(msg.sender, address(this), amount);
+            }
         }
 
         initTransferExtension(msg.sender, tokenAddress, initTransferNonce, amount, fee, nativeFee, recipient, message, extensionValue);

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -16,7 +16,8 @@ interface IWormhole {
 enum MessageType {
     InitTransfer,
     FinTransfer,
-    DeployToken
+    DeployToken,
+    LogMetadata
 }
 
 contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
@@ -43,6 +44,30 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             Borsh.encodeString(token),
             Borsh.encodeAddress(tokenAddress)
         );
+        _wormhole.publishMessage{value: msg.value}(
+            wormholeNonce,
+            payload,
+            _consistencyLevel
+        );
+
+        wormholeNonce++;
+    }
+
+
+    function logMetadataExtension(
+        address tokenAddress,
+        string memory name,
+        string memory symbol,
+        uint8 decimals
+    ) internal override {
+        bytes memory payload = bytes.concat(
+            bytes1(uint8(MessageType.LogMetadata)),
+            Borsh.encodeAddress(tokenAddress),
+            Borsh.encodeString(name),
+            Borsh.encodeString(symbol),
+            bytes1(decimals)
+        );
+
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
             payload,

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -60,7 +60,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             Borsh.encodeString(payload.feeRecipient),
             Borsh.encodeUint128(payload.nonce)
         );
-        _wormhole.publishMessage{value: msg.value} (
+        _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
             messagePayload,
             _consistencyLevel

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -50,7 +50,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
     function finTransferExtension(BridgeTypes.FinTransferPayload memory payload) internal override {
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,
-            abi.encode(MessageType.FinTransfer, payload.token, payload.amount, payload.feeRecipient, payload.nonce),
+            abi.encode(MessageType.FinTransfer, payload.tokenAddress, payload.amount, payload.feeRecipient, payload.nonce),
             _consistencyLevel
         );
 

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -50,6 +50,13 @@ library BridgeTypes {
         uint8 decimals
     );
 
+    event LogMetadata(
+        address indexed tokenAddress,
+        string name,
+        string symbol,
+        uint8 decimals
+    );
+
     event SetMetadata(
         address indexed tokenAddress,
         string token,

--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -3924,6 +3924,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "omni-token"
+version = "0.1.0"
+dependencies = [
+ "near-contract-standards",
+ "near-sdk",
+]
+
+[[package]]
 name = "omni-types"
 version = "2.0.0"
 dependencies = [
@@ -5841,6 +5849,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56eb9e5a28c3c4f0a6aa8ea70a8ad2d6c53e4bf364571ce78f57945b6766843"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "token-deployer"
+version = "0.1.0"
+dependencies = [
+ "borsh",
+ "hex",
+ "near-contract-standards",
+ "near-plugins",
+ "near-sdk",
+ "omni-types",
+ "serde",
 ]
 
 [[package]]

--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -3929,6 +3929,7 @@ version = "0.1.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
+ "omni-types",
 ]
 
 [[package]]

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Karim Alabtakh <karim.alabtakh@nearone.org>"]
 resolver = "2"
 members = [
     "nep141-locker",
+    "token-deployer",
     "omni-prover/omni-prover",
     "omni-prover/wormhole-omni-prover-proxy",
     "omni-prover/evm-prover",
+    "omni-token",
     "omni-types",
     "omni-tests",
     "mock/mock-token",

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -790,7 +790,7 @@ impl Contract {
                 Self::ext(env::current_account_id())
                     .with_attached_deposit(NO_DEPOSIT)
                     .with_static_gas(DEPLOY_TOKEN_CALLBACK_GAS)
-                    .bind_token_callback(near_sdk::env::attached_deposit()),
+                    .deploy_token_callback(near_sdk::env::attached_deposit()),
             )
     }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -628,12 +628,16 @@ impl Contract {
                 );
 
                 if is_deployed_token {
-                    promise =
-                        promise.then(ext_token::ext(token).with_static_gas(MINT_TOKEN_GAS).mint(
-                            predecessor_account_id.clone(),
-                            transfer_message.fee.fee,
-                            None,
-                        ));
+                    promise = promise.then(
+                        ext_token::ext(token)
+                            .with_static_gas(MINT_TOKEN_GAS)
+                            .with_attached_deposit(ONE_YOCTO)
+                            .mint(
+                                predecessor_account_id.clone(),
+                                transfer_message.fee.fee,
+                                None,
+                            ),
+                    );
                 } else {
                     promise = promise.then(
                         ext_token::ext(token)

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -776,7 +776,7 @@ impl Contract {
             .token_deployer_accounts
             .get(&chain)
             .unwrap_or_else(|| env::panic_str("ERR_DEPLOYER_NOT_SET"));
-        let prefix = metadata.token_address.encode('-');
+        let prefix = metadata.token_address.get_token_prefix();
         let token_id: AccountId = format!("{}.{}", prefix, deployer)
             .parse()
             .unwrap_or_else(|_| env::panic_str("ERR_PARSE_ACCOUNT"));

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -42,11 +42,12 @@ const MPC_SIGNING_GAS: Gas = Gas::from_tgas(250);
 const SIGN_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(5);
 const SIGN_LOG_METADATA_CALLBACK_GAS: Gas = Gas::from_tgas(5);
 const SIGN_CLAIM_NATIVE_FEE_CALLBACK_GAS: Gas = Gas::from_tgas(5);
-const VERIFY_PROOF_GAS: Gas = Gas::from_tgas(50);
+const VERIFY_PROOF_GAS: Gas = Gas::from_tgas(30);
+const VERIFY_PROOF_CALLBACK_GAS: Gas = Gas::from_tgas(150);
 const CLAIM_FEE_CALLBACK_GAS: Gas = Gas::from_tgas(50);
 const BIND_TOKEN_CALLBACK_GAS: Gas = Gas::from_tgas(25);
 const BIND_TOKEN_REFUND_GAS: Gas = Gas::from_tgas(5);
-const FT_TRANSFER_CALL_GAS: Gas = Gas::from_tgas(50);
+const FT_TRANSFER_CALL_GAS: Gas = Gas::from_tgas(125);
 const FT_TRANSFER_GAS: Gas = Gas::from_tgas(5);
 const WNEAR_WITHDRAW_GAS: Gas = Gas::from_tgas(10);
 const STORAGE_BALANCE_OF_GAS: Gas = Gas::from_tgas(3);
@@ -517,7 +518,7 @@ impl Contract {
         .then(
             Self::ext(env::current_account_id())
                 .with_attached_deposit(attached_deposit)
-                .with_static_gas(CLAIM_FEE_CALLBACK_GAS)
+                .with_static_gas(VERIFY_PROOF_CALLBACK_GAS)
                 .fin_transfer_callback(
                     &args.storage_deposit_args,
                     env::predecessor_account_id(),

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -926,6 +926,18 @@ impl Contract {
     pub fn add_token_deployer(&mut self, chain: ChainKind, account_id: AccountId) {
         self.token_deployer_accounts.insert(&chain, &account_id);
     }
+
+    #[access_control_any(roles(Role::DAO))]
+    pub fn add_deployed_tokens(&mut self, tokens: Vec<(OmniAddress, AccountId)>) {
+        for (token_address, token_id) in tokens {
+            self.deployed_tokens.insert(&token_id);
+            self.token_address_to_id.insert(&token_address, &token_id);
+            self.token_id_to_address.insert(
+                &(token_address.get_chain(), token_id.clone()),
+                &token_address,
+            );
+        }
+    }
 }
 
 impl Contract {

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -62,6 +62,7 @@ enum StorageKey {
     TokenIdToAddress,
     AccountsBalances,
     TokenAddressToId,
+    TokenDeployerAccounts,
 }
 
 #[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
@@ -136,6 +137,7 @@ pub struct Contract {
     pub finalised_transfers: LookupMap<TransferId, Option<NativeFee>>,
     pub token_id_to_address: LookupMap<(ChainKind, AccountId), OmniAddress>,
     pub token_address_to_id: LookupMap<OmniAddress, AccountId>,
+    pub token_deployer_accounts: LookupMap<ChainKind, AccountId>,
     pub mpc_signer: AccountId,
     pub current_nonce: Nonce,
     pub accounts_balances: LookupMap<AccountId, StorageBalance>,
@@ -206,6 +208,7 @@ impl Contract {
             finalised_transfers: LookupMap::new(StorageKey::FinalisedTransfers),
             token_id_to_address: LookupMap::new(StorageKey::TokenIdToAddress),
             token_address_to_id: LookupMap::new(StorageKey::TokenAddressToId),
+            token_deployer_accounts: LookupMap::new(StorageKey::TokenDeployerAccounts),
             mpc_signer,
             current_nonce: nonce.0,
             accounts_balances: LookupMap::new(StorageKey::AccountsBalances),
@@ -825,6 +828,11 @@ impl Contract {
     #[access_control_any(roles(Role::DAO))]
     pub fn add_factory(&mut self, address: OmniAddress) {
         self.factories.insert(&(&address).into(), &address);
+    }
+
+    #[access_control_any(roles(Role::DAO))]
+    pub fn add_token_deployer(&mut self, chain: ChainKind, account_id: AccountId) {
+        self.token_deployer_accounts.insert(&chain, &account_id);
     }
 }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -255,7 +255,7 @@ impl Contract {
         };
 
         contract.acl_init_super_admin(near_sdk::env::predecessor_account_id());
-        contract.acl_grant_role("DAO".to_owned(), near_sdk::env::predecessor_account_id());
+        contract.acl_grant_role(Role::DAO.into(), near_sdk::env::predecessor_account_id());
         contract
     }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -8,7 +8,7 @@ use near_contract_standards::fungible_token::metadata::FungibleTokenMetadata;
 use near_contract_standards::fungible_token::receiver::FungibleTokenReceiver;
 use near_contract_standards::storage_management::StorageBalance;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::collections::LookupMap;
+use near_sdk::collections::{LookupMap, LookupSet};
 use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::{
@@ -68,6 +68,7 @@ enum StorageKey {
     AccountsBalances,
     TokenAddressToId,
     TokenDeployerAccounts,
+    DeployedTokens,
 }
 
 #[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
@@ -147,6 +148,7 @@ pub struct Contract {
     pub finalised_transfers: LookupMap<TransferId, Option<NativeFee>>,
     pub token_id_to_address: LookupMap<(ChainKind, AccountId), OmniAddress>,
     pub token_address_to_id: LookupMap<OmniAddress, AccountId>,
+    pub deployed_tokens: LookupSet<AccountId>,
     pub token_deployer_accounts: LookupMap<ChainKind, AccountId>,
     pub mpc_signer: AccountId,
     pub current_nonce: Nonce,
@@ -218,6 +220,7 @@ impl Contract {
             finalised_transfers: LookupMap::new(StorageKey::FinalisedTransfers),
             token_id_to_address: LookupMap::new(StorageKey::TokenIdToAddress),
             token_address_to_id: LookupMap::new(StorageKey::TokenAddressToId),
+            deployed_tokens: LookupSet::new(StorageKey::DeployedTokens),
             token_deployer_accounts: LookupMap::new(StorageKey::TokenDeployerAccounts),
             mpc_signer,
             current_nonce: nonce.0,
@@ -779,10 +782,19 @@ impl Contract {
             .unwrap_or_else(|_| env::panic_str("ERR_PARSE_ACCOUNT"));
 
         let storage_usage = env::storage_usage();
-        self.token_id_to_address
-            .insert(&(chain, token_id.clone()), &metadata.token_address);
-        self.token_address_to_id
-            .insert(&metadata.token_address, &token_id);
+        require!(
+            self.token_id_to_address
+                .insert(&(chain, token_id.clone()), &metadata.token_address)
+                .is_none(),
+            "ERR_TOKEN_EXIST"
+        );
+        require!(
+            self.token_address_to_id
+                .insert(&metadata.token_address, &token_id)
+                .is_none(),
+            "ERR_TOKEN_EXIST"
+        );
+        require!(self.deployed_tokens.insert(&token_id), "ERR_TOKEN_EXIST");
         let required_deposit = env::storage_byte_cost()
             .saturating_mul((env::storage_usage().saturating_sub(storage_usage)).into())
             .saturating_add(BRIDGE_TOKEN_INIT_BALANCE);

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -802,7 +802,7 @@ impl Contract {
         #[serializer(borsh)]
         call_result: Result<ProverResult, PromiseError>,
     ) -> Promise {
-        let Ok(ProverResult::TokenMetadata(metadata)) = call_result else {
+        let Ok(ProverResult::LogMetadata(metadata)) = call_result else {
             env::panic_str("ERR_INVALID_PROOF");
         };
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -15,15 +15,17 @@ use near_sdk::{
     env, ext_contract, near, require, serde_json, AccountId, BorshStorageKey, Gas, NearToken,
     PanicOnDefault, Promise, PromiseError, PromiseOrValue, PromiseResult,
 };
-use omni_types::locker_args::{BindTokenArgs, ClaimFeeArgs, FinTransferArgs, StorageDepositArgs};
+use omni_types::locker_args::{
+    BindTokenArgs, ClaimFeeArgs, DeployTokenArgs, FinTransferArgs, StorageDepositArgs,
+};
 use omni_types::mpc_types::SignatureResponse;
 use omni_types::near_events::Nep141LockerEvent;
 use omni_types::prover_args::VerifyProofArgs;
 use omni_types::prover_result::ProverResult;
 use omni_types::{
-    ChainKind, ClaimNativeFeePayload, Fee, InitTransferMsg, MetadataPayload, NativeFee, Nonce,
-    OmniAddress, PayloadType, SignRequest, TransferId, TransferMessage, TransferMessagePayload,
-    UpdateFee,
+    BasicMetadata, ChainKind, ClaimNativeFeePayload, Fee, InitTransferMsg, MetadataPayload,
+    NativeFee, Nonce, OmniAddress, PayloadType, SignRequest, TransferId, TransferMessage,
+    TransferMessagePayload, UpdateFee,
 };
 use storage::{TransferMessageStorage, TransferMessageStorageValue};
 
@@ -48,10 +50,13 @@ const FT_TRANSFER_GAS: Gas = Gas::from_tgas(5);
 const WNEAR_WITHDRAW_GAS: Gas = Gas::from_tgas(10);
 const STORAGE_BALANCE_OF_GAS: Gas = Gas::from_tgas(3);
 const STORAGE_DEPOSIT_GAS: Gas = Gas::from_tgas(3);
+const DEPLOY_TOKEN_CALLBACK_GAS: Gas = Gas::from_tgas(75);
+const DEPLOY_TOKEN_GAS: Gas = Gas::from_tgas(50);
+
 const NO_DEPOSIT: NearToken = NearToken::from_near(0);
 const ONE_YOCTO: NearToken = NearToken::from_yoctonear(1);
 const NEP141_DEPOSIT: NearToken = NearToken::from_yoctonear(1_250_000_000_000_000_000_000);
-
+const BRIDGE_TOKEN_INIT_BALANCE: NearToken = NearToken::from_near(3);
 const SIGN_PATH: &str = "bridge-1";
 
 #[derive(BorshSerialize, BorshStorageKey)]
@@ -117,6 +122,11 @@ pub trait Prover {
 #[ext_contract(ext_wnear_token)]
 pub trait ExtWNearToken {
     fn near_withdraw(&self, amount: U128);
+}
+
+#[ext_contract(ext_deployer)]
+pub trait TokenDeployer {
+    fn deploy_token(&self, account_id: AccountId, metadata: BasicMetadata) -> Promise;
 }
 
 #[near(contract_state)]
@@ -723,6 +733,76 @@ impl Contract {
             .with_static_gas(LOG_METADATA_GAS)
             .with_attached_deposit(ONE_YOCTO)
             .ft_transfer(fin_transfer.fee_recipient, U128(fee), None)
+    }
+
+    #[payable]
+    pub fn deploy_token(&mut self, #[serializer(borsh)] args: DeployTokenArgs) -> Promise {
+        ext_prover::ext(self.prover_account.clone())
+            .with_static_gas(VERIFY_POOF_GAS)
+            .with_attached_deposit(NO_DEPOSIT)
+            .verify_proof(VerifyProofArgs {
+                prover_id: args.chain_kind.as_ref().to_owned(),
+                prover_args: args.prover_args,
+            })
+            .then(
+                Self::ext(env::current_account_id())
+                    .with_attached_deposit(NO_DEPOSIT)
+                    .with_static_gas(DEPLOY_TOKEN_CALLBACK_GAS)
+                    .bind_token_callback(near_sdk::env::attached_deposit()),
+            )
+    }
+
+    #[private]
+    pub fn deploy_token_callback(
+        &mut self,
+        attached_deposit: NearToken,
+        #[callback_result]
+        #[serializer(borsh)]
+        call_result: Result<ProverResult, PromiseError>,
+    ) -> Promise {
+        let Ok(ProverResult::TokenMetadata(metadata)) = call_result else {
+            env::panic_str("ERR_INVALID_PROOF");
+        };
+
+        let chain = metadata.emitter_address.get_chain();
+        require!(
+            self.factories.get(&chain) == Some(metadata.emitter_address),
+            "ERR_UNKNOWN_FACTORY"
+        );
+        let deployer = self
+            .token_deployer_accounts
+            .get(&chain)
+            .unwrap_or_else(|| env::panic_str("ERR_DEPLOYER_NOT_SET"));
+        let prefix = metadata.token_address.encode('-');
+        let token_id: AccountId = format!("{}.{}", prefix, deployer)
+            .parse()
+            .unwrap_or_else(|_| env::panic_str("ERR_PARSE_ACCOUNT"));
+
+        let storage_usage = env::storage_usage();
+        self.token_id_to_address
+            .insert(&(chain, token_id.clone()), &metadata.token_address);
+        self.token_address_to_id
+            .insert(&metadata.token_address, &token_id);
+        let required_deposit = env::storage_byte_cost()
+            .saturating_mul((env::storage_usage().saturating_sub(storage_usage)).into())
+            .saturating_add(BRIDGE_TOKEN_INIT_BALANCE);
+
+        require!(
+            attached_deposit >= required_deposit,
+            "ERROR: The deposit is not sufficient to cover the storage."
+        );
+
+        ext_deployer::ext(deployer)
+            .with_static_gas(DEPLOY_TOKEN_GAS)
+            .with_attached_deposit(BRIDGE_TOKEN_INIT_BALANCE)
+            .deploy_token(
+                token_id,
+                BasicMetadata {
+                    name: metadata.name,
+                    symbol: metadata.symbol,
+                    decimals: metadata.decimals,
+                },
+            )
     }
 
     #[payable]

--- a/near/omni-prover/evm-prover/src/lib.rs
+++ b/near/omni-prover/evm-prover/src/lib.rs
@@ -117,6 +117,10 @@ impl EvmProver {
                 self.chain_kind,
                 log_entry_data,
             )?)),
+            ProofKind::LogMetadata => Ok(ProverResult::LogMetadata(parse_evm_event(
+                self.chain_kind,
+                log_entry_data,
+            )?)),
         }
     }
 

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/lib.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/lib.rs
@@ -79,6 +79,7 @@ impl WormholeOmniProverProxy {
             ProofKind::InitTransfer => Ok(ProverResult::InitTransfer(parsed_vaa.try_into()?)),
             ProofKind::FinTransfer => Ok(ProverResult::FinTransfer(parsed_vaa.try_into()?)),
             ProofKind::DeployToken => Ok(ProverResult::DeployToken(parsed_vaa.try_into()?)),
+            ProofKind::LogMetadata => Ok(ProverResult::LogMetadata(parsed_vaa.try_into()?)),
         }
     }
 }

--- a/near/omni-token/Cargo.toml
+++ b/near/omni-token/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "omni-token"
+version = "0.1.0"
+authors = ["Karim Alabtakh <karim.alabtakh@nearone.org>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+near-sdk.workspace = true
+near-contract-standards.workspace = true

--- a/near/omni-token/Cargo.toml
+++ b/near/omni-token/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 near-sdk.workspace = true
 near-contract-standards.workspace = true
+omni-types.workspace = true

--- a/near/omni-token/src/lib.rs
+++ b/near/omni-token/src/lib.rs
@@ -45,7 +45,7 @@ pub trait ExtOmniTokenFactory {
 #[near]
 impl OmniToken {
     #[init]
-    pub fn new(controller: AccountId, metadta: BasicMetadata) -> Self {
+    pub fn new(controller: AccountId, metadata: BasicMetadata) -> Self {
         let current_account_id = env::current_account_id();
         let deployer_account = current_account_id
             .get_parent_account_id()
@@ -63,12 +63,12 @@ impl OmniToken {
                 b"m".to_vec(),
                 Some(&FungibleTokenMetadata {
                     spec: FT_METADATA_SPEC.to_string(),
-                    name: metadta.name,
-                    symbol: metadta.symbol,
+                    name: metadata.name,
+                    symbol: metadata.symbol,
                     icon: None,
                     reference: None,
                     reference_hash: None,
-                    decimals: metadta.decimals,
+                    decimals: metadata.decimals,
                 }),
             ),
         }
@@ -154,7 +154,10 @@ impl MetadataManagment for OmniToken {
             metadata.reference_hash = Some(reference_hash);
         }
         if let Some(decimals) = decimals {
-            metadata.decimals = decimals;
+            // Decimals can't be changed if it's already set.
+            if decimals != 0 {
+                metadata.decimals = decimals;
+            }
         }
         if let Some(icon) = icon {
             metadata.icon = Some(icon);

--- a/near/omni-token/src/lib.rs
+++ b/near/omni-token/src/lib.rs
@@ -105,6 +105,7 @@ impl OmniToken {
         self.metadata.set(&metadata);
     }
 
+    #[payable]
     pub fn mint(
         &mut self,
         account_id: AccountId,

--- a/near/omni-token/src/lib.rs
+++ b/near/omni-token/src/lib.rs
@@ -14,6 +14,7 @@ use near_sdk::{
     assert_one_yocto, env, ext_contract, near, require, AccountId, Gas, NearToken, PanicOnDefault,
     Promise, PromiseOrValue, PublicKey, StorageUsage,
 };
+use omni_types::BasicMetadata;
 /// Gas to call finish withdraw method on factory.
 const FINISH_WITHDRAW_GAS: Gas = Gas::from_tgas(50);
 const OUTER_UPGRADE_GAS: Gas = Gas::from_tgas(15);
@@ -44,7 +45,7 @@ pub trait ExtOmniTokenFactory {
 #[near]
 impl OmniToken {
     #[init]
-    pub fn new(controller: AccountId, metadta: Option<FungibleTokenMetadata>) -> Self {
+    pub fn new(controller: AccountId, metadta: BasicMetadata) -> Self {
         let current_account_id = env::current_account_id();
         let deployer_account = current_account_id
             .get_parent_account_id()
@@ -58,7 +59,18 @@ impl OmniToken {
         Self {
             controller,
             token: FungibleToken::new(b"t".to_vec()),
-            metadata: LazyOption::new(b"m".to_vec(), metadta.as_ref()),
+            metadata: LazyOption::new(
+                b"m".to_vec(),
+                Some(&FungibleTokenMetadata {
+                    spec: FT_METADATA_SPEC.to_string(),
+                    name: metadta.name,
+                    symbol: metadta.symbol,
+                    icon: None,
+                    reference: None,
+                    reference_hash: None,
+                    decimals: metadta.decimals,
+                }),
+            ),
             paused: Mask::default(),
         }
     }

--- a/near/omni-token/src/lib.rs
+++ b/near/omni-token/src/lib.rs
@@ -1,0 +1,270 @@
+use near_contract_standards::fungible_token::metadata::{
+    FungibleTokenMetadata, FungibleTokenMetadataProvider, FT_METADATA_SPEC,
+};
+use near_contract_standards::fungible_token::{
+    Balance, FungibleToken, FungibleTokenCore, FungibleTokenResolver,
+};
+use near_contract_standards::storage_management::{
+    StorageBalance, StorageBalanceBounds, StorageManagement,
+};
+use near_sdk::json_types::{Base64VecU8, U128};
+use near_sdk::serde_json::json;
+use near_sdk::{
+    assert_one_yocto, env, ext_contract, near, require, AccountId, Gas, NearToken, PanicOnDefault,
+    Promise, PromiseOrValue, PublicKey, StorageUsage,
+};
+/// Gas to call finish withdraw method on factory.
+const FINISH_WITHDRAW_GAS: Gas = Gas::from_tgas(50);
+const OUTER_UPGRADE_GAS: Gas = Gas::from_tgas(15);
+const NO_DEPOSIT: NearToken = NearToken::from_yoctonear(0);
+const CURRENT_STATE_VERSION: u32 = 1;
+
+pub type Mask = u128;
+
+#[near(contract_state)]
+#[derive(PanicOnDefault)]
+pub struct OmniToken {
+    controller: AccountId,
+    token: FungibleToken,
+    name: String,
+    symbol: String,
+    reference: String,
+    reference_hash: Base64VecU8,
+    decimals: u8,
+    paused: Mask,
+    icon: Option<String>,
+}
+
+#[ext_contract(ext_omni_factory)]
+pub trait ExtOmniTokenFactory {
+    #[result_serializer(borsh)]
+    fn finish_withdraw(
+        &self,
+        #[serializer(borsh)] amount: Balance,
+        #[serializer(borsh)] recipient: String,
+    ) -> Promise;
+}
+
+#[near]
+impl OmniToken {
+    #[init]
+    pub fn new(controller: AccountId) -> Self {
+        let current_account_id = env::current_account_id();
+        let deployer_account = current_account_id
+            .get_parent_account_id()
+            .unwrap_or_else(|| env::panic_str("ERR_INVALID_PARENT_ACCOUNT"));
+
+        require!(
+            env::predecessor_account_id().as_str() == deployer_account,
+            "Only the deployer account can init this contract"
+        );
+
+        Self {
+            controller,
+            token: FungibleToken::new(b"t".to_vec()),
+            name: String::default(),
+            symbol: String::default(),
+            reference: String::default(),
+            reference_hash: Base64VecU8(vec![]),
+            decimals: 0,
+            paused: Mask::default(),
+            icon: None,
+        }
+    }
+
+    pub fn set_metadata(
+        &mut self,
+        name: Option<String>,
+        symbol: Option<String>,
+        reference: Option<String>,
+        reference_hash: Option<Base64VecU8>,
+        decimals: Option<u8>,
+        icon: Option<String>,
+    ) {
+        require!(self.controller_or_self());
+
+        name.map(|name| self.name = name);
+        symbol.map(|symbol| self.symbol = symbol);
+        reference.map(|reference| self.reference = reference);
+        reference_hash.map(|reference_hash| self.reference_hash = reference_hash);
+        decimals.map(|decimals| self.decimals = decimals);
+        icon.map(|icon| self.icon = Some(icon));
+    }
+
+    #[payable]
+    pub fn mint(&mut self, account_id: AccountId, amount: U128) {
+        assert_eq!(
+            env::predecessor_account_id(),
+            self.controller,
+            "Only controller can call mint"
+        );
+
+        self.storage_deposit(Some(account_id.clone()), None);
+        self.token.internal_deposit(&account_id, amount.into());
+    }
+
+    #[payable]
+    pub fn withdraw(&mut self, amount: U128, recipient: String) -> Promise {
+        require!(!self.is_paused());
+        assert_one_yocto();
+
+        self.token
+            .internal_withdraw(&env::predecessor_account_id(), amount.into());
+
+        ext_omni_factory::ext(self.controller.clone())
+            .with_static_gas(FINISH_WITHDRAW_GAS)
+            .finish_withdraw(amount.into(), recipient)
+    }
+
+    pub fn account_storage_usage(&self) -> StorageUsage {
+        self.token.account_storage_usage
+    }
+
+    /// Return true if the caller is either controller or self
+    pub fn controller_or_self(&self) -> bool {
+        let caller = env::predecessor_account_id();
+        caller == self.controller || caller == env::current_account_id()
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.paused != 0 && !self.controller_or_self()
+    }
+
+    pub fn set_paused(&mut self, paused: bool) {
+        require!(self.controller_or_self());
+        self.paused = if paused { 1 } else { 0 };
+    }
+
+    pub fn upgrade_and_migrate(&self) {
+        require!(
+            self.controller_or_self(),
+            "Only the controller or self can update the code"
+        );
+
+        // Receive the code directly from the input to avoid the
+        // GAS overhead of deserializing parameters
+        let code = env::input().unwrap_or_else(|| panic!("ERR_NO_INPUT"));
+        // Deploy the contract code.
+        let promise_id = env::promise_batch_create(&env::current_account_id());
+        env::promise_batch_action_deploy_contract(promise_id, &code);
+        // Call promise to migrate the state.
+        // Batched together to fail upgrade if migration fails.
+        env::promise_batch_action_function_call(
+            promise_id,
+            "migrate",
+            &json!({ "from_version": CURRENT_STATE_VERSION })
+                .to_string()
+                .into_bytes(),
+            NO_DEPOSIT,
+            env::prepaid_gas()
+                .saturating_sub(env::used_gas())
+                .saturating_sub(OUTER_UPGRADE_GAS),
+        );
+        env::promise_return(promise_id);
+    }
+
+    #[private]
+    #[init(ignore_state)]
+    pub fn migrate(_from_version: u32) -> Self {
+        env::state_read().unwrap_or_else(|| env::panic_str("ERR_FAILED_TO_READ_STATE"))
+    }
+
+    /// Attach a new full access to the current contract.
+    pub fn attach_full_access_key(&mut self, public_key: PublicKey) -> Promise {
+        require!(self.controller_or_self());
+        Promise::new(env::current_account_id()).add_full_access_key(public_key)
+    }
+
+    pub fn version(&self) -> String {
+        env!("CARGO_PKG_VERSION").to_owned()
+    }
+}
+
+#[near]
+impl FungibleTokenCore for OmniToken {
+    #[payable]
+    fn ft_transfer(&mut self, receiver_id: AccountId, amount: U128, memo: Option<String>) {
+        self.token.ft_transfer(receiver_id, amount, memo)
+    }
+
+    #[payable]
+    fn ft_transfer_call(
+        &mut self,
+        receiver_id: AccountId,
+        amount: U128,
+        memo: Option<String>,
+        msg: String,
+    ) -> PromiseOrValue<U128> {
+        self.token.ft_transfer_call(receiver_id, amount, memo, msg)
+    }
+
+    fn ft_total_supply(&self) -> U128 {
+        self.token.ft_total_supply()
+    }
+
+    fn ft_balance_of(&self, account_id: AccountId) -> U128 {
+        self.token.ft_balance_of(account_id)
+    }
+}
+
+#[near]
+impl FungibleTokenResolver for OmniToken {
+    #[private]
+    fn ft_resolve_transfer(
+        &mut self,
+        sender_id: AccountId,
+        receiver_id: AccountId,
+        amount: U128,
+    ) -> U128 {
+        let (used_amount, _burned_amount) =
+            self.token
+                .internal_ft_resolve_transfer(&sender_id, receiver_id, amount);
+
+        used_amount.into()
+    }
+}
+
+#[near]
+impl StorageManagement for OmniToken {
+    #[payable]
+    fn storage_deposit(
+        &mut self,
+        account_id: Option<AccountId>,
+        registration_only: Option<bool>,
+    ) -> StorageBalance {
+        self.token.storage_deposit(account_id, registration_only)
+    }
+
+    #[payable]
+    fn storage_withdraw(&mut self, amount: Option<NearToken>) -> StorageBalance {
+        self.token.storage_withdraw(amount)
+    }
+
+    #[payable]
+    fn storage_unregister(&mut self, force: Option<bool>) -> bool {
+        self.token.internal_storage_unregister(force).is_some()
+    }
+
+    fn storage_balance_bounds(&self) -> StorageBalanceBounds {
+        self.token.storage_balance_bounds()
+    }
+
+    fn storage_balance_of(&self, account_id: AccountId) -> Option<StorageBalance> {
+        self.token.storage_balance_of(account_id)
+    }
+}
+
+#[near]
+impl FungibleTokenMetadataProvider for OmniToken {
+    fn ft_metadata(&self) -> FungibleTokenMetadata {
+        FungibleTokenMetadata {
+            spec: FT_METADATA_SPEC.to_string(),
+            name: self.name.clone(),
+            symbol: self.symbol.clone(),
+            icon: self.icon.clone(),
+            reference: Some(self.reference.clone()),
+            reference_hash: Some(self.reference_hash.clone()),
+            decimals: self.decimals,
+        }
+    }
+}

--- a/near/omni-token/src/omni_ft.rs
+++ b/near/omni-token/src/omni_ft.rs
@@ -1,0 +1,35 @@
+use near_sdk::{
+    ext_contract,
+    json_types::{Base64VecU8, U128},
+    AccountId, PromiseOrValue,
+};
+
+#[ext_contract(ext_mint_and_burn)]
+pub trait MintAndBurn {
+    fn mint(
+        &mut self,
+        account_id: AccountId,
+        amount: U128,
+        msg: Option<String>,
+    ) -> PromiseOrValue<U128>;
+
+    fn burn(&mut self, amount: U128);
+}
+
+#[ext_contract(ext_metadata_managment)]
+pub trait MetadataManagment {
+    fn set_metadata(
+        &mut self,
+        name: Option<String>,
+        symbol: Option<String>,
+        reference: Option<String>,
+        reference_hash: Option<Base64VecU8>,
+        decimals: Option<u8>,
+        icon: Option<String>,
+    );
+}
+
+#[ext_contract(ext_upgrade_and_migrate)]
+pub trait UpgradeAndMigrate {
+    fn upgrade_and_migrate(&self);
+}

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -175,6 +175,17 @@ impl OmniAddress {
             OmniAddress::Base(_) => ChainKind::Base,
         }
     }
+
+    pub fn encode(&self, separator: char) -> String {
+        let (chain_str, recipient) = match self {
+            OmniAddress::Eth(recipient) => ("eth", recipient.to_string()),
+            OmniAddress::Near(recipient) => ("near", recipient.to_string()),
+            OmniAddress::Sol(recipient) => ("sol", recipient.to_string()),
+            OmniAddress::Arb(recipient) => ("arb", recipient.to_string()),
+            OmniAddress::Base(recipient) => ("base", recipient.to_string()),
+        };
+        format!("{chain_str}{separator}{recipient}")
+    }
 }
 
 impl FromStr for OmniAddress {
@@ -196,14 +207,7 @@ impl FromStr for OmniAddress {
 
 impl fmt::Display for OmniAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let (chain_str, recipient) = match self {
-            OmniAddress::Eth(recipient) => ("eth", recipient.to_string()),
-            OmniAddress::Near(recipient) => ("near", recipient.to_string()),
-            OmniAddress::Sol(recipient) => ("sol", recipient.to_string()),
-            OmniAddress::Arb(recipient) => ("arb", recipient.to_string()),
-            OmniAddress::Base(recipient) => ("base", recipient.to_string()),
-        };
-        write!(f, "{chain_str}:{recipient}")
+        write!(f, "{}", &self.encode(':'))
     }
 }
 
@@ -385,4 +389,11 @@ pub type Nonce = u128;
 
 pub fn stringify<T: std::fmt::Display>(item: T) -> String {
     item.to_string()
+}
+
+#[derive(Deserialize, Serialize, Clone)]
+pub struct BasicMetadata {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
 }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -155,6 +155,9 @@ impl From<&OmniAddress> for ChainKind {
 
 pub type EvmAddress = H160;
 
+pub const ZERO_ACCOUNT_ID: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
 #[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq, Eq)]
 pub enum OmniAddress {
     Eth(EvmAddress),
@@ -165,6 +168,17 @@ pub enum OmniAddress {
 }
 
 impl OmniAddress {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn new_zero(chain_kind: ChainKind) -> OmniAddress {
+        match chain_kind {
+            ChainKind::Eth => OmniAddress::Eth(H160::ZERO),
+            ChainKind::Near => OmniAddress::Near(ZERO_ACCOUNT_ID.parse().unwrap()),
+            ChainKind::Sol => OmniAddress::Sol(SolAddress::ZERO),
+            ChainKind::Arb => OmniAddress::Arb(H160::ZERO),
+            ChainKind::Base => OmniAddress::Base(H160::ZERO),
+        }
+    }
+
     pub fn from_evm_address(chain_kind: ChainKind, address: EvmAddress) -> Result<Self, String> {
         match chain_kind {
             ChainKind::Eth => Ok(Self::Eth(address)),
@@ -203,7 +217,7 @@ impl OmniAddress {
             OmniAddress::Eth(address) | OmniAddress::Arb(address) | OmniAddress::Base(address) => {
                 address.is_zero()
             }
-            OmniAddress::Near(address) => address.len() == 0,
+            OmniAddress::Near(address) => *address == ZERO_ACCOUNT_ID,
             OmniAddress::Sol(address) => address.is_zero(),
         }
     }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -327,38 +327,6 @@ impl<'de> Deserialize<'de> for OmniAddress {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
-pub struct NearRecipient {
-    pub target: AccountId,
-    pub message: Option<String>,
-}
-
-impl FromStr for NearRecipient {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let (target, message) = input.split_once(':').map_or_else(
-            || (input, None),
-            |(recipient, msg)| (recipient, Some(msg.to_owned())),
-        );
-
-        Ok(Self {
-            target: target.parse().map_err(stringify)?,
-            message,
-        })
-    }
-}
-
-impl fmt::Display for NearRecipient {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(message) = &self.message {
-            write!(f, "{}:{}", self.target, message)
-        } else {
-            write!(f, "{}", self.target)
-        }
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMsg {
     pub recipient: OmniAddress,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -192,7 +192,7 @@ impl OmniAddress {
         };
 
         if skip_zero_address && self.is_zero() {
-            format!("{chain_str}")
+            chain_str.to_string()
         } else {
             format!("{chain_str}{separator}{address}")
         }
@@ -200,11 +200,11 @@ impl OmniAddress {
 
     pub fn is_zero(&self) -> bool {
         match self {
-            OmniAddress::Eth(address) => address.is_zero(),
+            OmniAddress::Eth(address) | OmniAddress::Arb(address) | OmniAddress::Base(address) => {
+                address.is_zero()
+            }
             OmniAddress::Near(address) => address.len() == 0,
             OmniAddress::Sol(address) => address.is_zero(),
-            OmniAddress::Arb(address) => address.is_zero(),
-            OmniAddress::Base(address) => address.is_zero(),
         }
     }
 

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -217,7 +217,7 @@ impl FromStr for OmniAddress {
     type Err = String;
 
     fn from_str(input: &str) -> Result<OmniAddress, Self::Err> {
-        let (chain, recipient) = input.split_once(':').ok_or("Invalid OmniAddress format")?;
+        let (chain, recipient) = input.split_once(':').unwrap_or(("eth", input));
 
         match chain {
             "eth" => Ok(OmniAddress::Eth(recipient.parse().map_err(stringify)?)),

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -31,7 +31,7 @@ impl FromStr for H160 {
         } else {
             s
         };
-        let result = Vec::from_hex(s).map_err(|err| err.to_string())?;
+        let result = Vec::from_hex(s).map_err(|_| "ERR_INVALIDE_HEX")?;
         Ok(H160(
             result
                 .try_into()

--- a/near/omni-types/src/locker_args.rs
+++ b/near/omni-types/src/locker_args.rs
@@ -30,3 +30,9 @@ pub struct BindTokenArgs {
     pub chain_kind: ChainKind,
     pub prover_args: Vec<u8>,
 }
+
+#[derive(BorshDeserialize, BorshSerialize, Clone)]
+pub struct DeployTokenArgs {
+    pub chain_kind: ChainKind,
+    pub prover_args: Vec<u8>,
+}

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -27,10 +27,21 @@ pub struct DeployTokenMessage {
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+pub struct TokenMetadataMessage {
+    pub token_address: OmniAddress,
+    pub token: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub emitter_address: OmniAddress,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub enum ProverResult {
     InitTransfer(InitTransferMessage),
     FinTransfer(FinTransferMessage),
     DeployToken(DeployTokenMessage),
+    TokenMetadata(TokenMetadataMessage),
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone, Copy)]

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -27,9 +27,8 @@ pub struct DeployTokenMessage {
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
-pub struct TokenMetadataMessage {
+pub struct LogMetadataMessage {
     pub token_address: OmniAddress,
-    pub token: String,
     pub name: String,
     pub symbol: String,
     pub decimals: u8,
@@ -41,7 +40,7 @@ pub enum ProverResult {
     InitTransfer(InitTransferMessage),
     FinTransfer(FinTransferMessage),
     DeployToken(DeployTokenMessage),
-    TokenMetadata(TokenMetadataMessage),
+    LogMetadata(LogMetadataMessage),
 }
 
 #[derive(
@@ -51,4 +50,5 @@ pub enum ProofKind {
     InitTransfer,
     FinTransfer,
     DeployToken,
+    LogMetadata,
 }

--- a/near/omni-types/src/sol_address.rs
+++ b/near/omni-types/src/sol_address.rs
@@ -8,6 +8,14 @@ use serde::de::Visitor;
 #[derive(BorshDeserialize, BorshSerialize, Debug, Clone, PartialEq, Eq)]
 pub struct SolAddress(pub [u8; 32]);
 
+impl SolAddress {
+    pub const ZERO: Self = Self([0u8; 32]);
+
+    pub fn is_zero(&self) -> bool {
+        *self == Self::ZERO
+    }
+}
+
 impl FromStr for SolAddress {
     type Err = String;
 

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -2,9 +2,7 @@ use near_sdk::borsh;
 use near_sdk::json_types::U128;
 use near_sdk::serde_json;
 
-use crate::{
-    stringify, ChainKind, Fee, NearRecipient, OmniAddress, PayloadType, TransferMessage, H160,
-};
+use crate::{stringify, ChainKind, Fee, OmniAddress, PayloadType, TransferMessage, H160};
 use std::str::FromStr;
 
 #[test]
@@ -286,96 +284,6 @@ fn test_omni_address_visitor_expecting() {
     let result: Result<OmniAddress, _> = serde_json::from_value(serde_json::json!(invalid_value));
     let error = result.unwrap_err().to_string();
     assert_eq!(error, expected_error, "{}", message);
-}
-
-#[test]
-fn test_near_recipient_from_str() {
-    type TestFn = Box<dyn Fn(Result<NearRecipient, String>)>;
-
-    let test_cases: Vec<(&str, TestFn)> = vec![
-        (
-            "alice.near",
-            Box::new(|r| {
-                let message = "Should parse simple account without message";
-                let recipient = r.expect(message);
-                assert_eq!(recipient.target.to_string(), "alice.near", "{message}");
-                assert_eq!(recipient.message, None, "{message}");
-            }),
-        ),
-        (
-            "bob.near:Hello World",
-            Box::new(|r| {
-                let message = "Should parse account with message";
-                let recipient = r.expect(message);
-                assert_eq!(recipient.target.to_string(), "bob.near", "{message}");
-                assert_eq!(
-                    recipient.message,
-                    Some("Hello World".to_string()),
-                    "{message}"
-                );
-            }),
-        ),
-        (
-            "test.near:message:with:colons",
-            Box::new(|r| {
-                let message = "Should parse account with colons";
-                let recipient = r.expect(message);
-                assert_eq!(recipient.target.to_string(), "test.near", "{message}");
-                assert_eq!(
-                    recipient.message,
-                    Some("message:with:colons".to_string()),
-                    "{message}"
-                );
-            }),
-        ),
-    ];
-
-    for (input, validator) in test_cases {
-        let result = NearRecipient::from_str(input);
-        validator(result);
-    }
-}
-
-#[test]
-fn test_near_recipient_display() {
-    let test_cases = vec![
-        (
-            NearRecipient {
-                target: "alice.near".parse().unwrap(),
-                message: None,
-            },
-            "alice.near",
-            "Should format account without message",
-        ),
-        (
-            NearRecipient {
-                target: "bob.near".parse().unwrap(),
-                message: Some("Hello World".to_string()),
-            },
-            "bob.near:Hello World",
-            "Should format account with message",
-        ),
-        (
-            NearRecipient {
-                target: "test.near".parse().unwrap(),
-                message: Some("message:with:colons".to_string()),
-            },
-            "test.near:message:with:colons",
-            "Should format account with colon-containing message",
-        ),
-        (
-            NearRecipient {
-                target: "empty.near".parse().unwrap(),
-                message: Some("".to_string()),
-            },
-            "empty.near:",
-            "Should format account with empty message",
-        ),
-    ];
-
-    for (recipient, expected, message) in test_cases {
-        assert_eq!(recipient.to_string(), expected, "{}", message);
-    }
 }
 
 #[test]

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -39,7 +39,7 @@ fn test_h160_from_str() {
 
     let invalid_hex = "0xnot_a_hex_string";
     let err = H160::from_str(invalid_hex).expect_err("Should fail with invalid hex");
-    assert!(err.contains("Invalid character"), "Error was: {err}");
+    assert!(err.contains("ERR_INVALIDE_HEX"), "Error was: {err}");
 
     let short_addr = "0x5a08";
     let err = H160::from_str(short_addr).expect_err("Should fail with invalid length");
@@ -95,8 +95,8 @@ fn test_h160_deserialization() {
     assert!(result.is_err(), "Should fail with invalid hex");
     let err = result.unwrap_err().to_string();
     assert!(
-        err.contains("Invalid character"),
-        "Error was: {err} but expected Invalid character"
+        err.contains("ERR_INVALIDE_HEX"),
+        "Error was: {err} but expected ERR_INVALIDE_HEX"
     );
 
     let json = r#""0x5a08""#;

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -221,7 +221,7 @@ fn test_omni_address_from_str() {
         ),
         (
             "invalid_format".to_string(),
-            Err("Invalid OmniAddress format".to_string()),
+            Err("ERR_INVALIDE_HEX".to_string()),
             "Should fail on missing chain prefix",
         ),
         (

--- a/near/token-deployer/Cargo.toml
+++ b/near/token-deployer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "token-deployer"
+version = "0.1.0"
+authors = ["Karim Alabtakh <karim.alabtakh@nearone.org>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+near-sdk.workspace = true
+near-contract-standards.workspace = true
+hex.workspace = true
+borsh.workspace = true
+serde.workspace = true
+near-plugins.workspace = true
+omni-types.workspace = true

--- a/near/token-deployer/src/lib.rs
+++ b/near/token-deployer/src/lib.rs
@@ -1,4 +1,5 @@
-use near_sdk::{env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+use near_sdk::{env, near, serde_json, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+use omni_types::BasicMetadata;
 
 const BRIDGE_TOKEN_INIT_BALANCE: NearToken = NearToken::from_near(3);
 const NO_DEPOSIT: NearToken = NearToken::from_near(0);
@@ -20,7 +21,7 @@ impl Contract {
         Self { controller }
     }
 
-    pub fn deploy_token(&mut self, account_id: AccountId, init_args: Vec<u8>) -> Promise {
+    pub fn deploy_token(&mut self, account_id: AccountId, metadata: BasicMetadata) -> Promise {
         assert_eq!(
             env::predecessor_account_id(),
             self.controller,
@@ -33,7 +34,7 @@ impl Contract {
             .deploy_contract(BRIDGE_TOKEN_BINARY.to_vec())
             .function_call(
                 "new".to_string(),
-                init_args,
+                serde_json::to_string(&metadata).unwrap().into_bytes(),
                 NO_DEPOSIT,
                 OMNI_TOKEN_INIT_GAS,
             )

--- a/near/token-deployer/src/lib.rs
+++ b/near/token-deployer/src/lib.rs
@@ -1,4 +1,11 @@
-use near_sdk::{env, near, serde_json, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+use near_plugins::{
+    access_control, access_control_any, AccessControlRole, AccessControllable, Pausable, Upgradable,
+};
+use near_sdk::borsh::BorshDeserialize;
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{
+    env, near, require, serde_json, AccountId, Gas, NearToken, PanicOnDefault, Promise,
+};
 use omni_types::BasicMetadata;
 
 const BRIDGE_TOKEN_INIT_BALANCE: NearToken = NearToken::from_near(3);
@@ -8,24 +15,53 @@ const OMNI_TOKEN_INIT_GAS: Gas = Gas::from_tgas(10);
 const BRIDGE_TOKEN_BINARY: &'static [u8] =
     include_bytes!("../.././target/wasm32-unknown-unknown/release/omni_token.wasm");
 
+#[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+#[serde(crate = "near_sdk::serde")]
+pub enum Role {
+    DAO,
+    PauseManager,
+    UnrestrictedDeposit,
+    UpgradableCodeStager,
+    UpgradableCodeDeployer,
+}
+
 #[near(contract_state)]
-#[derive(PanicOnDefault)]
-pub struct Contract {
+#[derive(Pausable, Upgradable, PanicOnDefault)]
+#[pausable(manager_roles(Role::PauseManager))]
+#[access_control(role_type(Role))]
+#[upgradable(access_control_roles(
+    code_stagers(Role::UpgradableCodeStager, Role::DAO),
+    code_deployers(Role::UpgradableCodeDeployer, Role::DAO),
+    duration_initializers(Role::DAO),
+    duration_update_stagers(Role::DAO),
+    duration_update_appliers(Role::DAO),
+))]
+pub struct TokenDeployer {
     pub controller: AccountId,
 }
 
 #[near]
-impl Contract {
+impl TokenDeployer {
     #[init]
-    pub fn new(controller: AccountId) -> Self {
-        Self { controller }
+    pub fn new(controller: AccountId, dao: AccountId) -> Self {
+        let mut contract = Self { controller };
+
+        contract.acl_init_super_admin(near_sdk::env::predecessor_account_id());
+        contract.acl_grant_role("DAO".to_owned(), dao.clone());
+        contract.acl_transfer_super_admin(dao);
+        contract
     }
 
+    #[payable]
     pub fn deploy_token(&mut self, account_id: AccountId, metadata: BasicMetadata) -> Promise {
-        assert_eq!(
-            env::predecessor_account_id(),
-            self.controller,
-            "ERR_NOT_OWNER"
+        require!(
+            env::predecessor_account_id() == self.controller,
+            "ERR_NOT_CONTROLLER"
+        );
+
+        require!(
+            env::attached_deposit() >= BRIDGE_TOKEN_INIT_BALANCE,
+            "ERR_NOT_ENOUGH_ATTACHED_BALANCE"
         );
 
         Promise::new(account_id)
@@ -38,5 +74,15 @@ impl Contract {
                 NO_DEPOSIT,
                 OMNI_TOKEN_INIT_GAS,
             )
+    }
+
+    #[result_serializer(borsh)]
+    pub fn get_token_binary() -> Vec<u8> {
+        BRIDGE_TOKEN_BINARY.to_vec()
+    }
+
+    #[access_control_any(roles(Role::DAO))]
+    pub fn set_controller(&mut self, controller: AccountId) {
+        self.controller = controller;
     }
 }

--- a/near/token-deployer/src/lib.rs
+++ b/near/token-deployer/src/lib.rs
@@ -1,0 +1,41 @@
+use near_sdk::{env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+
+const BRIDGE_TOKEN_INIT_BALANCE: NearToken = NearToken::from_near(3);
+const NO_DEPOSIT: NearToken = NearToken::from_near(0);
+const OMNI_TOKEN_INIT_GAS: Gas = Gas::from_tgas(10);
+
+const BRIDGE_TOKEN_BINARY: &'static [u8] =
+    include_bytes!("../.././target/wasm32-unknown-unknown/release/omni_token.wasm");
+
+#[near(contract_state)]
+#[derive(PanicOnDefault)]
+pub struct Contract {
+    pub controller: AccountId,
+}
+
+#[near]
+impl Contract {
+    #[init]
+    pub fn new(controller: AccountId) -> Self {
+        Self { controller }
+    }
+
+    pub fn deploy_token(&mut self, account_id: AccountId, init_args: Vec<u8>) -> Promise {
+        assert_eq!(
+            env::predecessor_account_id(),
+            self.controller,
+            "ERR_NOT_OWNER"
+        );
+
+        Promise::new(account_id)
+            .create_account()
+            .transfer(BRIDGE_TOKEN_INIT_BALANCE)
+            .deploy_contract(BRIDGE_TOKEN_BINARY.to_vec())
+            .function_call(
+                "new".to_string(),
+                init_args,
+                NO_DEPOSIT,
+                OMNI_TOKEN_INIT_GAS,
+            )
+    }
+}


### PR DESCRIPTION
The PR implement the NEAR token factory to bridge the none-NEAR first tokens to Near and other chains.

1. Added token deployer contract.
2. Added the token contract with mint and burn methods.
3. Implemented the factory logic in the locker contract.
4. Added support for native tokens transfers from the EVMs
