### PR TITLE
feat: support different nonces for different chains

### DIFF
--- a/evm/bridge-token-factory/contracts/Borsh.sol
+++ b/evm/bridge-token-factory/contracts/Borsh.sol
@@ -2,12 +2,16 @@
 pragma solidity ^0.8.24;
 
 library Borsh {
-    function encodeUint32(uint32 val) internal pure returns (bytes memory) {
-        return abi.encodePacked(swapBytes4(val));
+    function encodeUint32(uint32 val) internal pure returns (bytes4) {
+        return bytes4(swapBytes4(val));
     }
 
-    function encodeUint128(uint128 val) internal pure returns (bytes memory) {
-        return abi.encodePacked(swapBytes16(val));
+    function encodeUint64(uint64 val) public pure returns (bytes8) {
+        return bytes8(swapBytes8(val));
+    }
+
+    function encodeUint128(uint128 val) internal pure returns (bytes16) {
+        return bytes16(swapBytes16(val));
     }
 
     function encodeString(string memory val) internal pure returns (bytes memory) {
@@ -25,6 +29,12 @@ library Borsh {
     function swapBytes4(uint32 v) internal pure returns (uint32) {
         v = ((v & 0x00ff00ff) << 8) | ((v & 0xff00ff00) >> 8);
         return (v << 16) | (v >> 16);
+    }
+
+    function swapBytes8(uint64 v) internal pure returns (uint64) {
+        v = ((v & 0x00ff00ff00ff00ff) << 8) | ((v & 0xff00ff00ff00ff00) >> 8);
+        v = ((v & 0x0000ffff0000ffff) << 16) | ((v & 0xffff0000ffff0000) >> 16);
+        return (v << 32) | (v >> 32);
     }
 
     function swapBytes16(uint128 v) internal pure returns (uint128) {

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -28,8 +28,8 @@ contract BridgeTokenFactory is
     address public nearBridgeDerivedAddress;
     uint8 public omniBridgeChainId;
 
-    mapping(uint128 => bool) public completedTransfers;
-    mapping(uint128 => bool) public claimedFee;
+    mapping(uint64 => bool) public completedTransfers;
+    mapping(uint64 => bool) public claimedFee;
     uint64 public currentOriginNonce; 
 
     bytes32 public constant PAUSABLE_ADMIN_ROLE = keccak256("PAUSABLE_ADMIN_ROLE");

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -39,7 +39,6 @@ contract BridgeTokenFactory is
 
     error InvalidSignature();
     error NonceAlreadyUsed(uint128 nonce);
-    error TransferAlreadyFinalised(uint8 chain, uint128 nonce);
     error InvalidFee();
 
     function initialize(
@@ -154,10 +153,7 @@ contract BridgeTokenFactory is
         BridgeTypes.FinTransferPayload calldata payload
     ) payable external whenNotPaused(PAUSED_FIN_TRANSFER) {
         if (completedTransfers[payload.nonce]) {
-            revert TransferAlreadyFinalised(
-                payload.origin_chain,
-                payload.nonce
-            );
+            revert NonceAlreadyUsed(payload.nonce);
         }
 
         bytes memory borshEncoded = bytes.concat(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -38,7 +38,7 @@ contract BridgeTokenFactory is
     uint constant PAUSED_FIN_TRANSFER = 1 << 1;
 
     error InvalidSignature();
-    error NonceAlreadyUsed(uint128 nonce);
+    error NonceAlreadyUsed(uint64 nonce);
     error InvalidFee();
 
     function initialize(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactory.sol
@@ -160,9 +160,9 @@ contract BridgeTokenFactory is
 
         bytes memory borshEncoded = bytes.concat(
             bytes1(uint8(BridgeTypes.PayloadType.TransferMessage)),
-            Borsh.encodeUint128(payload.destinationNonce),
+            Borsh.encodeUint64(payload.destinationNonce),
             bytes1(payload.originChain),
-            Borsh.encodeUint128(payload.originNonce),
+            Borsh.encodeUint64(payload.originNonce),
             bytes1(omniBridgeChainId),
             Borsh.encodeAddress(payload.tokenAddress),
             Borsh.encodeUint128(payload.amount),
@@ -245,10 +245,10 @@ contract BridgeTokenFactory is
     ) internal virtual {}
 
     function claimNativeFee(bytes calldata signatureData, BridgeTypes.ClaimFeePayload memory payload) external {
-        bytes memory borshEncodedNonces = Borsh.encodeUint32(uint32(payload.nonces.length));
+        bytes memory borshEncodedNonces = abi.encodePacked(Borsh.encodeUint32(uint32(payload.nonces.length)));
 
         for (uint i = 0; i < payload.nonces.length; ++i) {
-            uint128 nonce = payload.nonces[i];
+            uint64 nonce = payload.nonces[i];
             if (claimedFee[nonce]) {
                 revert NonceAlreadyUsed(nonce);
             }
@@ -257,7 +257,7 @@ contract BridgeTokenFactory is
             borshEncodedNonces = bytes.concat(
             bytes1(uint8(BridgeTypes.PayloadType.ClaimNativeFee)),
                 borshEncodedNonces,
-                Borsh.encodeUint128(nonce)
+                Borsh.encodeUint64(nonce)
             );
         }        
         

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -82,8 +82,8 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
     function finTransferExtension(BridgeTypes.TransferMessagePayload memory payload) internal override {
         bytes memory messagePayload = bytes.concat(
             bytes1(uint8(MessageType.FinTransfer)),
-            bytes1(payload.origin_chain),
-            Borsh.encodeUint128(payload.origin_nonce),
+            bytes1(payload.originChain),
+            Borsh.encodeUint128(payload.originNonce),
             bytes1(omniBridgeChainId),
             Borsh.encodeAddress(payload.tokenAddress),
             Borsh.encodeUint128(payload.amount),
@@ -101,7 +101,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
     function initTransferExtension(
         address sender,
         address tokenAddress,
-        uint128 nonce,
+        uint128 originNonce,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
@@ -115,7 +115,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             Borsh.encodeAddress(sender),
             bytes1(omniBridgeChainId),
             Borsh.encodeAddress(tokenAddress),
-            Borsh.encodeUint128(nonce),
+            Borsh.encodeUint128(originNonce),
             Borsh.encodeUint128(amount),
             Borsh.encodeUint128(fee),
             Borsh.encodeUint128(nativeFee),

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -87,6 +87,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             Borsh.encodeUint128(payload.amount),
             Borsh.encodeString(payload.feeRecipient),
             bytes1(payload.origin_chain),
+            Borsh.encodeUint128(payload.origin_nonce),
             Borsh.encodeUint128(payload.nonce)
         );
         _wormhole.publishMessage{value: msg.value}(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -86,6 +86,7 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
             Borsh.encodeAddress(payload.tokenAddress),
             Borsh.encodeUint128(payload.amount),
             Borsh.encodeString(payload.feeRecipient),
+            bytes1(payload.origin_chain),
             Borsh.encodeUint128(payload.nonce)
         );
         _wormhole.publishMessage{value: msg.value}(

--- a/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTokenFactoryWormhole.sol
@@ -79,16 +79,15 @@ contract BridgeTokenFactoryWormhole is BridgeTokenFactory {
         wormholeNonce++;
     }
 
-    function finTransferExtension(BridgeTypes.FinTransferPayload memory payload) internal override {
+    function finTransferExtension(BridgeTypes.TransferMessagePayload memory payload) internal override {
         bytes memory messagePayload = bytes.concat(
             bytes1(uint8(MessageType.FinTransfer)),
+            bytes1(payload.origin_chain),
+            Borsh.encodeUint128(payload.origin_nonce),
             bytes1(omniBridgeChainId),
             Borsh.encodeAddress(payload.tokenAddress),
             Borsh.encodeUint128(payload.amount),
-            Borsh.encodeString(payload.feeRecipient),
-            bytes1(payload.origin_chain),
-            Borsh.encodeUint128(payload.origin_nonce),
-            Borsh.encodeUint128(payload.nonce)
+            Borsh.encodeString(payload.feeRecipient)
         );
         _wormhole.publishMessage{value: msg.value}(
             wormholeNonce,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.24;
 
 library BridgeTypes {
     struct TransferMessagePayload {
-        uint128 destination_nonce;
-        uint8 origin_chain;
-        uint128 origin_nonce;
+        uint64 destinationNonce;
+        uint8 originChain;
+        uint64 originNonce;
         address tokenAddress;
         uint128 amount;
         address recipient;
@@ -28,7 +28,7 @@ library BridgeTypes {
     event InitTransfer(
         address indexed sender,
         address indexed tokenAddress,
-        uint128 indexed nonce,
+        uint64 indexed originNonce,
         uint128 amount,
         uint128 fee,
         uint128 nativeFee,
@@ -37,8 +37,8 @@ library BridgeTypes {
     );
 
     event FinTransfer(
-        uint8 indexed origin_chain,
-        uint128 indexed origin_nonce,
+        uint8 indexed originChain,
+        uint64 indexed originNonce,
         address tokenAddress,
         uint128 amount,
         address recipient,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.24;
 
 library BridgeTypes {
-    struct FinTransferPayload {
-        uint128 nonce;
-        uint128 origin_nonce;
+    struct TransferMessagePayload {
+        uint128 destination_nonce;
         uint8 origin_chain;
+        uint128 origin_nonce;
         address tokenAddress;
         uint128 amount;
         address recipient;
@@ -37,9 +37,8 @@ library BridgeTypes {
     );
 
     event FinTransfer(
-        uint128 indexed payload_nonce,
+        uint8 indexed origin_chain,
         uint128 indexed origin_nonce,
-        uint8 origin_chain,
         address tokenAddress,
         uint128 amount,
         address recipient,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 library BridgeTypes {
     struct FinTransferPayload {
         uint128 nonce;
+        uint8 origin_chain;
         address tokenAddress;
         uint128 amount;
         address recipient;
@@ -36,6 +37,7 @@ library BridgeTypes {
 
     event FinTransfer(
         uint128 indexed nonce,
+        uint8 origin_chain,
         address tokenAddress,
         uint128 amount,
         address recipient,

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -20,7 +20,7 @@ library BridgeTypes {
     }
 
     struct ClaimFeePayload {
-        uint128[] nonces;
+        uint64[] nonces;
         uint128 amount;
         address recipient;
     }

--- a/evm/bridge-token-factory/contracts/BridgeTypes.sol
+++ b/evm/bridge-token-factory/contracts/BridgeTypes.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 library BridgeTypes {
     struct FinTransferPayload {
         uint128 nonce;
+        uint128 origin_nonce;
         uint8 origin_chain;
         address tokenAddress;
         uint128 amount;
@@ -36,7 +37,8 @@ library BridgeTypes {
     );
 
     event FinTransfer(
-        uint128 indexed nonce,
+        uint128 indexed payload_nonce,
+        uint128 indexed origin_nonce,
         uint8 origin_chain,
         address tokenAddress,
         uint128 amount,

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -73,7 +73,6 @@ enum StorageKey {
     TokenAddressToId,
     TokenDeployerAccounts,
     DeployedTokens,
-    CurrentPayloadNonces,
 }
 
 #[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
@@ -172,8 +171,6 @@ pub struct Contract {
     pub token_deployer_accounts: LookupMap<ChainKind, AccountId>,
     pub mpc_signer: AccountId,
     pub init_transfer_nonce: Nonce,
-    // We maintain a separate nonce for each chain to oprimise the storage usage on Solana by reducing the gaps.
-    pub current_payload_nonces: LookupMap<ChainKind, Nonce>,
     pub accounts_balances: LookupMap<AccountId, StorageBalance>,
     pub wnear_account_id: AccountId,
 }
@@ -249,7 +246,6 @@ impl Contract {
             token_deployer_accounts: LookupMap::new(StorageKey::TokenDeployerAccounts),
             mpc_signer,
             init_transfer_nonce: U128(0),
-            current_payload_nonces: LookupMap::new(StorageKey::CurrentPayloadNonces),
             accounts_balances: LookupMap::new(StorageKey::AccountsBalances),
             wnear_account_id,
         };

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -73,7 +73,7 @@ enum StorageKey {
     TokenAddressToId,
     TokenDeployerAccounts,
     DeployedTokens,
-    CurrentPayloadNonces,
+    DestinationNonces,
 }
 
 #[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
@@ -173,7 +173,7 @@ pub struct Contract {
     pub mpc_signer: AccountId,
     pub init_transfer_nonce: Nonce,
     // We maintain a separate nonce for each chain to oprimise the storage usage on Solana by reducing the gaps.
-    pub current_payload_nonces: LookupMap<ChainKind, Nonce>,
+    pub destination_nonces: LookupMap<ChainKind, Nonce>,
     pub accounts_balances: LookupMap<AccountId, StorageBalance>,
     pub wnear_account_id: AccountId,
 }
@@ -191,7 +191,7 @@ impl FungibleTokenReceiver for Contract {
         let token_id = env::predecessor_account_id();
 
         self.init_transfer_nonce.0 += 1;
-        let payload_nonce = self.get_next_payload_nonce(parsed_msg.recipient.get_chain());
+        let destination_nonce = self.get_next_destination_nonce(parsed_msg.recipient.get_chain());
 
         let transfer_message = TransferMessage {
             origin_nonce: self.init_transfer_nonce,
@@ -204,7 +204,7 @@ impl FungibleTokenReceiver for Contract {
             },
             sender: OmniAddress::Near(sender_id.clone()),
             msg: String::new(),
-            payload_nonce,
+            destination_nonce,
         };
         require!(
             transfer_message.fee.fee < transfer_message.amount,
@@ -252,7 +252,7 @@ impl Contract {
             token_deployer_accounts: LookupMap::new(StorageKey::TokenDeployerAccounts),
             mpc_signer,
             init_transfer_nonce: U128(0),
-            current_payload_nonces: LookupMap::new(StorageKey::CurrentPayloadNonces),
+            destination_nonces: LookupMap::new(StorageKey::DestinationNonces),
             accounts_balances: LookupMap::new(StorageKey::AccountsBalances),
             wnear_account_id,
         };
@@ -454,7 +454,7 @@ impl Contract {
 
         let transfer_payload = TransferMessagePayload {
             prefix: PayloadType::TransferMessage,
-            nonce: transfer_message.payload_nonce,
+            destination_nonce: transfer_message.destination_nonce,
             transfer_id,
             token_address,
             amount: U128(transfer_message.amount.0 - transfer_message.fee.fee.0),
@@ -551,7 +551,8 @@ impl Contract {
             "Unknown factory"
         );
 
-        let payload_nonce = self.get_next_payload_nonce(init_transfer.recipient.get_chain());
+        let destination_nonce =
+            self.get_next_destination_nonce(init_transfer.recipient.get_chain());
         let transfer_message = TransferMessage {
             origin_nonce: init_transfer.origin_nonce,
             token: init_transfer.token,
@@ -560,7 +561,7 @@ impl Contract {
             fee: init_transfer.fee,
             sender: init_transfer.sender,
             msg: init_transfer.msg,
-            payload_nonce,
+            destination_nonce,
         };
 
         if let OmniAddress::Near(recipient) = transfer_message.recipient.clone() {
@@ -924,16 +925,12 @@ impl Contract {
 }
 
 impl Contract {
-    fn get_next_payload_nonce(&mut self, chain_kind: ChainKind) -> Nonce {
-        let mut payload_nonce = self
-            .current_payload_nonces
-            .get(&chain_kind)
-            .unwrap_or_default();
+    fn get_next_destination_nonce(&mut self, chain_kind: ChainKind) -> Nonce {
+        let mut payload_nonce = self.destination_nonces.get(&chain_kind).unwrap_or_default();
 
         payload_nonce.0 += 1;
 
-        self.current_payload_nonces
-            .insert(&chain_kind, &payload_nonce);
+        self.destination_nonces.insert(&chain_kind, &payload_nonce);
 
         payload_nonce
     }

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -540,7 +540,7 @@ impl Contract {
         #[serializer(borsh)] storage_deposit_args: &StorageDepositArgs,
         #[serializer(borsh)] predecessor_account_id: AccountId,
         #[serializer(borsh)] native_fee_recipient: Option<OmniAddress>,
-    ) -> PromiseOrValue<()> {
+    ) -> PromiseOrValue<Nonce> {
         let Ok(ProverResult::InitTransfer(init_transfer)) = Self::decode_prover_result(0) else {
             env::panic_str("Invalid proof message")
         };
@@ -575,7 +575,7 @@ impl Contract {
             .into()
         } else {
             self.process_fin_transfer_to_other_cahin(predecessor_account_id, transfer_message);
-            PromiseOrValue::Value(())
+            PromiseOrValue::Value(destination_nonce)
         }
     }
 

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -922,10 +922,18 @@ impl Contract {
             .with_static_gas(SET_METADATA_GAS)
             .set_metadata(name, symbol, reference, reference_hash, decimals, icon)
     }
+
+    pub fn get_current_destination_nonce(&self, chain_kind: ChainKind) -> Nonce {
+        self.destination_nonces.get(&chain_kind).unwrap_or_default()
+    }
 }
 
 impl Contract {
     fn get_next_destination_nonce(&mut self, chain_kind: ChainKind) -> Nonce {
+        if chain_kind == ChainKind::Near {
+            return 0;
+        }
+
         let mut payload_nonce = self.destination_nonces.get(&chain_kind).unwrap_or_default();
 
         payload_nonce += 1;

--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -376,8 +376,8 @@ impl Contract {
             let native_fee = self
                 .finalised_transfers
                 .get(&TransferId {
-                    chain: chain_kind,
-                    nonce: *nonce,
+                    origin_chain: chain_kind,
+                    origin_nonce: *nonce,
                 })
                 .flatten()
                 .sdk_expect("ERR_NATIVE_FEE_NOT_EXISIT");

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -1,7 +1,7 @@
 use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
 use near_sdk::{assert_one_yocto, borsh};
 use near_sdk::{env, near_bindgen, AccountId, NearToken};
-use omni_types::PayloadId;
+use omni_types::TransferId;
 
 use crate::{
     require, BorshDeserialize, BorshSerialize, ChainKind, Contract, ContractExt, Deserialize, Fee,
@@ -132,7 +132,7 @@ impl Contract {
     }
 
     pub fn required_balance_for_init_transfer(&self) -> NearToken {
-        let key_len = borsh::to_vec(&PayloadId::default())
+        let key_len = borsh::to_vec(&TransferId::default())
             .sdk_expect("ERR_BORSH")
             .len() as u64;
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -145,7 +145,7 @@ impl Contract {
                 fee: Fee::default(),
                 sender: OmniAddress::Near(max_account_id.clone()),
                 msg: String::new(),
-                payload_nonce: U128(0),
+                destination_nonce: U128(0),
             },
             owner: max_account_id,
         }))

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -138,14 +138,14 @@ impl Contract {
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&TransferMessageStorage::V0(TransferMessageStorageValue {
             message: TransferMessage {
-                origin_nonce: U128(0),
+                origin_nonce: 0,
                 token: OmniAddress::Near(max_account_id.clone()),
                 amount: U128(0),
                 recipient: OmniAddress::Near(max_account_id.clone()),
                 fee: Fee::default(),
                 sender: OmniAddress::Near(max_account_id.clone()),
                 msg: String::new(),
-                destination_nonce: U128(0),
+                destination_nonce: 0,
             },
             owner: max_account_id,
         }))

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -145,6 +145,7 @@ impl Contract {
                 fee: Fee::default(),
                 sender: OmniAddress::Near(max_account_id.clone()),
                 msg: String::new(),
+                payload_nonce: U128(0),
             },
             owner: max_account_id,
         }))

--- a/near/nep141-locker/src/storage.rs
+++ b/near/nep141-locker/src/storage.rs
@@ -1,6 +1,7 @@
 use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
 use near_sdk::{assert_one_yocto, borsh};
 use near_sdk::{env, near_bindgen, AccountId, NearToken};
+use omni_types::PayloadId;
 
 use crate::{
     require, BorshDeserialize, BorshSerialize, ChainKind, Contract, ContractExt, Deserialize, Fee,
@@ -131,7 +132,9 @@ impl Contract {
     }
 
     pub fn required_balance_for_init_transfer(&self) -> NearToken {
-        let key_len = borsh::to_vec(&0_u128).sdk_expect("ERR_BORSH").len() as u64;
+        let key_len = borsh::to_vec(&PayloadId::default())
+            .sdk_expect("ERR_BORSH")
+            .len() as u64;
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&TransferMessageStorage::V0(TransferMessageStorageValue {
             message: TransferMessage {

--- a/near/nep141-locker/src/tests/lib_test.rs
+++ b/near/nep141-locker/src/tests/lib_test.rs
@@ -17,8 +17,8 @@ use omni_types::{ChainKind, Fee, InitTransferMsg, OmniAddress, TransferMessage, 
 
 const DEFAULT_NONCE: Nonce = 0;
 const DEFAULT_TRANSFER_ID: TransferId = TransferId {
-    chain: ChainKind::Near,
-    nonce: DEFAULT_NONCE,
+    origin_chain: ChainKind::Near,
+    origin_nonce: DEFAULT_NONCE,
 };
 const DEFAULT_PROVER_ACCOUNT: &str = "prover.testnet";
 const DEFAULT_MPC_SIGNER_ACCOUNT: &str = "mpc_signer.testnet";
@@ -154,8 +154,8 @@ fn test_ft_on_transfer_stored_transfer_message() {
     );
 
     let stored_transfer = contract.get_transfer_message(TransferId {
-        chain: ChainKind::Near,
-        nonce: contract.current_origin_nonce,
+        origin_chain: ChainKind::Near,
+        origin_nonce: contract.current_origin_nonce,
     });
     assert_eq!(
         stored_transfer.recipient, msg.recipient,
@@ -571,8 +571,8 @@ fn test_fin_transfer_callback_non_near_success() {
 
             // Verify transfer was stored correctly
             let stored_transfer = contract.get_transfer_message(TransferId {
-                chain: ChainKind::Eth,
-                nonce: DEFAULT_NONCE,
+                origin_chain: ChainKind::Eth,
+                origin_nonce: DEFAULT_NONCE,
             });
             assert_eq!(stored_transfer.recipient, eth_recipient);
         }
@@ -670,7 +670,10 @@ fn test_is_transfer_finalised() {
     let mut contract = get_default_contract();
     let chain = ChainKind::Eth;
     let nonce = 1;
-    let transfer_id = TransferId { chain, nonce };
+    let transfer_id = TransferId {
+        origin_chain: chain,
+        origin_nonce: nonce,
+    };
 
     assert!(!contract.is_transfer_finalised(transfer_id));
 

--- a/near/nep141-locker/src/tests/lib_test.rs
+++ b/near/nep141-locker/src/tests/lib_test.rs
@@ -561,15 +561,18 @@ fn test_fin_transfer_callback_non_near_success() {
 
     let result = contract.fin_transfer_callback(&storage_args, predecessor.clone(), None);
 
-    // For non-NEAR recipients, should return U128 value of current_nonce
+    // For non-NEAR recipients, should return u64 value of current_destination_nonce
     match result {
         PromiseOrValue::Value(nonce) => {
-            assert_eq!(nonce, contract.current_origin_nonce);
+            assert_eq!(
+                nonce,
+                contract.get_current_destination_nonce(ChainKind::Eth)
+            );
 
             // Verify transfer was stored correctly
             let stored_transfer = contract.get_transfer_message(TransferId {
                 chain: ChainKind::Eth,
-                nonce,
+                nonce: DEFAULT_NONCE,
             });
             assert_eq!(stored_transfer.recipient, eth_recipient);
         }

--- a/near/nep141-locker/src/tests/lib_test.rs
+++ b/near/nep141-locker/src/tests/lib_test.rs
@@ -5,7 +5,7 @@ use near_sdk::test_utils::VMContextBuilder;
 use near_sdk::RuntimeFeesConfig;
 use near_sdk::{test_vm_config, testing_env};
 use omni_types::prover_result::{InitTransferMessage, ProverResult};
-use omni_types::{EvmAddress, NativeFee};
+use omni_types::{EvmAddress, NativeFee, Nonce, TransferId};
 use std::str::FromStr;
 
 use near_contract_standards::fungible_token::receiver::FungibleTokenReceiver;
@@ -15,7 +15,11 @@ use near_sdk::{serde_json, AccountId, NearToken, PromiseOrValue, PromiseResult};
 use omni_types::locker_args::StorageDepositArgs;
 use omni_types::{ChainKind, Fee, InitTransferMsg, OmniAddress, TransferMessage, UpdateFee};
 
-const DEFAULT_NONCE: u128 = 0;
+const DEFAULT_NONCE: Nonce = 0;
+const DEFAULT_TRANSFER_ID: TransferId = TransferId {
+    chain: ChainKind::Near,
+    nonce: DEFAULT_NONCE,
+};
 const DEFAULT_PROVER_ACCOUNT: &str = "prover.testnet";
 const DEFAULT_MPC_SIGNER_ACCOUNT: &str = "mpc_signer.testnet";
 const DEFAULT_WNEAR_ACCOUNT: &str = "wnear.testnet";
@@ -48,16 +52,10 @@ fn setup_test_env(
     }
 }
 
-fn setup_contract(
-    prover_id: String,
-    mpc_signer_id: String,
-    wnear_id: String,
-    init_nonce: u128,
-) -> Contract {
+fn setup_contract(prover_id: String, mpc_signer_id: String, wnear_id: String) -> Contract {
     Contract::new(
         AccountId::try_from(prover_id).expect("Invalid default prover ID"),
         AccountId::try_from(mpc_signer_id).expect("Invalid default mpc signer ID"),
-        U128(init_nonce),
         AccountId::try_from(wnear_id).expect("Invalid default wnear ID"),
     )
 }
@@ -67,7 +65,6 @@ fn get_default_contract() -> Contract {
         DEFAULT_PROVER_ACCOUNT.to_string(),
         DEFAULT_MPC_SIGNER_ACCOUNT.to_string(),
         DEFAULT_WNEAR_ACCOUNT.to_string(),
-        DEFAULT_NONCE,
     )
 }
 
@@ -122,7 +119,7 @@ fn test_initialize_contract() {
 
     assert_eq!(contract.prover_account, DEFAULT_PROVER_ACCOUNT);
     assert_eq!(contract.mpc_signer, DEFAULT_MPC_SIGNER_ACCOUNT);
-    assert_eq!(contract.current_nonce, DEFAULT_NONCE);
+    assert_eq!(contract.current_origin_nonce, DEFAULT_NONCE);
     assert_eq!(contract.wnear_account_id, DEFAULT_WNEAR_ACCOUNT);
 }
 
@@ -139,7 +136,7 @@ fn test_ft_on_transfer_nonce_increment() {
         get_init_transfer_msg(DEFAULT_ETH_USER_ADDRESS.to_string(), 0, 0),
     );
 
-    assert_eq!(contract.current_nonce, DEFAULT_NONCE + 1);
+    assert_eq!(contract.current_origin_nonce, DEFAULT_NONCE + 1);
 }
 
 #[test]
@@ -156,7 +153,10 @@ fn test_ft_on_transfer_stored_transfer_message() {
         msg.clone(),
     );
 
-    let stored_transfer = contract.get_transfer_message(U128(contract.current_nonce));
+    let stored_transfer = contract.get_transfer_message(TransferId {
+        chain: ChainKind::Near,
+        nonce: contract.current_origin_nonce,
+    });
     assert_eq!(
         stored_transfer.recipient, msg.recipient,
         "Incorrect stored recipient"
@@ -258,7 +258,7 @@ fn run_update_transfer_fee(
     use std::str::FromStr;
 
     let transfer_msg = TransferMessage {
-        origin_nonce: U128(DEFAULT_NONCE),
+        origin_nonce: DEFAULT_NONCE,
         token: OmniAddress::Near(
             AccountId::try_from(DEFAULT_FT_CONTRACT_ACCOUNT.to_string()).unwrap(),
         ),
@@ -267,11 +267,11 @@ fn run_update_transfer_fee(
         fee: init_fee.clone(),
         sender: OmniAddress::Near(sender_id.clone().parse().unwrap()),
         msg: "".to_string(),
+        destination_nonce: 1,
     };
 
     contract.insert_raw_transfer(
-        DEFAULT_NONCE,
-        transfer_msg,
+        transfer_msg.clone(),
         AccountId::try_from(sender_id.clone()).unwrap(),
     );
 
@@ -287,7 +287,7 @@ fn run_update_transfer_fee(
         attached_deposit,
         None,
     );
-    contract.update_transfer_fee(U128(DEFAULT_NONCE), new_fee);
+    contract.update_transfer_fee(transfer_msg.get_transfer_id(), new_fee);
 }
 
 #[test]
@@ -307,7 +307,7 @@ fn test_update_transfer_fee_same_fee() {
         Some(NearToken::from_yoctonear(0)),
     );
 
-    let updated_transfer = contract.get_transfer_message(U128(DEFAULT_NONCE));
+    let updated_transfer = contract.get_transfer_message(DEFAULT_TRANSFER_ID);
     assert_eq!(updated_transfer.fee, fee);
 }
 
@@ -333,7 +333,7 @@ fn test_update_transfer_fee_valid() {
         None,
     );
 
-    let updated_transfer = contract.get_transfer_message(U128(DEFAULT_NONCE));
+    let updated_transfer = contract.get_transfer_message(DEFAULT_TRANSFER_ID);
     assert_eq!(updated_transfer.fee, new_fee);
 }
 
@@ -439,7 +439,7 @@ fn test_update_transfer_fee_wrong_sender() {
         NearToken::from_yoctonear(5),
         None,
     );
-    contract.update_transfer_fee(U128(DEFAULT_NONCE), UpdateFee::Fee(new_fee));
+    contract.update_transfer_fee(DEFAULT_TRANSFER_ID, UpdateFee::Fee(new_fee));
 }
 
 fn get_default_storage_deposit_args() -> StorageDepositArgs {
@@ -455,21 +455,19 @@ fn get_prover_result(recipient: Option<OmniAddress>) -> ProverResult {
         DEFAULT_NEAR_USER_ACCOUNT.parse().unwrap(),
     ));
     ProverResult::InitTransfer(InitTransferMessage {
-        emitter_address: OmniAddress::Eth(EvmAddress::from_str(DEFAULT_ETH_USER_ADDRESS).unwrap()),
-        transfer: TransferMessage {
-            origin_nonce: U128(DEFAULT_NONCE),
-            token: OmniAddress::Near(
-                AccountId::try_from(DEFAULT_FT_CONTRACT_ACCOUNT.to_string()).unwrap(),
-            ),
-            amount: U128(DEFAULT_TRANSFER_AMOUNT),
-            recipient,
-            fee: Fee {
-                fee: U128(10),
-                native_fee: U128(5),
-            },
-            sender: OmniAddress::Eth(EvmAddress::from_str(DEFAULT_ETH_USER_ADDRESS).unwrap()),
-            msg: "".to_string(),
+        origin_nonce: DEFAULT_NONCE,
+        token: OmniAddress::Near(
+            AccountId::try_from(DEFAULT_FT_CONTRACT_ACCOUNT.to_string()).unwrap(),
+        ),
+        amount: U128(DEFAULT_TRANSFER_AMOUNT),
+        recipient,
+        fee: Fee {
+            fee: U128(10),
+            native_fee: U128(5),
         },
+        sender: OmniAddress::Eth(EvmAddress::from_str(DEFAULT_ETH_USER_ADDRESS).unwrap()),
+        msg: "".to_string(),
+        emitter_address: OmniAddress::Eth(EvmAddress::from_str(DEFAULT_ETH_USER_ADDRESS).unwrap()),
     })
 }
 
@@ -566,10 +564,13 @@ fn test_fin_transfer_callback_non_near_success() {
     // For non-NEAR recipients, should return U128 value of current_nonce
     match result {
         PromiseOrValue::Value(nonce) => {
-            assert_eq!(nonce, U128(contract.current_nonce));
+            assert_eq!(nonce, contract.current_origin_nonce);
 
             // Verify transfer was stored correctly
-            let stored_transfer = contract.get_transfer_message(nonce);
+            let stored_transfer = contract.get_transfer_message(TransferId {
+                chain: ChainKind::Eth,
+                nonce,
+            });
             assert_eq!(stored_transfer.recipient, eth_recipient);
         }
         PromiseOrValue::Promise(_) => panic!("Expected Value variant, got Promise"),
@@ -635,7 +636,7 @@ fn test_fin_transfer_callback_missing_fee_recipient() {
 
     let mut prover_result = get_prover_result(None);
     if let ProverResult::InitTransfer(ref mut init_transfer) = prover_result {
-        init_transfer.transfer.fee.native_fee = U128(100); // Set non-zero native fee
+        init_transfer.fee.native_fee = U128(100); // Set non-zero native fee
     }
 
     let storage_args = get_default_storage_deposit_args();
@@ -665,14 +666,13 @@ fn test_fin_transfer_callback_missing_fee_recipient() {
 fn test_is_transfer_finalised() {
     let mut contract = get_default_contract();
     let chain = ChainKind::Eth;
-    let nonce = U128(1);
+    let nonce = 1;
+    let transfer_id = TransferId { chain, nonce };
 
-    assert!(!contract.is_transfer_finalised(chain, nonce));
+    assert!(!contract.is_transfer_finalised(transfer_id));
 
-    contract
-        .finalised_transfers
-        .insert(&(chain, nonce.0), &None);
-    assert!(contract.is_transfer_finalised(chain, nonce));
+    contract.finalised_transfers.insert(&transfer_id, &None);
+    assert!(contract.is_transfer_finalised(transfer_id));
 
     let native_fee = NativeFee {
         amount: U128(100),
@@ -680,6 +680,6 @@ fn test_is_transfer_finalised() {
     };
     contract
         .finalised_transfers
-        .insert(&(chain, nonce.0), &Some(native_fee));
-    assert!(contract.is_transfer_finalised(chain, nonce));
+        .insert(&transfer_id, &Some(native_fee));
+    assert!(contract.is_transfer_finalised(transfer_id));
 }

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -9,7 +9,7 @@ use {
             DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
             ProofKind,
         },
-        stringify, Fee, OmniAddress, TransferId, TransferMessage,
+        stringify, Fee, Nonce, OmniAddress, TransferId,
     },
 };
 
@@ -136,6 +136,7 @@ struct FinTransferWh {
     amount: u128,
     recipient: String,
     transfer_id: TransferId,
+    payload_nonce: Nonce,
 }
 
 #[derive(Debug, BorshDeserialize)]
@@ -162,18 +163,16 @@ impl TryInto<InitTransferMessage> for ParsedVAA {
         }
 
         Ok(InitTransferMessage {
-            transfer: TransferMessage {
-                token: transfer.token_address.clone(),
-                amount: transfer.amount.into(),
-                fee: Fee {
-                    fee: transfer.fee.into(),
-                    native_fee: transfer.native_fee.into(),
-                },
-                recipient: transfer.recipient.parse().map_err(stringify)?,
-                origin_nonce: transfer.nonce.into(),
-                sender: transfer.sender,
-                msg: transfer.message,
+            token: transfer.token_address.clone(),
+            amount: transfer.amount.into(),
+            fee: Fee {
+                fee: transfer.fee.into(),
+                native_fee: transfer.native_fee.into(),
             },
+            recipient: transfer.recipient.parse().map_err(stringify)?,
+            origin_nonce: transfer.nonce.into(),
+            sender: transfer.sender,
+            msg: transfer.message,
             emitter_address: OmniAddress::new_from_slice(
                 transfer.token_address.get_chain(),
                 &self.emitter_address,
@@ -193,6 +192,7 @@ impl TryInto<FinTransferMessage> for ParsedVAA {
         }
 
         Ok(FinTransferMessage {
+            payload_nonce: transfer.payload_nonce,
             transfer_id: transfer.transfer_id,
             fee_recipient: transfer.recipient.parse().map_err(stringify)?,
             amount: transfer.amount.into(),

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -8,8 +8,7 @@ use {
         prover_result::{
             DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
             ProofKind,
-        },
-        stringify, Fee, OmniAddress, TransferId,
+        }, stringify, Fee, Nonce, OmniAddress, TransferId
     },
 };
 
@@ -143,7 +142,7 @@ struct InitTransferWh {
     payload_type: ProofKind,
     sender: OmniAddress,
     token_address: OmniAddress,
-    nonce: u128,
+    origin_nonce: Nonce,
     amount: u128,
     fee: u128,
     native_fee: u128,
@@ -169,7 +168,7 @@ impl TryInto<InitTransferMessage> for ParsedVAA {
                 native_fee: transfer.native_fee.into(),
             },
             recipient: transfer.recipient.parse().map_err(stringify)?,
-            origin_nonce: transfer.nonce.into(),
+            origin_nonce: transfer.origin_nonce,
             sender: transfer.sender,
             msg: transfer.message,
             emitter_address: OmniAddress::new_from_slice(

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -9,7 +9,7 @@ use {
             DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
             ProofKind,
         },
-        stringify, Fee, OmniAddress, TransferMessage,
+        stringify, Fee, OmniAddress, TransferId, TransferMessage,
     },
 };
 
@@ -135,7 +135,7 @@ struct FinTransferWh {
     token_address: OmniAddress,
     amount: u128,
     recipient: String,
-    nonce: u128,
+    transfer_id: TransferId,
 }
 
 #[derive(Debug, BorshDeserialize)]
@@ -193,7 +193,7 @@ impl TryInto<FinTransferMessage> for ParsedVAA {
         }
 
         Ok(FinTransferMessage {
-            nonce: transfer.nonce.into(),
+            transfer_id: transfer.transfer_id,
             fee_recipient: transfer.recipient.parse().map_err(stringify)?,
             amount: transfer.amount.into(),
             emitter_address: OmniAddress::new_from_slice(

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -8,7 +8,8 @@ use {
         prover_result::{
             DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
             ProofKind,
-        }, stringify, Fee, Nonce, OmniAddress, TransferId
+        },
+        stringify, Fee, Nonce, OmniAddress, TransferId,
     },
 };
 

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -9,7 +9,7 @@ use {
             DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
             ProofKind,
         },
-        stringify, Fee, Nonce, OmniAddress, TransferId,
+        stringify, Fee, OmniAddress, TransferId,
     },
 };
 
@@ -132,11 +132,10 @@ struct LogMetadataWh {
 #[derive(Debug, BorshDeserialize)]
 struct FinTransferWh {
     payload_type: ProofKind,
+    transfer_id: TransferId,
     token_address: OmniAddress,
     amount: u128,
-    recipient: String,
-    transfer_id: TransferId,
-    payload_nonce: Nonce,
+    fee_recipient: String,
 }
 
 #[derive(Debug, BorshDeserialize)]
@@ -192,9 +191,8 @@ impl TryInto<FinTransferMessage> for ParsedVAA {
         }
 
         Ok(FinTransferMessage {
-            payload_nonce: transfer.payload_nonce,
             transfer_id: transfer.transfer_id,
-            fee_recipient: transfer.recipient.parse().map_err(stringify)?,
+            fee_recipient: transfer.fee_recipient.parse().map_err(stringify)?,
             amount: transfer.amount.into(),
             emitter_address: OmniAddress::new_from_slice(
                 transfer.token_address.get_chain(),

--- a/near/omni-tests/src/lib.rs
+++ b/near/omni-tests/src/lib.rs
@@ -5,7 +5,7 @@ mod tests {
     use omni_types::{
         locker_args::{FinTransferArgs, StorageDepositArgs},
         prover_result::{InitTransferMessage, ProverResult},
-        Fee, OmniAddress, TransferMessage,
+        Fee, OmniAddress,
     };
 
     const MOCK_TOKEN_PATH: &str = "./../target/wasm32-unknown-unknown/release/mock_token.wasm";
@@ -234,19 +234,17 @@ mod tests {
                     accounts: storage_deposit_accounts,
                 },
                 prover_args: borsh::to_vec(&ProverResult::InitTransfer(InitTransferMessage {
-                    emitter_address: eth_factory_address(),
-                    transfer: TransferMessage {
-                        origin_nonce: U128(1),
-                        token: OmniAddress::Near(token_contract.id().clone()),
-                        recipient: OmniAddress::Near(account_1()),
-                        amount: U128(amount),
-                        fee: Fee {
-                            fee: U128(fee),
-                            native_fee: U128(0),
-                        },
-                        sender: eth_eoa_address(),
-                        msg: String::default(),
+                    origin_nonce: 1,
+                    token: OmniAddress::Near(token_contract.id().clone()),
+                    recipient: OmniAddress::Near(account_1()),
+                    amount: U128(amount),
+                    fee: Fee {
+                        fee: U128(fee),
+                        native_fee: U128(0),
                     },
+                    sender: eth_eoa_address(),
+                    msg: String::default(),
+                    emitter_address: eth_factory_address(),
                 }))
                 .unwrap(),
             })

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -24,9 +24,8 @@ sol! {
     );
 
     event FinTransfer(
-        uint128 indexed payload_nonce,
+        uint8 indexed origin_chain,
         uint128 indexed origin_nonce,
-        uint8 origin_chain,
         address tokenAddress,
         uint128 amount,
         address recipient,
@@ -79,7 +78,6 @@ impl TryFromLog<Log<FinTransfer>> for FinTransferMessage {
         }
 
         Ok(FinTransferMessage {
-            payload_nonce: near_sdk::json_types::U128(event.data.payload_nonce),
             transfer_id: crate::TransferId {
                 chain: event.data.origin_chain.try_into()?,
                 nonce: near_sdk::json_types::U128(event.data.origin_nonce),
@@ -175,9 +173,8 @@ mod tests {
     use super::*;
     sol! {
         event TestFinTransfer(
-            uint128 indexed payload_nonce,
+            uint8 indexed origin_chain,
             uint128 indexed origin_nonce,
-            uint8 origin_chain,
             address tokenAddress,
             uint128 amount,
             address recipient,
@@ -188,7 +185,6 @@ mod tests {
     #[test]
     fn test_decode_log_with_same_params_with_validation() {
         let event = FinTransfer {
-            payload_nonce: 55,
             origin_nonce: 50,
             origin_chain: 1,
             amount: 100,
@@ -197,7 +193,6 @@ mod tests {
             feeRecipient: "some_fee_recipient".to_owned(),
         };
         let test_event = TestFinTransfer {
-            payload_nonce: event.payload_nonce,
             origin_nonce: event.origin_nonce,
             origin_chain: event.origin_chain,
             amount: event.amount,

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -25,6 +25,7 @@ sol! {
 
     event FinTransfer(
         uint128 indexed nonce,
+        uint8 origin_chain,
         address tokenAddress,
         uint128 amount,
         address recipient,
@@ -77,7 +78,10 @@ impl TryFromLog<Log<FinTransfer>> for FinTransferMessage {
         }
 
         Ok(FinTransferMessage {
-            nonce: near_sdk::json_types::U128(event.data.nonce),
+            transfer_id: crate::TransferId {
+                chain: event.data.origin_chain.try_into()?,
+                nonce: near_sdk::json_types::U128(event.data.nonce),
+            },
             amount: near_sdk::json_types::U128(event.data.amount),
             fee_recipient: event.data.feeRecipient.parse().map_err(stringify)?,
             emitter_address: OmniAddress::new_from_evm_address(
@@ -189,6 +193,7 @@ mod tests {
     fn test_decode_log_with_same_params_with_validation() {
         let event = FinTransfer {
             nonce: 55,
+            origin_chain: 1,
             amount: 100,
             tokenAddress: [0; 20].into(),
             recipient: [0; 20].into(),

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -79,8 +79,8 @@ impl TryFromLog<Log<FinTransfer>> for FinTransferMessage {
 
         Ok(FinTransferMessage {
             transfer_id: crate::TransferId {
-                chain: event.data.originChain.try_into()?,
-                nonce: event.data.originNonce,
+                origin_chain: event.data.originChain.try_into()?,
+                origin_nonce: event.data.originNonce,
             },
             amount: near_sdk::json_types::U128(event.data.amount),
             fee_recipient: event.data.feeRecipient.parse().map_err(stringify)?,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -138,8 +138,10 @@ impl Serialize for H160 {
     Serialize,
     Deserialize,
     strum_macros::AsRefStr,
+    Default,
 )]
 pub enum ChainKind {
+    #[default]
     Eth,
     Near,
     Sol,
@@ -360,7 +362,44 @@ impl Fee {
     }
 }
 
-pub type TransferId = (ChainKind, Nonce);
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Copy,
+)]
+pub struct TransferId {
+    // The origin chain kind
+    pub chain: ChainKind,
+    // The transfer nonce that maintained on the source chain
+    pub nonce: Nonce,
+}
+
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Copy,
+)]
+pub struct PayloadId {
+    // The destination chain kind
+    pub chain: ChainKind,
+    // The payload nonce that maintained on NEAR
+    pub nonce: Nonce,
+}
+
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessage {
     pub origin_nonce: U128,
@@ -378,7 +417,10 @@ impl TransferMessage {
     }
 
     pub fn get_transfer_id(&self) -> TransferId {
-        (self.get_origin_chain(), self.origin_nonce.0)
+        TransferId {
+            chain: self.get_origin_chain(),
+            nonce: self.origin_nonce,
+        }
     }
 
     pub fn get_destination_chain(&self) -> ChainKind {
@@ -401,6 +443,15 @@ pub struct TransferMessagePayload {
     pub amount: U128,
     pub recipient: OmniAddress,
     pub fee_recipient: Option<AccountId>,
+}
+
+impl TransferMessagePayload {
+    pub fn get_payload_id(&self) -> PayloadId {
+        PayloadId {
+            chain: self.recipient.get_chain(),
+            nonce: self.nonce,
+        }
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
@@ -434,7 +485,7 @@ pub enum UpdateFee {
     Proof(Vec<u8>),
 }
 
-pub type Nonce = u128;
+pub type Nonce = U128;
 
 pub fn stringify<T: std::fmt::Display>(item: T) -> String {
     item.to_string()

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -404,6 +404,7 @@ pub struct TransferMessage {
     pub fee: Fee,
     pub sender: OmniAddress,
     pub msg: String,
+    pub payload_nonce: U128,
 }
 
 impl TransferMessage {
@@ -433,6 +434,7 @@ pub enum PayloadType {
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessagePayload {
     pub prefix: PayloadType,
+    pub nonce: U128,
     pub transfer_id: TransferId,
     pub token_address: OmniAddress,
     pub amount: U128,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -159,11 +159,11 @@ impl TryFrom<u8> for ChainKind {
     type Error = String;
     fn try_from(input: u8) -> Result<Self, String> {
         match input {
-            1 => Ok(ChainKind::Eth),
-            2 => Ok(ChainKind::Near),
-            3 => Ok(ChainKind::Sol),
-            4 => Ok(ChainKind::Arb),
-            5 => Ok(ChainKind::Base),
+            0 => Ok(ChainKind::Eth),
+            1 => Ok(ChainKind::Near),
+            2 => Ok(ChainKind::Sol),
+            3 => Ok(ChainKind::Arb),
+            4 => Ok(ChainKind::Base),
             _ => Err(format!("{input:?} invalid chain kind")),
         }
     }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -404,7 +404,7 @@ pub struct TransferMessage {
     pub fee: Fee,
     pub sender: OmniAddress,
     pub msg: String,
-    pub payload_nonce: U128,
+    pub destination_nonce: U128,
 }
 
 impl TransferMessage {
@@ -434,7 +434,7 @@ pub enum PayloadType {
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessagePayload {
     pub prefix: PayloadType,
-    pub nonce: U128,
+    pub destination_nonce: Nonce,
     pub transfer_id: TransferId,
     pub token_address: OmniAddress,
     pub amount: U128,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -397,14 +397,14 @@ pub struct TransferId {
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessage {
-    pub origin_nonce: U128,
+    pub origin_nonce: Nonce,
     pub token: OmniAddress,
     pub amount: U128,
     pub recipient: OmniAddress,
     pub fee: Fee,
     pub sender: OmniAddress,
     pub msg: String,
-    pub destination_nonce: U128,
+    pub destination_nonce: Nonce,
 }
 
 impl TransferMessage {
@@ -445,7 +445,7 @@ pub struct TransferMessagePayload {
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct ClaimNativeFeePayload {
     pub prefix: PayloadType,
-    pub nonces: Vec<U128>,
+    pub nonces: Vec<Nonce>,
     pub amount: U128,
     pub recipient: OmniAddress,
 }
@@ -473,7 +473,7 @@ pub enum UpdateFee {
     Proof(Vec<u8>),
 }
 
-pub type Nonce = U128;
+pub type Nonce = u64;
 
 pub fn stringify<T: std::fmt::Display>(item: T) -> String {
     item.to_string()

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -155,6 +155,20 @@ impl From<&OmniAddress> for ChainKind {
     }
 }
 
+impl TryFrom<u8> for ChainKind {
+    type Error = String;
+    fn try_from(input: u8) -> Result<Self, String> {
+        match input {
+            1 => Ok(ChainKind::Eth),
+            2 => Ok(ChainKind::Near),
+            3 => Ok(ChainKind::Sol),
+            4 => Ok(ChainKind::Arb),
+            5 => Ok(ChainKind::Base),
+            _ => Err(format!("{input:?} invalid chain kind")),
+        }
+    }
+}
+
 pub type EvmAddress = H160;
 
 pub const ZERO_ACCOUNT_ID: &str =
@@ -381,25 +395,6 @@ pub struct TransferId {
     pub nonce: Nonce,
 }
 
-#[derive(
-    BorshDeserialize,
-    BorshSerialize,
-    Serialize,
-    Deserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    Default,
-    Copy,
-)]
-pub struct PayloadId {
-    // The destination chain kind
-    pub chain: ChainKind,
-    // The payload nonce that maintained on NEAR
-    pub nonce: Nonce,
-}
-
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessage {
     pub origin_nonce: U128,
@@ -438,20 +433,11 @@ pub enum PayloadType {
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct TransferMessagePayload {
     pub prefix: PayloadType,
-    pub nonce: U128,
+    pub transfer_id: TransferId,
     pub token_address: OmniAddress,
     pub amount: U128,
     pub recipient: OmniAddress,
     pub fee_recipient: Option<AccountId>,
-}
-
-impl TransferMessagePayload {
-    pub fn get_payload_id(&self) -> PayloadId {
-        PayloadId {
-            chain: self.recipient.get_chain(),
-            nonce: self.nonce,
-        }
-    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -390,9 +390,9 @@ impl Fee {
 )]
 pub struct TransferId {
     // The origin chain kind
-    pub chain: ChainKind,
+    pub origin_chain: ChainKind,
     // The transfer nonce that maintained on the source chain
-    pub nonce: Nonce,
+    pub origin_nonce: Nonce,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
@@ -414,8 +414,8 @@ impl TransferMessage {
 
     pub fn get_transfer_id(&self) -> TransferId {
         TransferId {
-            chain: self.get_origin_chain(),
-            nonce: self.origin_nonce,
+            origin_chain: self.get_origin_chain(),
+            origin_nonce: self.origin_nonce,
         }
     }
 

--- a/near/omni-types/src/near_events.rs
+++ b/near/omni-types/src/near_events.rs
@@ -2,9 +2,7 @@ use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::json;
 
 use crate::mpc_types::SignatureResponse;
-use crate::{
-    ClaimNativeFeePayload, MetadataPayload, PayloadId, TransferMessage, TransferMessagePayload,
-};
+use crate::{ClaimNativeFeePayload, MetadataPayload, TransferMessage, TransferMessagePayload};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Nep141LockerEvent {
@@ -16,7 +14,6 @@ pub enum Nep141LockerEvent {
         message_payload: TransferMessagePayload,
     },
     FinTransferEvent {
-        payload_id: Option<PayloadId>,
         transfer_message: TransferMessage,
     },
     UpdateFeeEvent {

--- a/near/omni-types/src/near_events.rs
+++ b/near/omni-types/src/near_events.rs
@@ -1,9 +1,10 @@
-use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::json;
 
 use crate::mpc_types::SignatureResponse;
-use crate::{ClaimNativeFeePayload, MetadataPayload, TransferMessage, TransferMessagePayload};
+use crate::{
+    ClaimNativeFeePayload, MetadataPayload, PayloadId, TransferMessage, TransferMessagePayload,
+};
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub enum Nep141LockerEvent {
@@ -15,7 +16,7 @@ pub enum Nep141LockerEvent {
         message_payload: TransferMessagePayload,
     },
     FinTransferEvent {
-        nonce: Option<U128>,
+        payload_id: Option<PayloadId>,
         transfer_message: TransferMessage,
     },
     UpdateFeeEvent {

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -3,16 +3,23 @@ use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-use crate::{OmniAddress, TransferId, TransferMessage};
+use crate::{Fee, OmniAddress, TransferId};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMessage {
-    pub transfer: TransferMessage,
+    pub origin_nonce: U128,
+    pub token: OmniAddress,
+    pub amount: U128,
+    pub recipient: OmniAddress,
+    pub fee: Fee,
+    pub sender: OmniAddress,
+    pub msg: String,
     pub emitter_address: OmniAddress,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct FinTransferMessage {
+    pub payload_nonce: U128,
     pub transfer_id: TransferId,
     pub fee_recipient: AccountId,
     pub amount: U128,

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -3,7 +3,7 @@ use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-use crate::{OmniAddress, PayloadId, TransferMessage};
+use crate::{OmniAddress, TransferId, TransferMessage};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMessage {
@@ -13,19 +13,10 @@ pub struct InitTransferMessage {
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct FinTransferMessage {
-    pub nonce: U128,
+    pub transfer_id: TransferId,
     pub fee_recipient: AccountId,
     pub amount: U128,
     pub emitter_address: OmniAddress,
-}
-
-impl FinTransferMessage {
-    pub fn get_payload_id(&self) -> PayloadId {
-        PayloadId {
-            chain: self.emitter_address.get_chain(),
-            nonce: self.nonce,
-        }
-    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -3,11 +3,11 @@ use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-use crate::{Fee, OmniAddress, TransferId};
+use crate::{Fee, Nonce, OmniAddress, TransferId};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMessage {
-    pub origin_nonce: U128,
+    pub origin_nonce: Nonce,
     pub token: OmniAddress,
     pub amount: U128,
     pub recipient: OmniAddress,

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -3,7 +3,7 @@ use near_sdk::json_types::U128;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 
-use crate::{OmniAddress, TransferMessage};
+use crate::{OmniAddress, PayloadId, TransferMessage};
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMessage {
@@ -17,6 +17,15 @@ pub struct FinTransferMessage {
     pub fee_recipient: AccountId,
     pub amount: U128,
     pub emitter_address: OmniAddress,
+}
+
+impl FinTransferMessage {
+    pub fn get_payload_id(&self) -> PayloadId {
+        PayloadId {
+            chain: self.emitter_address.get_chain(),
+            nonce: self.nonce,
+        }
+    }
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]

--- a/near/omni-types/src/prover_result.rs
+++ b/near/omni-types/src/prover_result.rs
@@ -19,7 +19,6 @@ pub struct InitTransferMessage {
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct FinTransferMessage {
-    pub payload_nonce: U128,
     pub transfer_id: TransferId,
     pub fee_recipient: AccountId,
     pub amount: U128,

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -2,7 +2,9 @@ use near_sdk::borsh;
 use near_sdk::json_types::U128;
 use near_sdk::serde_json;
 
-use crate::{stringify, ChainKind, Fee, OmniAddress, PayloadType, TransferMessage, H160};
+use crate::{
+    stringify, ChainKind, Fee, OmniAddress, PayloadType, TransferId, TransferMessage, H160,
+};
 use std::str::FromStr;
 
 #[test]
@@ -335,6 +337,7 @@ fn test_transfer_message_getters() {
     let test_cases = vec![
         (
             TransferMessage {
+                destination_nonce: U128(1),
                 origin_nonce: U128(123),
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(1000),
@@ -344,11 +347,15 @@ fn test_transfer_message_getters() {
                 msg: "".to_string(),
             },
             ChainKind::Eth,
-            (ChainKind::Eth, 123),
+            TransferId {
+                chain: ChainKind::Eth,
+                nonce: U128(123),
+            },
             "Should handle ETH sender",
         ),
         (
             TransferMessage {
+                destination_nonce: U128(1),
                 origin_nonce: U128(456),
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(2000),
@@ -358,11 +365,15 @@ fn test_transfer_message_getters() {
                 msg: "".to_string(),
             },
             ChainKind::Near,
-            (ChainKind::Near, 456),
+            TransferId {
+                chain: ChainKind::Near,
+                nonce: U128(456),
+            },
             "Should handle NEAR sender",
         ),
         (
             TransferMessage {
+                destination_nonce: U128(1),
                 origin_nonce: U128(789),
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(3000),
@@ -372,7 +383,10 @@ fn test_transfer_message_getters() {
                 msg: "".to_string(),
             },
             ChainKind::Sol,
-            (ChainKind::Sol, 789),
+            TransferId {
+                chain: ChainKind::Sol,
+                nonce: U128(789),
+            },
             "Should handle SOL sender",
         ),
     ];

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -348,8 +348,8 @@ fn test_transfer_message_getters() {
             },
             ChainKind::Eth,
             TransferId {
-                chain: ChainKind::Eth,
-                nonce: 123,
+                origin_chain: ChainKind::Eth,
+                origin_nonce: 123,
             },
             "Should handle ETH sender",
         ),
@@ -366,8 +366,8 @@ fn test_transfer_message_getters() {
             },
             ChainKind::Near,
             TransferId {
-                chain: ChainKind::Near,
-                nonce: 456,
+                origin_chain: ChainKind::Near,
+                origin_nonce: 456,
             },
             "Should handle NEAR sender",
         ),
@@ -384,8 +384,8 @@ fn test_transfer_message_getters() {
             },
             ChainKind::Sol,
             TransferId {
-                chain: ChainKind::Sol,
-                nonce: 789,
+                origin_chain: ChainKind::Sol,
+                origin_nonce: 789,
             },
             "Should handle SOL sender",
         ),

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -337,8 +337,8 @@ fn test_transfer_message_getters() {
     let test_cases = vec![
         (
             TransferMessage {
-                destination_nonce: U128(1),
-                origin_nonce: U128(123),
+                destination_nonce: 1,
+                origin_nonce: 123,
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(1000),
                 recipient: OmniAddress::Near("bob.near".parse().unwrap()),
@@ -349,14 +349,14 @@ fn test_transfer_message_getters() {
             ChainKind::Eth,
             TransferId {
                 chain: ChainKind::Eth,
-                nonce: U128(123),
+                nonce: 123,
             },
             "Should handle ETH sender",
         ),
         (
             TransferMessage {
-                destination_nonce: U128(1),
-                origin_nonce: U128(456),
+                destination_nonce: 1,
+                origin_nonce: 456,
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(2000),
                 recipient: OmniAddress::Eth(evm_addr.clone()),
@@ -367,14 +367,14 @@ fn test_transfer_message_getters() {
             ChainKind::Near,
             TransferId {
                 chain: ChainKind::Near,
-                nonce: U128(456),
+                nonce: 456,
             },
             "Should handle NEAR sender",
         ),
         (
             TransferMessage {
-                destination_nonce: U128(1),
-                origin_nonce: U128(789),
+                destination_nonce: 1,
+                origin_nonce: 789,
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(3000),
                 recipient: OmniAddress::Near("carol.near".parse().unwrap()),
@@ -385,7 +385,7 @@ fn test_transfer_message_getters() {
             ChainKind::Sol,
             TransferId {
                 chain: ChainKind::Sol,
-                nonce: U128(789),
+                nonce: 789,
             },
             "Should handle SOL sender",
         ),


### PR DESCRIPTION
-  Introduce `destination_nonce` and track it for every chain separately
- Use the `TransferId` to to identify the transfer on all chains.
- Use `uint64` instead of `uint128` for nonces.
