### PR TITLE
fix: Remove excess storage deposit in test

### DIFF
--- a/near/omni-tests/src/fin_transfer.rs
+++ b/near/omni-tests/src/fin_transfer.rs
@@ -196,8 +196,6 @@ mod tests {
             .saturating_mul(storage_deposit_accounts.len() as u128)
             .saturating_add(required_balance_for_fin_transfer)
             .saturating_add(NearToken::from_yoctonear(2))
-            // This is a temporary value to cover the issue with incorrect storage deposit calculation
-            .saturating_add(NearToken::from_yoctonear(1250000000000000000000));
 
         let storage_deposit_actions = storage_deposit_accounts
             .iter()

--- a/near/omni-tests/src/fin_transfer.rs
+++ b/near/omni-tests/src/fin_transfer.rs
@@ -195,7 +195,7 @@ mod tests {
         let required_deposit_for_fin_transfer = NEP141_DEPOSIT
             .saturating_mul(storage_deposit_accounts.len() as u128)
             .saturating_add(required_balance_for_fin_transfer)
-            .saturating_add(NearToken::from_yoctonear(2))
+            .saturating_add(NearToken::from_yoctonear(2));
 
         let storage_deposit_actions = storage_deposit_accounts
             .iter()

--- a/near/omni-tests/src/fin_transfer.rs
+++ b/near/omni-tests/src/fin_transfer.rs
@@ -194,8 +194,7 @@ mod tests {
 
         let required_deposit_for_fin_transfer = NEP141_DEPOSIT
             .saturating_mul(storage_deposit_accounts.len() as u128)
-            .saturating_add(required_balance_for_fin_transfer)
-            .saturating_add(NearToken::from_yoctonear(2));
+            .saturating_add(required_balance_for_fin_transfer);
 
         let storage_deposit_actions = storage_deposit_accounts
             .iter()


### PR DESCRIPTION
With https://github.com/Near-One/omni-bridge/pull/117, we no longer need this adjustment for extra NEAR.

Closes #94 