### PR TITLE
fix: mint native fee on fin_transfer

### DIFF
--- a/near/nep141-locker/src/lib.rs
+++ b/near/nep141-locker/src/lib.rs
@@ -186,6 +186,10 @@ impl FungibleTokenReceiver for Contract {
     ) -> PromiseOrValue<U128> {
         let parsed_msg: InitTransferMsg = serde_json::from_str(&msg).sdk_expect("ERR_PARSE_MSG");
         let token_id = env::predecessor_account_id();
+        require!(
+            parsed_msg.recipient.get_chain() != ChainKind::Near,
+            "ERR_INVALID_RECIPIENT_CHAIN"
+        );
 
         self.current_origin_nonce += 1;
         let destination_nonce = self.get_next_destination_nonce(parsed_msg.recipient.get_chain());

--- a/near/omni-types/src/locker_args.rs
+++ b/near/omni-types/src/locker_args.rs
@@ -5,15 +5,16 @@ use near_sdk::{
 };
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
-pub struct StorageDepositArgs {
-    pub token: AccountId,
-    pub accounts: Vec<(AccountId, bool)>,
+pub struct StorageDepositAction {
+    pub token_id: AccountId,
+    pub account_id: AccountId,
+    pub storage_deposit_amount: Option<u128>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Clone)]
 pub struct FinTransferArgs {
     pub chain_kind: ChainKind,
-    pub storage_deposit_args: StorageDepositArgs,
+    pub storage_deposit_actions: Vec<StorageDepositAction>,
     pub prover_args: Vec<u8>,
 }
 


### PR DESCRIPTION
- Refactored the storage deposit arguments.
- Added verification for of storage deposit for the native token.
- Removed the hardcoded `NEP141_DEPOSIT` amount, the relayer now needs to set this value.