### PR TITLE
Speed up CI and modernize tests

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-all-crates: true
           shared-key: "lint-${{ matrix.component }}"
           workspaces: ${{ matrix.component }}
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         component: [near]  # Will be expanded with more components later
-        check: [clippy, fmt]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,8 +35,11 @@ jobs:
           cache-on-failure: true
           shared-key: "lint-${{ matrix.component }}"
 
-      - name: Run ${{ matrix.check }}
-        run: make ${{ matrix.check }}-${{ matrix.component }}
+      - name: Run clippy
+        run: make clippy-${{ matrix.component }}
+
+      - name: Run fmt
+        run: make fmt-${{ matrix.component }}
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,4 @@
-name: Rust testing and building
+name: Rust CI
 
 on:
   push:
@@ -13,52 +13,57 @@ on:
       - 'omni-relayer/**'
 
 jobs:
-  setup-rust:
+  lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [near]  # Will be expanded with more components later
+        check: [clippy, fmt]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Rust
+      - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.79.0
           components: clippy, rustfmt
           target: wasm32-unknown-unknown
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          shared-key: "lint-${{ matrix.component }}"
 
-      - name: Install nextest 
+      - name: Run ${{ matrix.check }}
+        run: make ${{ matrix.check }}-${{ matrix.component }}
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.79.0
+          target: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "build-test"
+
+      - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
 
-  lint:
-    needs: setup-rust
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        component: [near]
-        check: [clippy, fmt]
-    steps:
-      - name: Run ${{ matrix.check }}
-        run: |
-          make ${{ matrix.check }}-${{ matrix.component }}
+      - name: Build near contract
+        run: make rust-build-near
 
-  build:
-    needs: setup-rust
-    runs-on: ubuntu-latest
-    steps:
-      - name: Build Near contract
-        run: |
-          make rust-build-near
-
-  test:
-    needs: setup-rust
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test Near contracts
-        run: |
-          make test-near
+      - name: Test near contracts
+        run: make test-near

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: "lint-${{ matrix.component }}"
+          workspaces: ${{ matrix.component }}
 
       - name: Run clippy
         run: make clippy-${{ matrix.component }}
@@ -57,6 +58,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+          cache-all-crates: true
           shared-key: "build-test"
           workspaces: near
 
@@ -65,8 +67,11 @@ jobs:
         with:
           tool: nextest
 
-      - name: Build near contract
+      - name: Build token contract
         run: make rust-build-near
 
-      - name: Test near contracts
-        run: make test-near
+      - name: Build tests
+        run: cargo build --manifest-path ./near/Cargo.toml --tests --all-features
+
+      - name: Run tests
+        run: cargo nextest run --manifest-path ./near/Cargo.toml

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           cache-on-failure: true
           shared-key: "build-test"
+          workspaces: near
 
       - name: Install nextest
         uses: taiki-e/install-action@v2

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -13,58 +13,52 @@ on:
       - 'omni-relayer/**'
 
 jobs:
+  setup-rust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.79.0
+          components: clippy, rustfmt
+          target: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install nextest 
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
   lint:
+    needs: setup-rust
     runs-on: ubuntu-latest
     strategy:
       matrix:
         component: [near]
         check: [clippy, fmt]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.79.0
-          components: clippy, rustfmt
-          target: wasm32-unknown-unknown
-          override: true
-
       - name: Run ${{ matrix.check }}
         run: |
           make ${{ matrix.check }}-${{ matrix.component }}
 
   build:
+    needs: setup-rust
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.79.0
-          target: wasm32-unknown-unknown
-          override: true
-
       - name: Build Near contract
         run: |
           make rust-build-near
 
   test:
+    needs: setup-rust
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.79.0
-          target: wasm32-unknown-unknown
-          override: true
-
       - name: Test Near contracts
         run: |
           make test-near

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ rust-build-near: rust-build-token
 	RUSTFLAGS='$(RUSTFLAGS)' cargo build --target wasm32-unknown-unknown --release --manifest-path $(NEAR_MANIFEST)
 
 test-near: rust-build-near
-	cargo test --manifest-path $(NEAR_MANIFEST)
+	cargo nextest run --manifest-path $(NEAR_MANIFEST)

--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -1961,6 +1961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,6 +3926,7 @@ dependencies = [
  "near-sdk",
  "near-workspaces",
  "omni-types",
+ "rstest",
  "tokio",
 ]
 
@@ -4703,6 +4710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4836,6 +4849,35 @@ checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if 1.0.0",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version 0.4.1",
+ "syn 2.0.75",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -41,3 +41,4 @@ ethereum-types = { version = "0.15.1", default-features = false, features = ["rl
 rlp = "0.6"
 sha3 = "0.10.0"
 alloy-sol-types = "0.8"
+rstest = "0.18.2"

--- a/near/omni-tests/Cargo.toml
+++ b/near/omni-tests/Cargo.toml
@@ -14,3 +14,4 @@ near-workspaces.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
 omni-types.workspace = true
+rstest.workspace = true

--- a/near/omni-tests/src/fin_transfer.rs
+++ b/near/omni-tests/src/fin_transfer.rs
@@ -11,101 +11,72 @@ mod tests {
         prover_result::{InitTransferMessage, ProverResult},
         Fee, OmniAddress,
     };
+    use rstest::rstest;
 
+    #[rstest]
+    #[case(vec![(account_1(), true), (relayer_account_id(), true)], 1000, 1, None)]
+    #[case(vec![(account_1(), true)], 1000, 0, None)]
+    #[case(
+        vec![
+            (account_1(), true),
+            (relayer_account_id(), true),
+            (account_2(), true),
+            (account_2(), true),
+        ],
+        1000,
+        1,
+        Some("Invalid len of accounts for storage deposit")
+    )]
+    #[case(
+        vec![(relayer_account_id(), true), (account_1(), true)],
+        1000,
+        1,
+        Some("STORAGE_ERR: The transfer recipient is omitted")
+    )]
+    #[case(
+        vec![(account_1(), true)],
+        1000,
+        1,
+        Some("STORAGE_ERR: The fee recipient is omitted")
+    )]
+    #[case(vec![], 1000, 1, Some("STORAGE_ERR: The transfer recipient is omitted"))]
+    #[case(
+        vec![(account_1(), false), (relayer_account_id(), false)],
+        1000,
+        1,
+        Some("STORAGE_ERR: The transfer recipient is omitted")
+    )]
+    #[case(
+        vec![(account_1(), true), (relayer_account_id(), false)],
+        1000,
+        1,
+        Some("STORAGE_ERR: The fee recipient is omitted")
+    )]
+    #[case(
+        vec![(account_1(), false), (relayer_account_id(), true)],
+        1000,
+        1,
+        Some("STORAGE_ERR: The transfer recipient is omitted")
+    )]
     #[tokio::test]
-    async fn test_storage_deposit_on_fin_transfer() {
-        struct TestStorageDeposit<'a> {
-            storage_deposit_accounts: Vec<(AccountId, bool)>,
-            amount: u128,
-            fee: u128,
-            error: Option<&'a str>,
-        }
-        let test_data = [
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), true), (relayer_account_id(), true)]
-                    .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: None,
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), true)].to_vec(),
-                amount: 1000,
-                fee: 0,
-                error: None,
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [
-                    (account_1(), true),
-                    (relayer_account_id(), true),
-                    (account_2(), true),
-                    (account_2(), true),
-                ]
-                .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("Invalid len of accounts for storage deposit"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(relayer_account_id(), true), (account_1(), true)]
-                    .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The transfer recipient is omitted"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), true)].to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The fee recipient is omitted"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [].to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The transfer recipient is omitted"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), false), (relayer_account_id(), false)]
-                    .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The transfer recipient is omitted"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), true), (relayer_account_id(), false)]
-                    .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The fee recipient is omitted"),
-            },
-            TestStorageDeposit {
-                storage_deposit_accounts: [(account_1(), false), (relayer_account_id(), true)]
-                    .to_vec(),
-                amount: 1000,
-                fee: 1,
-                error: Some("STORAGE_ERR: The transfer recipient is omitted"),
-            },
-        ];
+    async fn test_storage_deposit_on_fin_transfer(
+        #[case] storage_deposit_accounts: Vec<(AccountId, bool)>,
+        #[case] amount: u128,
+        #[case] fee: u128,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let result = test_fin_transfer(storage_deposit_accounts, amount, fee).await;
 
-        for (index, test) in test_data.into_iter().enumerate() {
-            let result =
-                test_fin_transfer(test.storage_deposit_accounts, test.amount, test.fee).await;
-
-            match result {
-                Ok(_) => assert!(test.error.is_none()),
-                Err(result_error) => match test.error {
-                    Some(exepected_error) => {
-                        assert!(
-                            result_error.to_string().contains(exepected_error),
-                            "Wrong error. Test index: {}, err: {}, expected: {}",
-                            index,
-                            result_error,
-                            exepected_error
-                        )
-                    }
-                    None => panic!("Test index: {}, err: {}", index, result_error),
-                },
+        match result {
+            Ok(_) => assert!(expected_error.is_none(), "Expected an error but got success"),
+            Err(result_error) => {
+                let error = expected_error.expect("Got an error when none was expected");
+                assert!(
+                    result_error.to_string().contains(error),
+                    "Wrong error. Got: {}, Expected: {}",
+                    result_error,
+                    error
+                );
             }
         }
     }

--- a/near/omni-tests/src/fin_transfer.rs
+++ b/near/omni-tests/src/fin_transfer.rs
@@ -68,7 +68,10 @@ mod tests {
         let result = test_fin_transfer(storage_deposit_accounts, amount, fee).await;
 
         match result {
-            Ok(_) => assert!(expected_error.is_none(), "Expected an error but got success"),
+            Ok(_) => assert!(
+                expected_error.is_none(),
+                "Expected an error but got success"
+            ),
             Err(result_error) => {
                 let error = expected_error.expect("Got an error when none was expected");
                 assert!(


### PR DESCRIPTION
## ⚡️ Make CI 3x faster (9min → 2min 30s)!
- Switching to `nextest` for parallel test execution
- Consolidating build & test jobs to reduce GitHub Actions overhead
- Using `dtolnay/rust-toolchain` instead of `actions-rs/toolchain`
- Setting up proper Rust caching with workspace-aware configuration
- Enabling aggressive crate caching for both lint and build jobs
- Splitting test build/run for better cache utilization

## Also improved test maintainability by:
- Converting test cases to use `rstest` for better parameterization
- Replacing manual test tables with cleaner `#[case]` syntax
- Making test failure messages more descriptive

All checks remain the same - just way faster now 🚀