### PR TITLE
Backward compatible address prefix for ETH network

### DIFF
--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -273,6 +273,7 @@ impl OmniAddress {
                     format!("sol-{hashed_address}")
                 }
             }
+            OmniAddress::Eth(address) => address.to_string(),
             _ => self.encode('-', true),
         }
     }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -273,7 +273,13 @@ impl OmniAddress {
                     format!("sol-{hashed_address}")
                 }
             }
-            OmniAddress::Eth(address) => address.to_string(),
+            OmniAddress::Eth(address) => {
+                if self.is_zero() {
+                    "eth".to_string()
+                } else {
+                    address.to_string()[2..].to_string()
+                }
+            },
             _ => self.encode('-', true),
         }
     }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -279,7 +279,7 @@ impl OmniAddress {
                 } else {
                     address.to_string()[2..].to_string()
                 }
-            },
+            }
             _ => self.encode('-', true),
         }
     }

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -420,7 +420,7 @@ fn test_stringify() {
 }
 
 #[test]
-fn test_get_token_prefix() {
+fn test_get_native_token_prefix() {
     for chain_kind in [
         ChainKind::Near,
         ChainKind::Sol,
@@ -436,6 +436,23 @@ fn test_get_token_prefix() {
             chain_kind.as_ref().to_lowercase(),
             "Should return correct token prefix for {} chain",
             chain_kind.as_ref()
+        );
+    }
+}
+
+#[test]
+fn test_get_evm_token_prefix() {
+    let address = "0x23ddd3e3692d1861ed57ede224608875809e127f";
+    let eth_address: OmniAddress = format!("eth:{address}").parse().unwrap();
+    let prefix = eth_address.get_token_prefix();
+    assert_eq!(prefix, "23ddd3e3692d1861ed57ede224608875809e127f");
+
+    for chain_kind in [ChainKind::Base, ChainKind::Arb] {
+        let chain_kind_prefix: String = chain_kind.as_ref().to_lowercase();
+        let chain_address: OmniAddress = format!("{chain_kind_prefix}:{address}").parse().unwrap();
+        assert_eq!(
+            chain_address.get_token_prefix(),
+            format!("{chain_kind_prefix}-{address}"),
         );
     }
 }


### PR DESCRIPTION
The Rainbow Bridge deploys tokens in this format [<lower_case_hex>.factory.bridge.near](https://nearblocks.io/address/dac17f958d2ee523a2206206994597c13d831ec7.factory.bridge.near), after the migration we are going to use `factory.bridge.near` as deployer and the tokens for ethereum chain will be deployed in the same format.