### PR TITLE
feat: constructed persistent account keys from instruction

### DIFF
--- a/omni-relayer/clippy.toml
+++ b/omni-relayer/clippy.toml
@@ -1,0 +1,1 @@
+too-many-lines-threshold = 200

--- a/omni-relayer/example-mainnet-config.toml
+++ b/omni-relayer/example-mainnet-config.toml
@@ -38,20 +38,20 @@ expected_finalization_time = 1066
 rpc_http_url = "https://api.mainnet-beta.solana.com"
 rpc_ws_url = "wss://api.mainnet-beta.solana.com"
 # Program ID on Solana is an account ID whitch the bridge contract (basically bridge_token_factory_address on Solana)
-program_id = ""
+program_id = "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe"
 # This is the wormhole contract ID on Solana (can be found here https://wormhole.com/docs/build/reference/contract-addresses/#__tabbed_1_2)
-wormhole_id = ""
+wormhole_id = "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
 # There's a list of account keys and they are store in a strict order. We need indexes to get the right key
-init_transfer_sender_index = 0
-init_transfer_token_index = 6
-init_transfer_emitter_index = 15
-init_transfer_sol_sender_index = 0
-init_transfer_sol_emitter_index = 11
+init_transfer_sender_index = 5
+init_transfer_token_index = 1
+init_transfer_emitter_index = 6
+init_transfer_sol_sender_index = 1
+init_transfer_sol_emitter_index = 3
 # Discriminators are used to identify the type of the event (can be found during the building process of solana's contract)
 init_transfer_discriminator = [174, 50, 134, 99, 122, 243, 243, 224]
 init_transfer_sol_discriminator = [124, 167, 164, 191, 81, 140, 108, 30]
-finalize_transfer_emitter_index = 9
-finalize_transfer_sol_emitter_index = 8
+finalize_transfer_emitter_index = 6
+finalize_transfer_sol_emitter_index = 5
 finalize_transfer_discriminator = [124, 126, 103, 188, 144, 65, 135, 51]
 finalize_transfer_sol_discriminator = [104, 27, 121, 69, 3, 70, 217, 66]
 

--- a/omni-relayer/example-testnet-config.toml
+++ b/omni-relayer/example-testnet-config.toml
@@ -45,16 +45,16 @@ program_id = "Gy1XPwYZURfBzHiGAxnw3SYC33SfqsEpGSS5zeBge28p"
 # This is the wormhole contract ID on Solana (can be found here https://wormhole.com/docs/build/reference/contract-addresses/#__tabbed_1_2)
 wormhole_id = "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"
 # There's a list of account keys and they are store in a strict order. We need indexes to get the right key
-init_transfer_sender_index = 0
-init_transfer_token_index = 6
-init_transfer_emitter_index = 15
-init_transfer_sol_sender_index = 0
-init_transfer_sol_emitter_index = 11
+init_transfer_sender_index = 5
+init_transfer_token_index = 1
+init_transfer_emitter_index = 6
+init_transfer_sol_sender_index = 1
+init_transfer_sol_emitter_index = 3
 # Discriminators are used to identify the type of the event (can be found during the building process of solana's contract)
 init_transfer_discriminator = [174, 50, 134, 99, 122, 243, 243, 224]
 init_transfer_sol_discriminator = [124, 167, 164, 191, 81, 140, 108, 30]
-finalize_transfer_emitter_index = 9
-finalize_transfer_sol_emitter_index = 8
+finalize_transfer_emitter_index = 6
+finalize_transfer_sol_emitter_index = 5
 finalize_transfer_discriminator = [124, 126, 103, 188, 144, 65, 135, 51]
 finalize_transfer_sol_discriminator = [104, 27, 121, 69, 3, 70, 217, 66]
 

--- a/omni-relayer/src/startup/mod.rs
+++ b/omni-relayer/src/startup/mod.rs
@@ -37,10 +37,7 @@ fn build_evm_bridge_client(
                 .private_key(Some(crate::config::get_private_key(chain_kind)))
                 .bridge_token_factory_address(Some(evm.bridge_token_factory_address.to_string()))
                 .build()
-                .context(format!(
-                    "Failed to build EvmBridgeClient ({:?})",
-                    chain_kind
-                ))
+                .context(format!("Failed to build EvmBridgeClient ({chain_kind:?})"))
         })
         .transpose()
 }

--- a/omni-relayer/src/startup/near.rs
+++ b/omni-relayer/src/startup/near.rs
@@ -74,11 +74,13 @@ async fn create_lake_config(
         Some(block) => block,
         None => utils::redis::get_last_processed::<&str, u64>(
             redis_connection,
-            &utils::redis::get_last_processed_key(ChainKind::Near).await,
+            &utils::redis::get_last_processed_key(ChainKind::Near),
         )
         .await
-        .map(|block_height| block_height + 1)
-        .unwrap_or(utils::near::get_final_block(jsonrpc_client).await?),
+        .map_or(
+            utils::near::get_final_block(jsonrpc_client).await?,
+            |block_height| block_height + 1,
+        ),
     };
 
     info!("NEAR Lake will start from block: {}", start_block_height);
@@ -127,7 +129,7 @@ pub async fn start_indexer(
 
                 utils::redis::update_last_processed(
                     &mut redis_connection,
-                    &utils::redis::get_last_processed_key(ChainKind::Near).await,
+                    &utils::redis::get_last_processed_key(ChainKind::Near),
                     streamer_message.block.header.height,
                 )
                 .await;

--- a/omni-relayer/src/utils/evm.rs
+++ b/omni-relayer/src/utils/evm.rs
@@ -143,13 +143,10 @@ pub async fn construct_prover_args(
     borsh::to_vec(&evm_proof_args).ok()
 }
 
-pub async fn string_to_evm_omniaddress(
-    chain_kind: ChainKind,
-    address: String,
-) -> Result<OmniAddress> {
+pub fn string_to_evm_omniaddress(chain_kind: ChainKind, address: &str) -> Result<OmniAddress> {
     OmniAddress::new_from_evm_address(
         chain_kind,
-        H160::from_str(&address)
+        H160::from_str(address)
             .map_err(|err| anyhow::anyhow!("Failed to parse as H160 address: {:?}", err))?,
     )
     .map_err(|err| anyhow::anyhow!("Failed to parse as EvmOmniAddress address: {:?}", err))

--- a/omni-relayer/src/utils/redis.rs
+++ b/omni-relayer/src/utils/redis.rs
@@ -20,10 +20,10 @@ pub const SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS: u64 = 10;
 const QUERY_RETRY_ATTEMPTS: u64 = 10;
 const QUERY_RETRY_SLEEP_SECS: u64 = 1;
 
-pub async fn get_last_processed_key(chain_kind: ChainKind) -> String {
+pub fn get_last_processed_key(chain_kind: ChainKind) -> String {
     match chain_kind {
         ChainKind::Sol => "SOLANA_LAST_PROCESSED_SIGNATURE".to_string(),
-        _ => format!("{:?}_LAST_PROCESSED_BLOCK", chain_kind),
+        _ => format!("{chain_kind:?}_LAST_PROCESSED_BLOCK"),
     }
 }
 

--- a/omni-relayer/src/utils/solana.rs
+++ b/omni-relayer/src/utils/solana.rs
@@ -30,7 +30,7 @@ pub async fn process_message(
         let account_keys = instruction
             .accounts
             .into_iter()
-            .map(|i| message.account_keys.get(i as usize).cloned())
+            .map(|i| message.account_keys.get(usize::from(i)).cloned())
             .collect::<Vec<_>>();
 
         if let Err(err) = decode_instruction(
@@ -120,7 +120,7 @@ async fn decode_instruction(
                         let Some(sequence) = log
                             .split_ascii_whitespace()
                             .last()
-                            .map(|sequence| sequence.to_string())
+                            .map(std::string::ToString::to_string)
                         else {
                             warn!("Failed to parse sequence number from log: {:?}", log);
                             continue;
@@ -184,7 +184,7 @@ async fn decode_instruction(
                     let Some(sequence) = log
                         .split_ascii_whitespace()
                         .last()
-                        .map(|sequence| sequence.to_string())
+                        .map(std::string::ToString::to_string)
                     else {
                         warn!("Failed to parse sequence number from log: {:?}", log);
                         continue;

--- a/omni-relayer/src/utils/solana.rs
+++ b/omni-relayer/src/utils/solana.rs
@@ -27,13 +27,19 @@ pub async fn process_message(
     signature: Signature,
 ) {
     for instruction in message.instructions.clone() {
+        let account_keys = instruction
+            .accounts
+            .into_iter()
+            .map(|i| message.account_keys.get(i as usize).cloned())
+            .collect::<Vec<_>>();
+
         if let Err(err) = decode_instruction(
             redis_connection,
             solana,
             signature,
             transaction,
             &instruction.data,
-            &message.account_keys,
+            account_keys,
         )
         .await
         {
@@ -48,7 +54,7 @@ async fn decode_instruction(
     signature: Signature,
     transaction: &EncodedTransactionWithStatusMeta,
     data: &str,
-    account_keys: &[String],
+    account_keys: Vec<Option<String>>,
 ) -> Result<()> {
     let decoded_data = bs58::decode(data).into_vec()?;
 
@@ -78,21 +84,31 @@ async fn decode_instruction(
             let (sender, token, emitter) = if discriminator == &solana.init_transfer_discriminator {
                 let sender = account_keys
                     .get(solana.init_transfer_sender_index)
-                    .context("Missing sender account key")?;
+                    .context("Missing sender account key")?
+                    .as_ref()
+                    .context("Sender account key is None")?;
                 let token = account_keys
                     .get(solana.init_transfer_token_index)
-                    .context("Missing token account key")?;
+                    .context("Missing token account key")?
+                    .as_ref()
+                    .context("Sender account key is None")?;
                 let emitter = account_keys
                     .get(solana.init_transfer_emitter_index)
-                    .context("Missing emitter account key")?;
+                    .context("Missing emitter account key")?
+                    .as_ref()
+                    .context("Emitter key is None")?;
                 (sender, token, emitter)
             } else {
                 let sender = account_keys
                     .get(solana.init_transfer_sol_sender_index)
-                    .context("Missing SOL sender account key")?;
+                    .context("Missing SOL sender account key")?
+                    .as_ref()
+                    .context("SOL sender account key is None")?;
                 let emitter = account_keys
                     .get(solana.init_transfer_sol_emitter_index)
-                    .context("Missing SOL emitter account key")?;
+                    .context("Missing SOL emitter account key")?
+                    .as_ref()
+                    .context("Sol emitter key is None")?;
                 (sender, &Pubkey::default().to_string(), emitter)
             };
 
@@ -150,10 +166,14 @@ async fn decode_instruction(
             account_keys
                 .get(solana.finalize_transfer_emitter_index)
                 .context("Missing emitter account key")?
+                .as_ref()
+                .context("Emitter account key is None")?
         } else {
             account_keys
                 .get(solana.finalize_transfer_sol_emitter_index)
                 .context("Missing SOL emitter account key")?
+                .as_ref()
+                .context("SOL emitter account key is None")?
         };
 
         if let Some(OptionSerializer::Some(logs)) =

--- a/omni-relayer/src/utils/storage.rs
+++ b/omni-relayer/src/utils/storage.rs
@@ -17,43 +17,28 @@ async fn get_token_id(
     let omni_token_address = match chain_kind {
         ChainKind::Near => {
             let token = AccountId::from_str(token_address).map_err(|_| {
-                format!(
-                    "Failed to parse token address as AccountId: {:?}",
-                    token_address
-                )
+                format!("Failed to parse token address as AccountId: {token_address:?}",)
             })?;
             Ok(OmniAddress::Near(token))
         }
         ChainKind::Eth | ChainKind::Base | ChainKind::Arb => {
-            utils::evm::string_to_evm_omniaddress(chain_kind, token_address.to_string())
-                .await
+            utils::evm::string_to_evm_omniaddress(chain_kind, token_address)
                 .map_err(|err| err.to_string())
         }
         ChainKind::Sol => {
             let token = Pubkey::from_str(token_address).map_err(|_| {
-                format!(
-                    "Failed to parse token address as Pubkey: {:?}",
-                    token_address
-                )
+                format!("Failed to parse token address as Pubkey: {token_address:?}",)
             })?;
             OmniAddress::new_from_slice(ChainKind::Sol, &token.to_bytes())
         }
     }
-    .map_err(|_| {
-        format!(
-            "Failed to convert token address to OmniAddress: {:?}",
-            token_address
-        )
-    })?;
+    .map_err(|_| format!("Failed to convert token address to OmniAddress: {token_address:?}",))?;
 
     let token_id = connector
         .near_get_token_id(omni_token_address.clone())
         .await
         .map_err(|_| {
-            format!(
-                "Failed to get token id by omni token address: {:?}",
-                omni_token_address
-            )
+            format!("Failed to get token id by omni token address: {omni_token_address:?}",)
         })?;
 
     Ok(token_id)
@@ -69,10 +54,7 @@ async fn add_storage_deposit_action(
         .near_get_required_storage_deposit(token_id.clone(), account_id.clone())
         .await
         .map_err(|_| {
-            format!(
-                "Failed to get required storage deposit for account: {:?}",
-                account_id
-            )
+            format!("Failed to get required storage deposit for account: {account_id:?}",)
         })? {
         amount if amount > 0 => Some(amount),
         _ => None,
@@ -124,12 +106,7 @@ pub async fn get_storage_deposit_actions(
         let token_id = connector
             .near_get_native_token_id(chain_kind)
             .await
-            .map_err(|_| {
-                format!(
-                    "Failed to get native token id by chain kind: {:?}",
-                    chain_kind
-                )
-            })?;
+            .map_err(|_| format!("Failed to get native token id by chain kind: {chain_kind:?}",))?;
 
         let relayer = connector
             .near_bridge_client()


### PR DESCRIPTION
Just to add some clarity, I want to provide a small explanation why do we need this logic

These are account keys that we can get from `raw_message.account_keys`:
```txt
Account Keys: ["BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR", "DsR6nocBnnkmRdRNYCXtXoNsdTKfa9Kd4ZdcxJEZJeKv", "79nePUUxtfJSdrkbririgL5YMaoEh5g4HNQaar2EuJ7", "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe", "2yVjuQwpsvdsrywzs
JJVs9Ueh4zayyo5DYJbBNc3DDpn", "3ZLekZYq2qkZiSpnSvabjit34tUkjSwD1JFuW9as9wBG", "6tckHFBpiJ8YgYN8FUskvtvTpXQZ55g5LHeo1kvELoDQ", "9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxeintHy", "G7BgdUgsQ7iQmHUqPM85XvantPDqHxEi88Fs23FeDTLo", "11
111111111111111111111111111111", "SysvarC1ock11111111111111111111111111111111", "SysvarRent111111111111111111111111111111111", "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth", "2iA
NpDh96GgithLPTVMZjZFtnbrYBUCLqnEvaytbwTQq", "FvULawNPGBbuwYus74ECaQoV1oH9Tk6XPN7VPN51NYds"]
```

They are sorted based on few rules. Firstly, accounts are splitted into the groups and the priority is like this:

1) fee payer
2) signers
3) writable accounts
4) read-only accounts (e.g program and sysvar accounts)

Then accounts in each group are sorted in lexicographical order, which means that this is way too impersistent for our use case. In order to get a strong order that will be based on our instructions we can look into `instruction.accounts` which is a simple `&[u8]` with the correct strict position of each account key:

```txt
Instruction: [15, 5, 8, 3, 6, 0, 14, 4, 7, 2, 1, 0, 10, 11, 13, 9, 12]
Instruction account keys: ["FvULawNPGBbuwYus74ECaQoV1oH9Tk6XPN7VPN51NYds", "3ZLekZYq2qkZiSpnSvabjit34tUkjSwD1JFuW9as9wBG", "G7BgdUgsQ7iQmHUqPM85XvantPDqHxEi88Fs23FeDTLo", "dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe", "6tckHF
BpiJ8YgYN8FUskvtvTpXQZ55g5LHeo1kvELoDQ", "BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR", "2iANpDh96GgithLPTVMZjZFtnbrYBUCLqnEvaytbwTQq", "2yVjuQwpsvdsrywzsJJVs9Ueh4zayyo5DYJbBNc3DDpn", "9bFNrXNb2WTx8fMHXCheaZqkLZ3YCCaiqTftHxe
intHy", "79nePUUxtfJSdrkbririgL5YMaoEh5g4HNQaar2EuJ7", "DsR6nocBnnkmRdRNYCXtXoNsdTKfa9Kd4ZdcxJEZJeKv", "BXss9YNCX2p6VPf2Em54pHXkXnC2FPBeZgbB9fY1cuBR", "SysvarC1ock11111111111111111111111111111111", "SysvarRent1111111111111111
11111111111111111", "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth", "11111111111111111111111111111111", "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"]
```
