### PR TITLE
Add dummy GA pipeline for E2E tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,17 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      selected_pipelines:
+        description: "Space-separated list of pipelines to run (e.g. 'bridge_token_near_to_evm another_pipeline')"
+        required: false
+        default: "bridge_token_near_to_evm"
+
+jobs:
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3


### PR DESCRIPTION
The dummy pipeline is required to test the pipeline from another PR.

If the pipeline must be triggered manually, it can't be tested from PR unless its version is already in the main branch.