### PR TITLE
fix: restart ws connection to rpc when it was dropped

### DIFF
--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -53,22 +53,31 @@ pub async fn start_indexer(
         "Failed to parse {chain_kind:?} rpc provider as url",
     ))?);
 
-    let ws_provider = ProviderBuilder::new()
-        .on_ws(WsConnect::new(rpc_ws_url))
-        .await
-        .context(format!("Failed to initialize {chain_kind:?} WS provider"))?;
-
     let last_processed_block_key = utils::redis::get_last_processed_key(chain_kind);
     let latest_block = http_provider.get_block_number().await?;
     let from_block = match start_block {
         Some(block) => block,
         None => {
-            utils::redis::get_last_processed(&mut redis_connection, &last_processed_block_key)
-                .await
-                .unwrap_or(latest_block)
-                + 1
+            if let Some(block) = utils::redis::get_last_processed::<&str, u64>(
+                &mut redis_connection,
+                &last_processed_block_key,
+            )
+            .await
+            {
+                block + 1
+            } else {
+                utils::redis::update_last_processed(
+                    &mut redis_connection,
+                    &last_processed_block_key,
+                    latest_block + 1,
+                )
+                .await;
+                latest_block + 1
+            }
         }
     };
+
+    info!("{chain_kind:?} indexer will start from block: {from_block}");
 
     let filter = Filter::new()
         .address(bridge_token_factory_address)
@@ -110,19 +119,50 @@ pub async fn start_indexer(
         chain_kind
     );
 
-    let mut stream = ws_provider.subscribe_logs(&filter).await?.into_stream();
-    while let Some(log) = stream.next().await {
-        process_log(
-            chain_kind,
-            &mut redis_connection,
-            &http_provider,
-            log,
-            expected_finalization_time,
-        )
-        .await;
-    }
+    loop {
+        let ws_provider = match ProviderBuilder::new()
+            .on_ws(WsConnect::new(&rpc_ws_url))
+            .await
+        {
+            Ok(provider) => provider,
+            Err(err) => {
+                warn!(
+                    "{chain_kind:?} WebSocket connection failed: {}, retrying...",
+                    err
+                );
+                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
 
-    Ok(())
+        let mut stream = match ws_provider.subscribe_logs(&filter).await {
+            Ok(subscription) => subscription.into_stream(),
+            Err(err) => {
+                warn!(
+                    "Subscription to logs on {chain_kind:?} chain failed: {}, retrying...",
+                    err
+                );
+                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                continue;
+            }
+        };
+
+        info!("Subscribed to {:?} logs", chain_kind);
+
+        while let Some(log) = stream.next().await {
+            process_log(
+                chain_kind,
+                &mut redis_connection,
+                &http_provider,
+                log,
+                expected_finalization_time,
+            )
+            .await;
+        }
+
+        warn!("{chain_kind:?} WebSocket stream closed unexpectedly, reconnecting...");
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+    }
 }
 
 async fn process_log(

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use log::{info, warn};
+use log::{error, info, warn};
 use omni_types::ChainKind;
 use reqwest::Client;
 use tokio_stream::StreamExt;
@@ -126,7 +126,7 @@ pub async fn start_indexer(
         {
             Ok(provider) => provider,
             Err(err) => {
-                warn!(
+                error!(
                     "{chain_kind:?} WebSocket connection failed: {}, retrying...",
                     err
                 );
@@ -138,7 +138,7 @@ pub async fn start_indexer(
         let mut stream = match ws_provider.subscribe_logs(&filter).await {
             Ok(subscription) => subscription.into_stream(),
             Err(err) => {
-                warn!(
+                error!(
                     "Subscription to logs on {chain_kind:?} chain failed: {}, retrying...",
                     err
                 );
@@ -160,7 +160,7 @@ pub async fn start_indexer(
             .await;
         }
 
-        warn!("{chain_kind:?} WebSocket stream closed unexpectedly, reconnecting...");
+        error!("{chain_kind:?} WebSocket stream closed unexpectedly, reconnecting...");
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
     }
 }

--- a/omni-relayer/src/startup/mod.rs
+++ b/omni-relayer/src/startup/mod.rs
@@ -17,6 +17,20 @@ pub mod evm;
 pub mod near;
 pub mod solana;
 
+#[macro_export]
+macro_rules! skip_fail {
+    ($res:expr, $msg:expr, $dur:expr) => {
+        match $res {
+            Ok(val) => val,
+            Err(err) => {
+                error!("{}: {}", $msg, err);
+                tokio::time::sleep(tokio::time::Duration::from_secs($dur)).await;
+                continue;
+            }
+        }
+    };
+}
+
 fn build_evm_bridge_client(
     config: &config::Config,
     chain_kind: ChainKind,


### PR DESCRIPTION
<img width="982" alt="image" src="https://github.com/user-attachments/assets/29ec69c7-88cb-4e8d-8339-4c796b0ab81f" />

In the worst case scenario when there's no network connection relayer will try to reconnect to rpc providers every 5 seconds instead of dying silently

closes #220 