### PR TITLE
fix: restart ws connection to rpc when it was dropped and sync lost blocks

### DIFF
--- a/omni-relayer/src/main.rs
+++ b/omni-relayer/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use log::{error, info};
 use omni_types::ChainKind;
+use solana_sdk::signature::Signature;
 
 mod config;
 mod startup;
@@ -29,7 +30,7 @@ struct CliArgs {
     arb_start_block: Option<u64>,
     /// Start signature for Solana indexer
     #[clap(long)]
-    solana_start_signature: Option<String>,
+    solana_start_signature: Option<Signature>,
 }
 
 #[tokio::main]

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -32,7 +32,7 @@ pub async fn start_indexer(
     config: config::Config,
     redis_client: redis::Client,
     chain_kind: ChainKind,
-    start_block: Option<u64>,
+    mut start_block: Option<u64>,
 ) -> Result<()> {
     let mut redis_connection = redis_client.get_multiplexed_tokio_connection().await?;
 
@@ -49,36 +49,6 @@ pub async fn start_indexer(
         _ => anyhow::bail!("Unsupported chain kind: {chain_kind:?}"),
     };
 
-    let http_provider = ProviderBuilder::new().on_http(rpc_http_url.parse().context(format!(
-        "Failed to parse {chain_kind:?} rpc provider as url",
-    ))?);
-
-    let last_processed_block_key = utils::redis::get_last_processed_key(chain_kind);
-    let latest_block = http_provider.get_block_number().await?;
-    let from_block = match start_block {
-        Some(block) => block,
-        None => {
-            if let Some(block) = utils::redis::get_last_processed::<&str, u64>(
-                &mut redis_connection,
-                &last_processed_block_key,
-            )
-            .await
-            {
-                block + 1
-            } else {
-                utils::redis::update_last_processed(
-                    &mut redis_connection,
-                    &last_processed_block_key,
-                    latest_block + 1,
-                )
-                .await;
-                latest_block + 1
-            }
-        }
-    };
-
-    info!("{chain_kind:?} indexer will start from block: {from_block}");
-
     let filter = Filter::new()
         .address(bridge_token_factory_address)
         .event_signature(
@@ -90,36 +60,27 @@ pub async fn start_indexer(
             .to_vec(),
         );
 
-    for current_block in
-        (from_block..latest_block).step_by(usize::try_from(block_processing_batch_size)?)
-    {
-        let logs = http_provider
-            .get_logs(
-                &filter
-                    .clone()
-                    .from_block(current_block)
-                    .to_block((current_block + block_processing_batch_size).min(latest_block)),
-            )
-            .await?;
-
-        for log in logs {
-            process_log(
-                chain_kind,
-                &mut redis_connection,
-                &http_provider,
-                log,
-                expected_finalization_time,
-            )
-            .await;
-        }
-    }
-
-    info!(
-        "All historical logs processed, starting {:?} WS subscription",
-        chain_kind
-    );
-
     loop {
+        let http_provider = ProviderBuilder::new().on_http(rpc_http_url.parse().context(
+            format!("Failed to parse {chain_kind:?} rpc provider as url",),
+        )?);
+
+        process_recent_blocks(
+            &mut redis_connection,
+            &http_provider,
+            &filter,
+            chain_kind,
+            start_block,
+            block_processing_batch_size,
+            expected_finalization_time,
+        )
+        .await?;
+
+        info!(
+            "All historical logs processed, starting {:?} WS subscription",
+            chain_kind
+        );
+
         let ws_provider = crate::skip_fail!(
             ProviderBuilder::new()
                 .on_ws(WsConnect::new(&rpc_ws_url))
@@ -149,8 +110,72 @@ pub async fn start_indexer(
         }
 
         error!("{chain_kind:?} WebSocket stream closed unexpectedly, reconnecting...");
+        start_block = None;
+
         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
     }
+}
+
+async fn process_recent_blocks(
+    redis_connection: &mut redis::aio::MultiplexedConnection,
+    http_provider: &RootProvider<Http<Client>>,
+    filter: &Filter,
+    chain_kind: ChainKind,
+    start_block: Option<u64>,
+    block_processing_batch_size: u64,
+    expected_finalization_time: i64,
+) -> Result<()> {
+    let last_processed_block_key = utils::redis::get_last_processed_key(chain_kind);
+    let latest_block = http_provider.get_block_number().await?;
+    let from_block = match start_block {
+        Some(block) => block,
+        None => {
+            if let Some(block) = utils::redis::get_last_processed::<&str, u64>(
+                redis_connection,
+                &last_processed_block_key,
+            )
+            .await
+            {
+                block + 1
+            } else {
+                utils::redis::update_last_processed(
+                    redis_connection,
+                    &last_processed_block_key,
+                    latest_block + 1,
+                )
+                .await;
+                latest_block + 1
+            }
+        }
+    };
+
+    info!("{chain_kind:?} indexer will start from block: {from_block}");
+
+    for current_block in
+        (from_block..latest_block).step_by(usize::try_from(block_processing_batch_size)?)
+    {
+        let logs = http_provider
+            .get_logs(
+                &filter
+                    .clone()
+                    .from_block(current_block)
+                    .to_block((current_block + block_processing_batch_size).min(latest_block)),
+            )
+            .await?;
+
+        for log in logs {
+            process_log(
+                chain_kind,
+                redis_connection,
+                http_provider,
+                log,
+                expected_finalization_time,
+            )
+            .await;
+        }
+    }
+
+    Ok(())
 }
 
 async fn process_log(

--- a/omni-relayer/src/startup/solana.rs
+++ b/omni-relayer/src/startup/solana.rs
@@ -31,7 +31,7 @@ pub fn get_keypair(file: Option<&String>) -> Keypair {
 pub async fn start_indexer(
     config: config::Config,
     redis_client: redis::Client,
-    start_signature: Option<String>,
+    mut start_signature: Option<Signature>,
 ) -> Result<()> {
     let Some(solana_config) = config.solana else {
         anyhow::bail!("Failed to get Solana config");
@@ -43,27 +43,26 @@ pub async fn start_indexer(
     let rpc_ws_url = &solana_config.rpc_ws_url;
     let program_id = Pubkey::from_str(&solana_config.program_id)?;
 
-    let http_client = RpcClient::new(rpc_http_url.to_string());
-
-    if let Err(e) = process_recent_signatures(
-        &mut redis_connection,
-        &http_client,
-        &program_id,
-        start_signature,
-    )
-    .await
-    {
-        warn!("Failed to fetch recent logs: {}", e);
-    }
-
-    info!("All historical logs processed, starting Solana WS subscription");
-
-    let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
-    let config = RpcTransactionLogsConfig {
-        commitment: Some(CommitmentConfig::processed()),
-    };
-
     loop {
+        crate::skip_fail!(
+            process_recent_signatures(
+                &mut redis_connection,
+                rpc_http_url.clone(),
+                &program_id,
+                start_signature,
+            )
+            .await,
+            "Failed to process recent signatures",
+            5
+        );
+
+        info!("All historical logs processed, starting Solana WS subscription");
+
+        let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
+        let config = RpcTransactionLogsConfig {
+            commitment: Some(CommitmentConfig::processed()),
+        };
+
         let ws_client = crate::skip_fail!(
             PubsubClient::new(rpc_ws_url).await,
             "Solana WebSocket connection failed",
@@ -96,26 +95,31 @@ pub async fn start_indexer(
         }
 
         error!("Solana WebSocket stream closed, reconnecting...");
+        start_signature = None;
+
+        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
     }
 }
 
 async fn process_recent_signatures(
     redis_connection: &mut redis::aio::MultiplexedConnection,
-    http_client: &RpcClient,
+    rpc_http_url: String,
     program_id: &Pubkey,
-    start_signature: Option<String>,
+    start_signature: Option<Signature>,
 ) -> Result<()> {
+    let http_client = RpcClient::new(rpc_http_url);
+
     let from_signature = if let Some(signature) = start_signature {
         utils::redis::add_event(
             redis_connection,
             utils::redis::SOLANA_EVENTS,
-            signature.clone(),
+            signature.to_string(),
             // TODO: It's better to come up with a solution that wouldn't require storing `Null` value
             serde_json::Value::Null,
         )
         .await;
 
-        Signature::from_str(&signature)?
+        signature
     } else {
         let Some(signature) = utils::redis::get_last_processed::<&str, String>(
             redis_connection,


### PR DESCRIPTION
We found an issue when connection can be dropped right when new event should be found, so we need to fetch everything from the last_processed_block
![image](https://github.com/user-attachments/assets/b1980c3e-2250-4582-ba38-28a84b81d9a4)
![image](https://github.com/user-attachments/assets/be43c184-36fe-4996-b177-95900549dcd8)
