### PR TITLE
Revert "fix: replaced deprecated release action"

### DIFF
--- a/.github/workflows/build-contracts.yaml
+++ b/.github/workflows/build-contracts.yaml
@@ -65,7 +65,8 @@ jobs:
           fi
 
       - name: Upload Artifacts
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.platform }}-artifacts
-          files: ${{ github.workspace }}/e2e-testing/${{ matrix.platform }}_artifacts
+          path: |
+            ${{ github.workspace }}/e2e-testing/${{ matrix.platform }}_artifacts


### PR DESCRIPTION
Reverts Near-One/omni-bridge#231

Reason: https://github.com/Near-One/omni-bridge/actions/runs/13221464115/job/36907014544#step:10:7