### PR TITLE
feat: pass the fast relayer over `FastFinTransferMsg`

### DIFF
--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -1,7 +1,7 @@
 use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
 use near_sdk::{assert_one_yocto, borsh, near};
 use near_sdk::{env, near_bindgen, AccountId, NearToken};
-use omni_types::{FastTransferStatus, TransferId};
+use omni_types::{FastRelayer, FastTransferStatus, TransferId};
 
 use crate::{
     require, ChainKind, Contract, ContractExt, Fee, OmniAddress, Promise, SdkExpect,
@@ -196,12 +196,15 @@ impl Contract {
         storage_cost.saturating_add(ft_transfers_cost)
     }
 
-    pub fn required_balance_for_fast_transfer(&self) -> NearToken {
+    pub fn required_balance_for_fast_transfer(&self, msg: String) -> NearToken {
         let key_len = borsh::to_vec(&[0u8; 32]).sdk_expect("ERR_BORSH").len() as u64;
 
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&FastTransferStatus {
-            relayer: max_account_id,
+            relayer: FastRelayer {
+                relayer_id: max_account_id.clone(),
+                msg,
+            },
             finalised: false,
         })
         .sdk_expect("ERR_BORSH")

--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -1,7 +1,7 @@
 use near_contract_standards::storage_management::{StorageBalance, StorageBalanceBounds};
 use near_sdk::{assert_one_yocto, borsh, near};
 use near_sdk::{env, near_bindgen, AccountId, NearToken};
-use omni_types::{FastRelayer, FastTransferStatus, TransferId};
+use omni_types::{FastTransferStatus, TransferId};
 
 use crate::{
     require, ChainKind, Contract, ContractExt, Fee, OmniAddress, Promise, SdkExpect,
@@ -196,16 +196,13 @@ impl Contract {
         storage_cost.saturating_add(ft_transfers_cost)
     }
 
-    pub fn required_balance_for_fast_transfer(&self, msg: String) -> NearToken {
+    pub fn required_balance_for_fast_transfer(&self) -> NearToken {
         let key_len = borsh::to_vec(&[0u8; 32]).sdk_expect("ERR_BORSH").len() as u64;
 
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&FastTransferStatus {
-            relayer: FastRelayer {
-                relayer_id: max_account_id.clone(),
-                msg,
-            },
             finalised: false,
+            relayer_id: max_account_id.clone(),
         })
         .sdk_expect("ERR_BORSH")
         .len() as u64;

--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -201,8 +201,8 @@ impl Contract {
 
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&FastTransferStatus {
+            relayer: max_account_id.clone(),
             finalised: false,
-            relayer_id: max_account_id.clone(),
         })
         .sdk_expect("ERR_BORSH")
         .len() as u64;

--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -201,7 +201,7 @@ impl Contract {
 
         let max_account_id: AccountId = "a".repeat(64).parse().sdk_expect("ERR_PARSE_ACCOUNT_ID");
         let value_len = borsh::to_vec(&FastTransferStatus {
-            relayer: max_account_id.clone(),
+            relayer: max_account_id,
             finalised: false,
         })
         .sdk_expect("ERR_BORSH")

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -393,6 +393,7 @@ pub struct FastFinTransferMsg {
     pub fee: Fee,
     pub msg: String,
     pub storage_deposit_amount: Option<u128>,
+    pub relayer: FastRelayer,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -400,13 +401,6 @@ pub struct InitTransferMsg {
     pub recipient: OmniAddress,
     pub fee: U128,
     pub native_token_fee: U128,
-}
-
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Clone)]
-pub struct FeeRecipient {
-    pub recipient: AccountId,
-    pub native_fee_recipient: OmniAddress,
 }
 
 #[near(serializers=[borsh, json])]
@@ -556,8 +550,16 @@ impl FastTransfer {
     }
 }
 
-#[derive(BorshDeserialize, BorshSerialize, Debug, Clone)]
+#[near(serializers=[borsh, json])]
+#[derive(Debug, Clone)]
+pub struct FastRelayer {
+    pub relayer_id: AccountId,
+    pub msg: String,
+}
+
+#[near(serializers=[borsh, json])]
+#[derive(Debug, Clone)]
 pub struct FastTransferStatus {
     pub finalised: bool,
-    pub relayer: AccountId,
+    pub relayer: FastRelayer,
 }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -393,7 +393,7 @@ pub struct FastFinTransferMsg {
     pub fee: Fee,
     pub msg: String,
     pub storage_deposit_amount: Option<u128>,
-    pub relayer: FastRelayer,
+    pub relayer_id: AccountId,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -552,14 +552,7 @@ impl FastTransfer {
 
 #[near(serializers=[borsh, json])]
 #[derive(Debug, Clone)]
-pub struct FastRelayer {
-    pub relayer_id: AccountId,
-    pub msg: String,
-}
-
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Clone)]
 pub struct FastTransferStatus {
     pub finalised: bool,
-    pub relayer: FastRelayer,
+    pub relayer_id: AccountId,
 }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -393,7 +393,7 @@ pub struct FastFinTransferMsg {
     pub fee: Fee,
     pub msg: String,
     pub storage_deposit_amount: Option<u128>,
-    pub relayer_id: AccountId,
+    pub relayer: AccountId,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -554,5 +554,5 @@ impl FastTransfer {
 #[derive(Debug, Clone)]
 pub struct FastTransferStatus {
     pub finalised: bool,
-    pub relayer_id: AccountId,
+    pub relayer: AccountId,
 }


### PR DESCRIPTION
The fast relayer could use external protocols to hold and swap liquidity so that the sender_id will be the protocol contract instead of the real relayer ID. 
In the PR, the relayer id should be passed in the `FastFinTransferMsg`.