### PR TITLE
Universal Token Address Resolution

### DIFF
--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -910,7 +910,7 @@ impl Contract {
             (foreign_addr, ChainKind::Near) => self
                 .token_address_to_id
                 .get(foreign_addr)
-                .map(|near_id| OmniAddress::Near(near_id)),
+                .map(OmniAddress::Near),
             // foreign chain -> foreign chain
             (foreign_addr, _) => {
                 // First get the NEAR token ID

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -892,23 +892,21 @@ impl Contract {
         }
     }
 
-    pub fn resolve_token_address(
+    pub fn get_bridged_token_address(
         &self,
-        source_address: &OmniAddress,
-        target_chain: ChainKind,
+        address: &OmniAddress,
+        chain: ChainKind,
     ) -> Option<OmniAddress> {
-        match source_address {
+        match address {
             // If source is NEAR, directly look up in token_id_to_address
-            OmniAddress::Near(near_id) => self
-                .token_id_to_address
-                .get(&(target_chain, near_id.clone())),
+            OmniAddress::Near(near_id) => self.token_id_to_address.get(&(chain, near_id.clone())),
             // If source is foreign chain, first get NEAR id from token_address_to_id
-            foreign_addr => {
+            foreign_address => {
                 // Get the NEAR token ID for this foreign address
-                let near_id = self.token_address_to_id.get(foreign_addr)?;
+                let near_id = self.token_address_to_id.get(foreign_address)?;
 
                 // Look up the target chain address
-                self.token_id_to_address.get(&(target_chain, near_id))
+                self.token_id_to_address.get(&(chain, near_id))
             }
         }
     }

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -892,7 +892,7 @@ impl Contract {
         }
     }
 
-    pub fn get_bridged_token_address(
+    pub fn get_bridged_token(
         &self,
         address: &OmniAddress,
         chain: ChainKind,

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -892,6 +892,27 @@ impl Contract {
         }
     }
 
+    pub fn resolve_token_address(
+        &self,
+        source_address: &OmniAddress,
+        target_chain: ChainKind,
+    ) -> Option<OmniAddress> {
+        match source_address {
+            // If source is NEAR, directly look up in token_id_to_address
+            OmniAddress::Near(near_id) => self
+                .token_id_to_address
+                .get(&(target_chain, near_id.clone())),
+            // If source is foreign chain, first get NEAR id from token_address_to_id
+            foreign_addr => {
+                // Get the NEAR token ID for this foreign address
+                let near_id = self.token_address_to_id.get(foreign_addr)?;
+
+                // Look up the target chain address
+                self.token_id_to_address.get(&(target_chain, near_id))
+            }
+        }
+    }
+
     pub fn get_native_token_id(&self, chain: ChainKind) -> AccountId {
         let native_token_address =
             OmniAddress::new_zero(chain).sdk_expect("ERR_FAILED_TO_GET_ZERO_ADDRESS");

--- a/near/omni-bridge/src/tests/lib_test.rs
+++ b/near/omni-bridge/src/tests/lib_test.rs
@@ -761,10 +761,6 @@ fn test_get_bridged_token_address() {
         &(ChainKind::Sol, near_token_id.clone()),
         &OmniAddress::Sol(solana_address.clone()),
     );
-    contract.token_id_to_address.insert(
-        &(ChainKind::Near, near_token_id.clone()),
-        &OmniAddress::Near(near_token_id.clone()),
-    );
 
     // Then insert reverse mappings (chain addresses -> NEAR token)
     contract.token_address_to_id.insert(
@@ -826,5 +822,12 @@ fn test_get_bridged_token_address() {
         same_chain_result,
         Some(OmniAddress::Eth(eth_address.clone())),
         "Failed to handle same chain resolution"
+    );
+
+    // Test Case 7:  NEAR -> NEAR (no storage needed)
+    assert_eq!(
+        contract.get_bridged_token_address(&near_source, ChainKind::Near),
+        Some(near_source.clone()),
+        "Failed to handle NEAR to NEAR resolution"
     );
 }

--- a/near/omni-bridge/src/tests/lib_test.rs
+++ b/near/omni-bridge/src/tests/lib_test.rs
@@ -742,7 +742,7 @@ fn test_denormalize_amount() {
 }
 
 #[test]
-fn test_get_bridged_token_address() {
+fn test_get_bridged_token() {
     let mut contract = get_default_contract();
 
     // Set up test data
@@ -774,7 +774,7 @@ fn test_get_bridged_token_address() {
 
     // Test Case 1: NEAR to Ethereum
     let near_source = OmniAddress::Near(near_token_id.clone());
-    let eth_result = contract.get_bridged_token_address(&near_source, ChainKind::Eth);
+    let eth_result = contract.get_bridged_token(&near_source, ChainKind::Eth);
     assert_eq!(
         eth_result,
         Some(OmniAddress::Eth(eth_address.clone())),
@@ -782,7 +782,7 @@ fn test_get_bridged_token_address() {
     );
 
     // Test Case 2: NEAR to Solana
-    let solana_result = contract.get_bridged_token_address(&near_source, ChainKind::Sol);
+    let solana_result = contract.get_bridged_token(&near_source, ChainKind::Sol);
     assert_eq!(
         solana_result,
         Some(OmniAddress::Sol(solana_address.clone())),
@@ -791,7 +791,7 @@ fn test_get_bridged_token_address() {
 
     // Test Case 3: Ethereum to NEAR
     let eth_source = OmniAddress::Eth(eth_address.clone());
-    let near_result = contract.get_bridged_token_address(&eth_source, ChainKind::Near);
+    let near_result = contract.get_bridged_token(&eth_source, ChainKind::Near);
     assert_eq!(
         near_result,
         Some(OmniAddress::Near(near_token_id.clone())),
@@ -799,7 +799,7 @@ fn test_get_bridged_token_address() {
     );
 
     // Test Case 4: Ethereum to Solana (cross-chain)
-    let solana_cross_result = contract.get_bridged_token_address(&eth_source, ChainKind::Sol);
+    let solana_cross_result = contract.get_bridged_token(&eth_source, ChainKind::Sol);
     assert_eq!(
         solana_cross_result,
         Some(OmniAddress::Sol(solana_address.clone())),
@@ -810,14 +810,14 @@ fn test_get_bridged_token_address() {
     let unmapped_eth = OmniAddress::Eth(
         EvmAddress::from_str("0x9999999999999999999999999999999999999999").unwrap(),
     );
-    let unmapped_result = contract.get_bridged_token_address(&unmapped_eth, ChainKind::Sol);
+    let unmapped_result = contract.get_bridged_token(&unmapped_eth, ChainKind::Sol);
     assert_eq!(
         unmapped_result, None,
         "Expected None for unmapped token address"
     );
 
     // Test Case 6: Same chain resolution attempt
-    let same_chain_result = contract.get_bridged_token_address(&eth_source, ChainKind::Eth);
+    let same_chain_result = contract.get_bridged_token(&eth_source, ChainKind::Eth);
     assert_eq!(
         same_chain_result,
         Some(OmniAddress::Eth(eth_address.clone())),
@@ -826,7 +826,7 @@ fn test_get_bridged_token_address() {
 
     // Test Case 7:  NEAR -> NEAR (no storage needed)
     assert_eq!(
-        contract.get_bridged_token_address(&near_source, ChainKind::Near),
+        contract.get_bridged_token(&near_source, ChainKind::Near),
         Some(near_source.clone()),
         "Failed to handle NEAR to NEAR resolution"
     );

--- a/near/omni-bridge/src/tests/lib_test.rs
+++ b/near/omni-bridge/src/tests/lib_test.rs
@@ -11,6 +11,7 @@ use near_sdk::{
 use omni_types::{
     locker_args::StorageDepositAction,
     prover_result::{InitTransferMessage, ProverResult},
+    sol_address::SolAddress,
     ChainKind, EvmAddress, Fee, InitTransferMsg, Nonce, OmniAddress, TransferId, TransferMessage,
     UpdateFee,
 };
@@ -737,5 +738,93 @@ fn test_denormalize_amount() {
             }
         ),
         u128::from(u64::MAX) * 1_000_000_000_000_000_u128
+    );
+}
+
+#[test]
+fn test_resolve_token_address() {
+    let mut contract = get_default_contract();
+
+    // Set up test data
+    let near_token_id: AccountId = DEFAULT_FT_CONTRACT_ACCOUNT.parse().unwrap();
+    let eth_address = EvmAddress::from_str(DEFAULT_ETH_USER_ADDRESS).unwrap();
+    let solana_address: SolAddress = "2xNweLHLqbS9YpP3UyaPrxKqgqoC6yPBFyuLxA8qtgr4"
+        .parse()
+        .expect("Invalid Solana address");
+
+    // First insert token addresses for each chain target (NEAR token -> chain addresses)
+    contract.token_id_to_address.insert(
+        &(ChainKind::Eth, near_token_id.clone()),
+        &OmniAddress::Eth(eth_address.clone()),
+    );
+    contract.token_id_to_address.insert(
+        &(ChainKind::Sol, near_token_id.clone()),
+        &OmniAddress::Sol(solana_address.clone()),
+    );
+    contract.token_id_to_address.insert(
+        &(ChainKind::Near, near_token_id.clone()),
+        &OmniAddress::Near(near_token_id.clone()),
+    );
+
+    // Then insert reverse mappings (chain addresses -> NEAR token)
+    contract.token_address_to_id.insert(
+        &OmniAddress::Eth(eth_address.clone()),
+        &near_token_id.clone(),
+    );
+    contract.token_address_to_id.insert(
+        &OmniAddress::Sol(solana_address.clone()),
+        &near_token_id.clone(),
+    );
+
+    // Test Case 1: NEAR to Ethereum
+    let near_source = OmniAddress::Near(near_token_id.clone());
+    let eth_result = contract.resolve_token_address(&near_source, ChainKind::Eth);
+    assert_eq!(
+        eth_result,
+        Some(OmniAddress::Eth(eth_address.clone())),
+        "Failed to resolve NEAR to ETH address"
+    );
+
+    // Test Case 2: NEAR to Solana
+    let solana_result = contract.resolve_token_address(&near_source, ChainKind::Sol);
+    assert_eq!(
+        solana_result,
+        Some(OmniAddress::Sol(solana_address.clone())),
+        "Failed to resolve NEAR to Solana address"
+    );
+
+    // Test Case 3: Ethereum to NEAR
+    let eth_source = OmniAddress::Eth(eth_address.clone());
+    let near_result = contract.resolve_token_address(&eth_source, ChainKind::Near);
+    assert_eq!(
+        near_result,
+        Some(OmniAddress::Near(near_token_id.clone())),
+        "Failed to resolve ETH to NEAR address"
+    );
+
+    // Test Case 4: Ethereum to Solana (cross-chain)
+    let solana_cross_result = contract.resolve_token_address(&eth_source, ChainKind::Sol);
+    assert_eq!(
+        solana_cross_result,
+        Some(OmniAddress::Sol(solana_address.clone())),
+        "Failed to resolve ETH to Solana address"
+    );
+
+    // Test Case 5: Unmapped token
+    let unmapped_eth = OmniAddress::Eth(
+        EvmAddress::from_str("0x9999999999999999999999999999999999999999").unwrap(),
+    );
+    let unmapped_result = contract.resolve_token_address(&unmapped_eth, ChainKind::Sol);
+    assert_eq!(
+        unmapped_result, None,
+        "Expected None for unmapped token address"
+    );
+
+    // Test Case 6: Same chain resolution attempt
+    let same_chain_result = contract.resolve_token_address(&eth_source, ChainKind::Eth);
+    assert_eq!(
+        same_chain_result,
+        Some(OmniAddress::Eth(eth_address.clone())),
+        "Failed to handle same chain resolution"
     );
 }

--- a/near/omni-bridge/src/tests/lib_test.rs
+++ b/near/omni-bridge/src/tests/lib_test.rs
@@ -742,7 +742,7 @@ fn test_denormalize_amount() {
 }
 
 #[test]
-fn test_resolve_token_address() {
+fn test_get_bridged_token_address() {
     let mut contract = get_default_contract();
 
     // Set up test data
@@ -778,7 +778,7 @@ fn test_resolve_token_address() {
 
     // Test Case 1: NEAR to Ethereum
     let near_source = OmniAddress::Near(near_token_id.clone());
-    let eth_result = contract.resolve_token_address(&near_source, ChainKind::Eth);
+    let eth_result = contract.get_bridged_token_address(&near_source, ChainKind::Eth);
     assert_eq!(
         eth_result,
         Some(OmniAddress::Eth(eth_address.clone())),
@@ -786,7 +786,7 @@ fn test_resolve_token_address() {
     );
 
     // Test Case 2: NEAR to Solana
-    let solana_result = contract.resolve_token_address(&near_source, ChainKind::Sol);
+    let solana_result = contract.get_bridged_token_address(&near_source, ChainKind::Sol);
     assert_eq!(
         solana_result,
         Some(OmniAddress::Sol(solana_address.clone())),
@@ -795,7 +795,7 @@ fn test_resolve_token_address() {
 
     // Test Case 3: Ethereum to NEAR
     let eth_source = OmniAddress::Eth(eth_address.clone());
-    let near_result = contract.resolve_token_address(&eth_source, ChainKind::Near);
+    let near_result = contract.get_bridged_token_address(&eth_source, ChainKind::Near);
     assert_eq!(
         near_result,
         Some(OmniAddress::Near(near_token_id.clone())),
@@ -803,7 +803,7 @@ fn test_resolve_token_address() {
     );
 
     // Test Case 4: Ethereum to Solana (cross-chain)
-    let solana_cross_result = contract.resolve_token_address(&eth_source, ChainKind::Sol);
+    let solana_cross_result = contract.get_bridged_token_address(&eth_source, ChainKind::Sol);
     assert_eq!(
         solana_cross_result,
         Some(OmniAddress::Sol(solana_address.clone())),
@@ -814,14 +814,14 @@ fn test_resolve_token_address() {
     let unmapped_eth = OmniAddress::Eth(
         EvmAddress::from_str("0x9999999999999999999999999999999999999999").unwrap(),
     );
-    let unmapped_result = contract.resolve_token_address(&unmapped_eth, ChainKind::Sol);
+    let unmapped_result = contract.get_bridged_token_address(&unmapped_eth, ChainKind::Sol);
     assert_eq!(
         unmapped_result, None,
         "Expected None for unmapped token address"
     );
 
     // Test Case 6: Same chain resolution attempt
-    let same_chain_result = contract.resolve_token_address(&eth_source, ChainKind::Eth);
+    let same_chain_result = contract.get_bridged_token_address(&eth_source, ChainKind::Eth);
     assert_eq!(
         same_chain_result,
         Some(OmniAddress::Eth(eth_address.clone())),


### PR DESCRIPTION
## Problem
The existing token resolution system is split into two functions:
- `get_token_address`: converts NEAR tokens to foreign chain addresses
- `get_token_id`: converts foreign chain addresses to NEAR tokens

This creates several issues:
1. No direct way to resolve foreign chain to foreign chain addresses (e.g., ETH->Solana)
2. Developers need to chain functions manually, increasing complexity and error risk
3. Unclear documentation leads to confusion when first encountering the system
4. Inconsistent error handling between the two functions

## Solution
This PR introduces a new universal resolution function that:
- Enables foreign chain to foreign chain resolution using NEAR as an intermediary
- Provides a single, clear interface for all token address resolution needs
- Maintains backwards compatibility with existing functions

## Key Changes
- Added `resolve_token_address` function that:
  - Handles all chain combinations through NEAR as intermediary
  - Provides consistent error handling via `Option<OmniAddress>` return type
  - Uses existing storage structures efficiently
- Added comprehensive test coverage
- Improved documentation explaining the intermediary system

## Technical Details
The resolution works by:
1. For NEAR source: directly looks up target chain address
2. For foreign chain source: 
   - First resolves to NEAR token ID
   - Then resolves from NEAR to target chain
3. Uses existing LookupMap infrastructure for O(1) lookups

## Testing
Test suite covers all resolution paths:
- NEAR → foreign chain
- Foreign chain → NEAR
- Foreign chain → foreign chain (via NEAR)
- Edge cases (unmapped tokens, same chain requests)
- Proper handling of chain-specific address formats (ETH, Solana)

## Migration
No migration needed as this is an additive change. Existing code paths remain unchanged.

## Security Considerations
- No changes to existing security model
- Maintains same validation checks as current implementation
- No new attack vectors introduced
- Uses same trusted storage and access patterns

## Performance Impact
- Minimal impact despite adding foreign-to-foreign resolution
- Maintains O(1) lookup complexity using existing storage structures
- Two lookups maximum for foreign-to-foreign resolution