### PR TITLE
Add the ability to receive ETH in Omni Bridge.

### DIFF
--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -107,6 +107,18 @@ task("deploy-bridge-token-factory", "Deploys the OmniBridge contract")
     )
   })
 
+task("deploy-token-factory-impl", "Deploys the BridgeToken Factory implementation").setAction(async (_, hre) => {
+  const { ethers } = hre
+  const OmniBridgeContractFactory = await ethers.getContractFactory("OmniBridge")
+  const OmniBridgeContract = await OmniBridgeContractFactory.deploy()
+  await OmniBridgeContract.waitForDeployment()
+  console.log(
+    JSON.stringify({
+      tokenImplAddress: await OmniBridgeContract.getAddress(),
+    }),
+  )
+})
+
 task("deploy-token-impl", "Deploys the BridgeToken implementation").setAction(async (_, hre) => {
   const { ethers } = hre
   const BridgeTokenContractFactory = await ethers.getContractFactory("BridgeToken")

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -107,17 +107,19 @@ task("deploy-bridge-token-factory", "Deploys the OmniBridge contract")
     )
   })
 
-task("deploy-token-factory-impl", "Deploys the BridgeToken Factory implementation").setAction(async (_, hre) => {
-  const { ethers } = hre
-  const OmniBridgeContractFactory = await ethers.getContractFactory("OmniBridge")
-  const OmniBridgeContract = await OmniBridgeContractFactory.deploy()
-  await OmniBridgeContract.waitForDeployment()
-  console.log(
-    JSON.stringify({
-      tokenImplAddress: await OmniBridgeContract.getAddress(),
-    }),
-  )
-})
+task("deploy-token-factory-impl", "Deploys the BridgeToken Factory implementation").setAction(
+  async (_, hre) => {
+    const { ethers } = hre
+    const OmniBridgeContractFactory = await ethers.getContractFactory("OmniBridge")
+    const OmniBridgeContract = await OmniBridgeContractFactory.deploy()
+    await OmniBridgeContract.waitForDeployment()
+    console.log(
+      JSON.stringify({
+        tokenImplAddress: await OmniBridgeContract.getAddress(),
+      }),
+    )
+  },
+)
 
 task("deploy-token-impl", "Deploys the BridgeToken implementation").setAction(async (_, hre) => {
   const { ethers } = hre

--- a/evm/src/omni-bridge/contracts/OmniBridge.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridge.sol
@@ -70,7 +70,7 @@ contract OmniBridge is
         string memory name = IERC20Metadata(tokenAddress).name();
         string memory symbol = IERC20Metadata(tokenAddress).symbol();
         uint8 decimals = IERC20Metadata(tokenAddress).decimals();
-    
+
         deployTokenExtension(nearTokenId, tokenAddress, decimals, originDecimals);
 
         emit BridgeTypes.DeployToken(
@@ -314,6 +314,8 @@ contract OmniBridge is
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         nearBridgeDerivedAddress = nearBridgeDerivedAddress_;
     }
+
+    receive() external payable {}
 
     function _normalizeDecimals(
         uint8 decimals


### PR DESCRIPTION
The ability to receive Ether is necessary to facilitate the migration from Rainbow Bridge. Ether must be locked in this contract to enable unlock operations, so we need to transfer Ether to this contract from the EthCustodian.