### PR TITLE
fix: timestamps for evm events

### DIFF
--- a/omni-relayer/Cargo.lock
+++ b/omni-relayer/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1317fde6d2d3cd6082a15144c23230697a5e1a91a27d1facc146715d3b4b2046"
+checksum = "996564c1782285d4e0299c29b318bc74f24b1d7f456cef3e040810b061ee3256"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -1178,9 +1178,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.16"
+version = "1.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50236e4d60fe8458de90a71c0922c761e41755adf091b1b03de1cef537179915"
+checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1198,7 +1198,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "ring 0.17.10",
+ "ring 0.17.11",
  "time",
  "tokio",
  "tracing",
@@ -1246,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.76.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e83401ad7287ad15244d557e35502c2a94105ca5b41d656c391f1a4fc04ca2"
+checksum = "34e87342432a3de0e94e82c99a7cbd9042f99de029ae1f4e368160f9e9929264"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.59.0"
+version = "1.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a35fc7e74f5be45839eb753568535c074a592185dd0a2d406685018d581c43"
+checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fa655b4f313124ce272cbc38c5fef13793c832279cec750103e5e6b71a54b8"
+checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1cfe5e16b90421ea031f4c6348b534ef442e76f6bf4a1b2b592c12cc2c6af9"
+checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1366,7 +1366,7 @@ dependencies = [
  "once_cell",
  "p256",
  "percent-encoding",
- "ring 0.17.10",
+ "ring 0.17.11",
  "sha2 0.10.8",
  "subtle",
  "time",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
+checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1821,7 +1821,7 @@ dependencies = [
 [[package]]
 name = "bridge-connector-common"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "eth-proof",
  "ethers",
@@ -2108,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2118,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2480,6 +2480,34 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "crypto-shared"
+version = "0.1.0"
+source = "git+https://github.com/near-one/mpc?rev=463172481597ee09b12020b72c61d6b01da7b167#463172481597ee09b12020b72c61d6b01da7b167"
+dependencies = [
+ "anyhow",
+ "borsh 1.5.5",
+ "getrandom 0.2.15",
+ "k256",
+ "near-account-id",
+ "near-sdk",
+ "serde",
+ "serde_json",
+ "sha3",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-utils"
+version = "0.2.0"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
+dependencies = [
+ "crypto-shared",
+ "ethers",
+ "near-crypto",
+ "near-primitives",
 ]
 
 [[package]]
@@ -2887,6 +2915,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -2950,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elliptic-curve"
@@ -2989,6 +3018,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -3142,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "eth-proof"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "cita_trie",
@@ -3511,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "evm-bridge-client"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "bridge-connector-common",
@@ -3644,9 +3674,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -4756,6 +4786,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
+ "serdect",
  "sha2 0.10.8",
  "signature 2.2.0",
 ]
@@ -4817,9 +4848,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libm"
@@ -5068,7 +5099,7 @@ dependencies = [
 [[package]]
 name = "near-bridge-client"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "bridge-connector-common",
@@ -5251,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "near-light-client-on-eth"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "ethereum-types 0.14.1",
  "ethers",
@@ -5344,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-client"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "lazy_static",
@@ -5699,11 +5730,12 @@ dependencies = [
 
 [[package]]
 name = "omni-connector"
-version = "0.2.5"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+version = "0.2.6"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "bridge-connector-common",
+ "crypto-utils",
  "derive_builder",
  "eth-proof",
  "ethers",
@@ -5727,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "omni-relayer"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6187,9 +6219,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "powerfmt"
@@ -6394,7 +6426,7 @@ dependencies = [
  "bytes",
  "getrandom 0.2.15",
  "rand 0.8.5",
- "ring 0.17.10",
+ "ring 0.17.11",
  "rustc-hash",
  "rustls 0.23.23",
  "rustls-pki-types",
@@ -6764,9 +6796,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.10"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
+checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",
@@ -6914,7 +6946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.10",
+ "ring 0.17.11",
  "rustls-webpki 0.101.7",
  "sct",
 ]
@@ -6926,7 +6958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "once_cell",
- "ring 0.17.10",
+ "ring 0.17.11",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
@@ -7018,7 +7050,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.10",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -7028,7 +7060,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring 0.17.10",
+ "ring 0.17.11",
  "rustls-pki-types",
  "untrusted 0.9.0",
 ]
@@ -7110,9 +7142,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -7122,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7167,7 +7199,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.10",
+ "ring 0.17.11",
  "untrusted 0.9.0",
 ]
 
@@ -7195,6 +7227,7 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -7415,6 +7448,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
+ "serde",
 ]
 
 [[package]]
@@ -7749,8 +7792,8 @@ dependencies = [
 
 [[package]]
 name = "solana-bridge-client"
-version = "0.2.1"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+version = "0.2.2"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "borsh 1.5.5",
  "derive_builder",
@@ -11516,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "wormhole-bridge-client"
 version = "0.2.0"
-source = "git+https://github.com/Near-One/bridge-sdk-rs#e2c09080a7bff92e04229592b77815f2798cd01e"
+source = "git+https://github.com/Near-One/bridge-sdk-rs#d96493c9691baf509a14224ec2ba4ef7949f54e4"
 dependencies = [
  "bridge-connector-common",
  "derive_builder",

--- a/omni-relayer/Cargo.toml
+++ b/omni-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-relayer"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 resolver = "2"
 repository = "https://github.com/Near-One/omni-bridge"

--- a/omni-relayer/src/main.rs
+++ b/omni-relayer/src/main.rs
@@ -75,7 +75,6 @@ async fn main() -> Result<()> {
             .await
         }
     }));
-
     if config.eth.is_some() {
         handles.push(tokio::spawn({
             let config = config.clone();

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -219,6 +219,18 @@ async fn process_log(
         return;
     };
 
+    let timestamp = if let Ok(Some(block)) = http_provider
+        .get_block(
+            alloy::eips::BlockId::Number(alloy::eips::BlockNumberOrTag::Number(block_number)),
+            alloy::rpc::types::BlockTransactionsKind::Full,
+        )
+        .await
+    {
+        block.header.timestamp as i64
+    } else {
+        chrono::Utc::now().timestamp()
+    };
+
     if log.log_decode::<utils::evm::InitTransfer>().is_ok() {
         info!("Received InitTransfer on {:?} ({:?})", chain_kind, tx_hash);
         utils::redis::add_event(
@@ -230,7 +242,7 @@ async fn process_log(
                 block_number,
                 log,
                 tx_logs: tx_logs.map(Box::new),
-                creation_timestamp: chrono::Utc::now().timestamp(),
+                creation_timestamp: timestamp,
                 last_update_timestamp: None,
                 expected_finalization_time,
             },
@@ -248,7 +260,7 @@ async fn process_log(
                 block_number,
                 log,
                 tx_logs: tx_logs.map(Box::new),
-                creation_timestamp: chrono::Utc::now().timestamp(),
+                creation_timestamp: timestamp,
                 expected_finalization_time,
             },
         )
@@ -265,7 +277,7 @@ async fn process_log(
                 block_number,
                 log,
                 tx_logs: tx_logs.map(Box::new),
-                creation_timestamp: chrono::Utc::now().timestamp(),
+                creation_timestamp: timestamp,
                 expected_finalization_time,
             },
         )

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -219,18 +219,16 @@ async fn process_log(
         return;
     };
 
-    let mut timestamp = chrono::Utc::now().timestamp();
-    if let Ok(Some(block)) = http_provider
+    let timestamp = http_provider
         .get_block(
             alloy::eips::BlockId::Number(alloy::eips::BlockNumberOrTag::Number(block_number)),
             alloy::rpc::types::BlockTransactionsKind::Full,
         )
         .await
-    {
-        if let Ok(block_timestamp) = i64::try_from(block.header.timestamp) {
-            timestamp = block_timestamp;
-        }
-    };
+        .ok()
+        .flatten()
+        .and_then(|block| i64::try_from(block.header.timestamp).ok())
+        .unwrap_or_else(|| chrono::Utc::now().timestamp());
 
     if log.log_decode::<utils::evm::InitTransfer>().is_ok() {
         info!("Received InitTransfer on {:?} ({:?})", chain_kind, tx_hash);

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -219,16 +219,17 @@ async fn process_log(
         return;
     };
 
-    let timestamp = if let Ok(Some(block)) = http_provider
+    let mut timestamp = chrono::Utc::now().timestamp();
+    if let Ok(Some(block)) = http_provider
         .get_block(
             alloy::eips::BlockId::Number(alloy::eips::BlockNumberOrTag::Number(block_number)),
             alloy::rpc::types::BlockTransactionsKind::Full,
         )
         .await
     {
-        block.header.timestamp as i64
-    } else {
-        chrono::Utc::now().timestamp()
+        if let Ok(block_timestamp) = i64::try_from(block.header.timestamp) {
+            timestamp = block_timestamp;
+        }
     };
 
     if log.log_decode::<utils::evm::InitTransfer>().is_ok() {

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -222,7 +222,7 @@ async fn process_log(
     let timestamp = http_provider
         .get_block(
             alloy::eips::BlockId::Number(alloy::eips::BlockNumberOrTag::Number(block_number)),
-            alloy::rpc::types::BlockTransactionsKind::Full,
+            alloy::rpc::types::BlockTransactionsKind::Hashes,
         )
         .await
         .ok()


### PR DESCRIPTION
For some reason log doesn't provide information about timestamp (my guess that this is an issue with infura rpc), so we have to fetch block to get timestamp

<img width="638" alt="image" src="https://github.com/user-attachments/assets/f571648e-cf21-4a84-9476-91e3354b0ff3" />
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/02cd9429-8a30-481f-bf61-c1179fede33a" />
