### PR TITLE
fix: fast transfers audit fixes

### DIFF
--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -110,6 +110,7 @@ impl Contract {
         storage
     }
 
+    #[payable]
     pub fn storage_unregister(&mut self, force: Option<bool>) -> bool {
         assert_one_yocto();
         let account_id = env::predecessor_account_id();

--- a/near/omni-bridge/src/storage.rs
+++ b/near/omni-bridge/src/storage.rs
@@ -107,6 +107,9 @@ impl Contract {
             .sdk_expect("The amount is greater than the available storage balance");
 
         self.accounts_balances.insert(&account_id, &storage);
+
+        Promise::new(account_id).transfer(to_withdraw);
+
         storage
     }
 

--- a/near/omni-tests/src/fast_transfer.rs
+++ b/near/omni-tests/src/fast_transfer.rs
@@ -581,7 +581,7 @@ mod tests {
             let transfer_msg = get_transfer_msg_to_near(&env, transfer_amount);
             let mut fast_transfer_msg = get_fast_transfer_msg(&env, transfer_msg);
             fast_transfer_msg.storage_deposit_amount =
-                Some(NEP141_DEPOSIT.saturating_mul(100).as_yoctonear());
+                Some(U128(NEP141_DEPOSIT.saturating_mul(100).as_yoctonear()));
 
             let relayer_balance_before =
                 get_balance(&env.token_contract, env.relayer_account.id()).await?;
@@ -1070,7 +1070,7 @@ mod tests {
             fee: transfer_msg.fee,
             msg: transfer_msg.msg,
             storage_deposit_amount: match transfer_msg.recipient.get_chain() {
-                ChainKind::Near => Some(NEP141_DEPOSIT.as_yoctonear()),
+                ChainKind::Near => Some(U128(NEP141_DEPOSIT.as_yoctonear())),
                 _ => None,
             },
             relayer: env.relayer_account.id().clone(),

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -405,7 +405,7 @@ pub struct FastFinTransferMsg {
     pub recipient: OmniAddress,
     pub fee: Fee,
     pub msg: String,
-    pub storage_deposit_amount: Option<u128>,
+    pub storage_deposit_amount: Option<U128>,
     pub relayer: AccountId,
 }
 


### PR DESCRIPTION
https://github.com/AuditOneAuditReviews/Omnibridge3-audit-review/issues/31 - add payable attribute to `storage_unregister`
https://github.com/AuditOneAuditReviews/Omnibridge3-audit-review/issues/13 - convert storage_deposit_amount from u128 to U128
https://github.com/AuditOneAuditReviews/Omnibridge3-audit-review/issues/8 - add additional checks when completing fast transfer (not a vulnerability but as a good practice)
https://github.com/AuditOneAuditReviews/Omnibridge3-audit-review/issues/1 - get rid of `unwrap`'s
https://github.com/AuditOneAuditReviews/Omnibridge3-audit-review/issues/32 - transfer tokens in `storage_withdraw`