### PR TITLE
feat: update decimals over `set_token_metadata`

### DIFF
--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -1018,10 +1018,17 @@ impl Contract {
         icon: Option<String>,
         reference: Option<String>,
         reference_hash: Option<Base64VecU8>,
+        decimals: Option<u8>,
     ) -> Promise {
+        // Only DAO can set decimals
+        require!(
+            decimals.is_none()
+                || self.acl_has_role(Role::DAO.into(), env::predecessor_account_id())
+        );
+
         ext_token::ext(token)
             .with_static_gas(SET_METADATA_GAS)
-            .set_metadata(name, symbol, reference, reference_hash, None, icon)
+            .set_metadata(name, symbol, reference, reference_hash, decimals, icon)
     }
 
     pub fn get_current_destination_nonce(&self, chain_kind: ChainKind) -> Nonce {

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -1027,7 +1027,6 @@ impl Contract {
             .get(&address)
             .sdk_expect("ERR_TOKEN_DECIMALS_NOT_FOUND")
             .decimals;
-        require!(decimals > 0, "ERR_INVALID_DECIMALS");
 
         ext_token::ext(token)
             .with_static_gas(SET_METADATA_GAS)

--- a/near/omni-tests/src/omni_token.rs
+++ b/near/omni-tests/src/omni_token.rs
@@ -313,10 +313,9 @@ mod tests {
         env.locker_contract
             .call("set_token_metadata")
             .args_json(json!({
-                "token": env.token_contract.id(),
+                "address": env.init_token_address,
                 "name": "New Token Name",
-                "symbol": "NEW",
-                "decimals": 8,
+                "symbol": "NEW"
             }))
             .max_gas()
             .transact()
@@ -328,7 +327,7 @@ mod tests {
 
         assert_eq!(updated_metadata.name, "New Token Name");
         assert_eq!(updated_metadata.symbol, "NEW");
-        assert_eq!(updated_metadata.decimals, 8);
+        assert_eq!(updated_metadata.decimals, fetched_metadata.decimals);
 
         Ok(())
     }


### PR DESCRIPTION
Some of the migrated Rainbow tokens don't have the metadata, for example, this one https://github.com/aurora-is-near/bridge-assets/pull/326.
This PR allows setting decimal by DAO over the `set_token_metadata`