### PR TITLE
chore: derived `Hash` trait for `OmniAddress`

### DIFF
--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "omni-types"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/near/mock/mock-token/src/lib.rs
+++ b/near/mock/mock-token/src/lib.rs
@@ -35,7 +35,6 @@ enum StorageKey {
 impl Contract {
     /// Initializes the contract with the given total supply owned by the given `owner_id` with
     /// default metadata (for example purposes only).
-    #[allow(clippy::use_self)]
     #[init]
     pub fn new_default_meta(owner_id: &AccountId, total_supply: U128) -> Self {
         Self::new(
@@ -55,7 +54,6 @@ impl Contract {
 
     /// Initializes the contract with the given total supply owned by the given `owner_id` with
     /// the given fungible token metadata.
-    #[allow(clippy::use_self)]
     #[init]
     pub fn new(owner_id: &AccountId, total_supply: U128, metadata: &FungibleTokenMetadata) -> Self {
         require!(!env::state_exists(), "Already initialized");

--- a/near/mock/mock-token/src/lib.rs
+++ b/near/mock/mock-token/src/lib.rs
@@ -35,6 +35,7 @@ enum StorageKey {
 impl Contract {
     /// Initializes the contract with the given total supply owned by the given `owner_id` with
     /// default metadata (for example purposes only).
+    #[allow(clippy::use_self)]
     #[init]
     pub fn new_default_meta(owner_id: &AccountId, total_supply: U128) -> Self {
         Self::new(
@@ -54,6 +55,7 @@ impl Contract {
 
     /// Initializes the contract with the given total supply owned by the given `owner_id` with
     /// the given fungible token metadata.
+    #[allow(clippy::use_self)]
     #[init]
     pub fn new(owner_id: &AccountId, total_supply: U128, metadata: &FungibleTokenMetadata) -> Self {
         require!(!env::state_exists(), "Already initialized");

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/lib.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/lib.rs
@@ -28,7 +28,7 @@ impl WormholeOmniProverProxy {
     #[init]
     #[private]
     #[must_use]
-    pub fn init(prover_account: AccountId) -> Self {
+    pub const fn init(prover_account: AccountId) -> Self {
         Self { prover_account }
     }
 

--- a/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
+++ b/near/omni-prover/wormhole-omni-prover-proxy/src/parsed_vaa.rs
@@ -97,7 +97,7 @@ impl ParsedVAA {
         let consistency_level = data.get_u8(body_offset + Self::VAA_CONSISTENCY_LEVEL_POS);
         let payload = data[body_offset + Self::VAA_PAYLOAD_POS..].to_vec();
 
-        ParsedVAA {
+        Self {
             version,
             guardian_set_index,
             timestamp,

--- a/near/omni-types/Cargo.toml
+++ b/near/omni-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-types"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Near One <info@nearone.org>"]
 edition = "2021"
 

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -78,7 +78,7 @@ impl TryFromLog<Log<FinTransfer>> for FinTransferMessage {
             return Err(ERR_INVALIDE_SIGNATURE_HASH.to_string());
         }
 
-        Ok(FinTransferMessage {
+        Ok(Self {
             transfer_id: crate::TransferId {
                 origin_chain: event.data.originChain.try_into()?,
                 origin_nonce: event.data.originNonce,
@@ -101,7 +101,7 @@ impl TryFromLog<Log<InitTransfer>> for InitTransferMessage {
             return Err(ERR_INVALIDE_SIGNATURE_HASH.to_string());
         }
 
-        Ok(InitTransferMessage {
+        Ok(Self {
             emitter_address: OmniAddress::new_from_evm_address(
                 chain_kind,
                 H160(event.address.into()),
@@ -128,7 +128,7 @@ impl TryFromLog<Log<DeployToken>> for DeployTokenMessage {
             return Err(ERR_INVALIDE_SIGNATURE_HASH.to_string());
         }
 
-        Ok(DeployTokenMessage {
+        Ok(Self {
             token: event.data.token.parse().map_err(stringify)?,
             token_address: OmniAddress::new_from_evm_address(
                 chain_kind,
@@ -152,7 +152,7 @@ impl TryFromLog<Log<LogMetadata>> for LogMetadataMessage {
             return Err(ERR_INVALIDE_SIGNATURE_HASH.to_string());
         }
 
-        Ok(LogMetadataMessage {
+        Ok(Self {
             token_address: OmniAddress::new_from_evm_address(
                 chain_kind,
                 H160(event.data.tokenAddress.into()),

--- a/near/omni-types/src/evm/header.rs
+++ b/near/omni-types/src/evm/header.rs
@@ -38,7 +38,7 @@ struct CustomRlpIter<'a> {
 }
 
 impl<'a> CustomRlpIter<'a> {
-    fn new(rlp: &'a Rlp) -> Self {
+    const fn new(rlp: &'a Rlp) -> Self {
         Self {
             index: 0,
             consumed_bytes: 0,
@@ -72,7 +72,7 @@ impl<'a> CustomRlpIter<'a> {
 impl Decodable for BlockHeader {
     fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
         let mut iter = CustomRlpIter::new(rlp);
-        let mut block_header = BlockHeader {
+        let mut block_header = Self {
             parent_hash: iter.next()?,
             sha3_uncles: iter.next()?,
             miner: iter.next()?,

--- a/near/omni-types/src/evm/receipt.rs
+++ b/near/omni-types/src/evm/receipt.rs
@@ -23,7 +23,7 @@ impl Decodable for Receipt {
         }
 
         let rlp = Rlp::new(view);
-        Ok(Receipt {
+        Ok(Self {
             status: rlp.val_at(0)?,
             gas_used: rlp.val_at(1)?,
             log_bloom: rlp.val_at(2)?,
@@ -41,7 +41,7 @@ pub struct LogEntry {
 
 impl Decodable for LogEntry {
     fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
-        let result = LogEntry {
+        let result = Self {
             address: rlp.val_at(0)?,
             topics: rlp.list_at(1)?,
             data: rlp.val_at(2)?,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -30,13 +30,9 @@ impl FromStr for H160 {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = if let Some(stripped) = s.strip_prefix("0x") {
-            stripped
-        } else {
-            s
-        };
-        let result = Vec::from_hex(s).map_err(|_| "ERR_INVALIDE_HEX")?;
-        Ok(H160(
+        let result = Vec::from_hex(s.strip_prefix("0x").map_or(s, |stripped| stripped))
+            .map_err(|_| "ERR_INVALIDE_HEX")?;
+        Ok(Self(
             result
                 .try_into()
                 .map_err(|err| format!("Invalid length: {err:?}"))?,
@@ -160,7 +156,7 @@ pub enum ChainKind {
 impl FromStr for ChainKind {
     type Err = String;
 
-    fn from_str(s: &str) -> Result<ChainKind, Self::Err> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         near_sdk::serde_json::from_str(&format!("\"{s}\"")).map_err(stringify)
     }
 }
@@ -175,11 +171,11 @@ impl TryFrom<u8> for ChainKind {
     type Error = String;
     fn try_from(input: u8) -> Result<Self, String> {
         match input {
-            0 => Ok(ChainKind::Eth),
-            1 => Ok(ChainKind::Near),
-            2 => Ok(ChainKind::Sol),
-            3 => Ok(ChainKind::Arb),
-            4 => Ok(ChainKind::Base),
+            0 => Ok(Self::Eth),
+            1 => Ok(Self::Near),
+            2 => Ok(Self::Sol),
+            3 => Ok(Self::Arb),
+            4 => Ok(Self::Base),
             _ => Err(format!("{input:?} invalid chain kind")),
         }
     }
@@ -204,13 +200,11 @@ impl OmniAddress {
     #[allow(clippy::missing_panics_doc)]
     pub fn new_zero(chain_kind: ChainKind) -> Result<Self, String> {
         match chain_kind {
-            ChainKind::Eth => Ok(OmniAddress::Eth(H160::ZERO)),
-            ChainKind::Near => Ok(OmniAddress::Near(
-                ZERO_ACCOUNT_ID.parse().map_err(stringify)?,
-            )),
-            ChainKind::Sol => Ok(OmniAddress::Sol(SolAddress::ZERO)),
-            ChainKind::Arb => Ok(OmniAddress::Arb(H160::ZERO)),
-            ChainKind::Base => Ok(OmniAddress::Base(H160::ZERO)),
+            ChainKind::Eth => Ok(Self::Eth(H160::ZERO)),
+            ChainKind::Near => Ok(Self::Near(ZERO_ACCOUNT_ID.parse().map_err(stringify)?)),
+            ChainKind::Sol => Ok(Self::Sol(SolAddress::ZERO)),
+            ChainKind::Arb => Ok(Self::Arb(H160::ZERO)),
+            ChainKind::Base => Ok(Self::Base(H160::ZERO)),
         }
     }
 
@@ -236,23 +230,23 @@ impl OmniAddress {
         }
     }
 
-    pub fn get_chain(&self) -> ChainKind {
+    pub const fn get_chain(&self) -> ChainKind {
         match self {
-            OmniAddress::Eth(_) => ChainKind::Eth,
-            OmniAddress::Near(_) => ChainKind::Near,
-            OmniAddress::Sol(_) => ChainKind::Sol,
-            OmniAddress::Arb(_) => ChainKind::Arb,
-            OmniAddress::Base(_) => ChainKind::Base,
+            Self::Eth(_) => ChainKind::Eth,
+            Self::Near(_) => ChainKind::Near,
+            Self::Sol(_) => ChainKind::Sol,
+            Self::Arb(_) => ChainKind::Arb,
+            Self::Base(_) => ChainKind::Base,
         }
     }
 
     pub fn encode(&self, separator: char, skip_zero_address: bool) -> String {
         let (chain_str, address) = match self {
-            OmniAddress::Eth(address) => ("eth", address.to_string()),
-            OmniAddress::Near(address) => ("near", address.to_string()),
-            OmniAddress::Sol(address) => ("sol", address.to_string()),
-            OmniAddress::Arb(address) => ("arb", address.to_string()),
-            OmniAddress::Base(address) => ("base", address.to_string()),
+            Self::Eth(address) => ("eth", address.to_string()),
+            Self::Near(address) => ("near", address.to_string()),
+            Self::Sol(address) => ("sol", address.to_string()),
+            Self::Arb(address) => ("arb", address.to_string()),
+            Self::Base(address) => ("base", address.to_string()),
         };
 
         if skip_zero_address && self.is_zero() {
@@ -264,17 +258,15 @@ impl OmniAddress {
 
     pub fn is_zero(&self) -> bool {
         match self {
-            OmniAddress::Eth(address) | OmniAddress::Arb(address) | OmniAddress::Base(address) => {
-                address.is_zero()
-            }
-            OmniAddress::Near(address) => *address == ZERO_ACCOUNT_ID,
-            OmniAddress::Sol(address) => address.is_zero(),
+            Self::Eth(address) | Self::Arb(address) | Self::Base(address) => address.is_zero(),
+            Self::Near(address) => *address == ZERO_ACCOUNT_ID,
+            Self::Sol(address) => address.is_zero(),
         }
     }
 
     pub fn get_token_prefix(&self) -> String {
         match self {
-            OmniAddress::Sol(address) => {
+            Self::Sol(address) => {
                 if self.is_zero() {
                     "sol".to_string()
                 } else {
@@ -289,7 +281,7 @@ impl OmniAddress {
                     format!("sol-{hashed_address}")
                 }
             }
-            OmniAddress::Eth(address) => {
+            Self::Eth(address) => {
                 if self.is_zero() {
                     "eth".to_string()
                 } else {
@@ -307,17 +299,17 @@ impl OmniAddress {
             address
         };
 
-        match address.try_into() {
-            Ok(bytes) => Ok(H160(bytes)),
-            Err(_) => Err("Invalid EVM address".to_string()),
-        }
+        address.try_into().map_or_else(
+            |_| Err("Invalid EVM address".to_string()),
+            |bytes| Ok(H160(bytes)),
+        )
     }
 
     fn to_sol_address(address: &[u8]) -> Result<SolAddress, String> {
-        match address.try_into() {
-            Ok(bytes) => Ok(SolAddress(bytes)),
-            Err(_) => Err("Invalid SOL address".to_string()),
-        }
+        address.try_into().map_or_else(
+            |_| Err("Invalid SOL address".to_string()),
+            |bytes| Ok(SolAddress(bytes)),
+        )
     }
 
     fn to_near_account_id(address: &[u8]) -> Result<AccountId, String> {
@@ -329,15 +321,15 @@ impl OmniAddress {
 impl FromStr for OmniAddress {
     type Err = String;
 
-    fn from_str(input: &str) -> Result<OmniAddress, Self::Err> {
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
         let (chain, recipient) = input.split_once(':').unwrap_or(("eth", input));
 
         match chain {
-            "eth" => Ok(OmniAddress::Eth(recipient.parse().map_err(stringify)?)),
-            "near" => Ok(OmniAddress::Near(recipient.parse().map_err(stringify)?)),
-            "sol" => Ok(OmniAddress::Sol(recipient.parse().map_err(stringify)?)),
-            "arb" => Ok(OmniAddress::Arb(recipient.parse().map_err(stringify)?)),
-            "base" => Ok(OmniAddress::Base(recipient.parse().map_err(stringify)?)),
+            "eth" => Ok(Self::Eth(recipient.parse().map_err(stringify)?)),
+            "near" => Ok(Self::Near(recipient.parse().map_err(stringify)?)),
+            "sol" => Ok(Self::Sol(recipient.parse().map_err(stringify)?)),
+            "arb" => Ok(Self::Arb(recipient.parse().map_err(stringify)?)),
+            "base" => Ok(Self::Base(recipient.parse().map_err(stringify)?)),
             _ => Err(format!("Chain {chain} is not supported")),
         }
     }
@@ -422,14 +414,14 @@ pub struct InitTransferMsg {
 }
 
 #[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Fee {
     pub fee: U128,
     pub native_fee: U128,
 }
 
 impl Fee {
-    pub fn is_zero(&self) -> bool {
+    pub const fn is_zero(&self) -> bool {
         self.fee.0 == 0 && self.native_fee.0 == 0
     }
 }
@@ -471,18 +463,18 @@ pub struct TransferMessage {
 }
 
 impl TransferMessage {
-    pub fn get_origin_chain(&self) -> ChainKind {
+    pub const fn get_origin_chain(&self) -> ChainKind {
         self.sender.get_chain()
     }
 
-    pub fn get_transfer_id(&self) -> TransferId {
+    pub const fn get_transfer_id(&self) -> TransferId {
         TransferId {
             origin_chain: self.get_origin_chain(),
             origin_nonce: self.origin_nonce,
         }
     }
 
-    pub fn get_destination_chain(&self) -> ChainKind {
+    pub const fn get_destination_chain(&self) -> ChainKind {
         self.recipient.get_chain()
     }
 }
@@ -570,7 +562,7 @@ impl FastTransfer {
 
 impl FastTransfer {
     pub fn from_transfer(transfer: TransferMessage, token_id: AccountId) -> Self {
-        FastTransfer {
+        Self {
             transfer_id: transfer.get_transfer_id(),
             token_id,
             amount: transfer.amount,

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -23,7 +23,7 @@ pub mod utils;
 mod tests;
 
 #[near(serializers = [borsh])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct H160(pub [u8; 20]);
 
 impl FromStr for H160 {
@@ -191,7 +191,7 @@ pub const ZERO_ACCOUNT_ID: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
 
 #[near(serializers=[borsh])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum OmniAddress {
     Eth(EvmAddress),
     Near(AccountId),

--- a/near/omni-types/src/sol_address.rs
+++ b/near/omni-types/src/sol_address.rs
@@ -23,7 +23,7 @@ impl FromStr for SolAddress {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let result = bs58::decode(s).into_vec().map_err(|err| err.to_string())?;
 
-        Ok(SolAddress(
+        Ok(Self(
             result
                 .try_into()
                 .map_err(|err| format!("Invalid length: {err:?}"))?,

--- a/near/omni-types/src/sol_address.rs
+++ b/near/omni-types/src/sol_address.rs
@@ -6,7 +6,7 @@ use near_sdk::{bs58, near};
 use serde::de::Visitor;
 
 #[near(serializers=[borsh])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct SolAddress(pub [u8; 32]);
 
 impl SolAddress {

--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -360,7 +360,7 @@ fn test_transfer_message_getters() {
                 origin_nonce: 456,
                 token: OmniAddress::Near("token.near".parse().unwrap()),
                 amount: U128(2000),
-                recipient: OmniAddress::Eth(evm_addr.clone()),
+                recipient: OmniAddress::Eth(evm_addr),
                 fee: Fee::default(),
                 sender: OmniAddress::Near("alice.near".parse().unwrap()),
                 msg: String::new(),

--- a/omni-relayer/src/config.rs
+++ b/omni-relayer/src/config.rs
@@ -90,11 +90,11 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn is_bridge_indexer_enabled(&self) -> bool {
+    pub const fn is_bridge_indexer_enabled(&self) -> bool {
         self.bridge_indexer.mongodb_uri.is_some() && self.bridge_indexer.db_name.is_some()
     }
 
-    pub fn is_bridge_api_enabled(&self) -> bool {
+    pub const fn is_bridge_api_enabled(&self) -> bool {
         self.bridge_indexer.api_url.is_some()
     }
 }

--- a/solana/bridge_token_factory/programs/bridge_token_factory/src/instructions/admin/update_metadata.rs
+++ b/solana/bridge_token_factory/programs/bridge_token_factory/src/instructions/admin/update_metadata.rs
@@ -76,9 +76,9 @@ impl UpdateMetadata<'_> {
             cpi_ctx,
             None,
             Some(DataV2 {
-                name: name.unwrap_or(self.metadata.name.clone()),
-                symbol: symbol.unwrap_or(self.metadata.symbol.clone()),
-                uri: uri.unwrap_or(self.metadata.uri.clone()),
+                name: name.unwrap_or_else(|| self.metadata.name.clone()),
+                symbol: symbol.unwrap_or_else(|| self.metadata.symbol.clone()),
+                uri: uri.unwrap_or_else(|| self.metadata.uri.clone()),
                 seller_fee_basis_points: self.metadata.seller_fee_basis_points,
                 creators: self.metadata.creators.clone(),
                 collection: self.metadata.collection.clone(),

--- a/solana/bridge_token_factory/programs/bridge_token_factory/src/instructions/user/log_metadata.rs
+++ b/solana/bridge_token_factory/programs/bridge_token_factory/src/instructions/user/log_metadata.rs
@@ -73,7 +73,7 @@ impl LogMetadata<'_> {
         let metadata = self
             .metadata
             .as_ref()
-            .ok_or(error!(ErrorCode::TokenMetadataNotProvided))?
+            .ok_or_else(|| error!(ErrorCode::TokenMetadataNotProvided))?
             .to_account_info();
         require_keys_eq!(
             metadata.key(),

--- a/solana/bridge_token_factory/programs/bridge_token_factory/src/state/used_nonces.rs
+++ b/solana/bridge_token_factory/programs/bridge_token_factory/src/state/used_nonces.rs
@@ -38,7 +38,7 @@ impl UsedNonces {
 
     pub fn use_nonce<'info>(
         nonce: u64,
-        loader: &AccountLoader<'info, UsedNonces>,
+        loader: &AccountLoader<'info, Self>,
         config: &mut Account<'info, Config>,
         rent_reserve: AccountInfo<'info>,
         payer: AccountInfo<'info>,


### PR DESCRIPTION
This should help to get rid of [`OmniAddressWrapper`](https://github.com/Near-One/bridge-indexer-rs/blob/7aa8fc4bf4c4621da115b98742577862fecc3d4b/omni-indexer-enricher/src/enricher.rs#L45) in our enricher
