### PR TITLE
E2E test for transferring tokens from Near to EVM

### DIFF
--- a/e2e-testing/near_init_params.json
+++ b/e2e-testing/near_init_params.json
@@ -41,7 +41,7 @@
     "mock_token": {
         "init_function": "new_default_meta",
         "init_args": {
-            "total_supply": "1000000000"
+            "total_supply": "10000000000000000000000"
         }
     },
     "bridge_token": {

--- a/e2e-testing/snakefiles/01_bridge_token_near_to_evm.smk
+++ b/e2e-testing/snakefiles/01_bridge_token_near_to_evm.smk
@@ -38,7 +38,7 @@ evm_prover_setup_file = const.near_deploy_results_dir / "{network}-evm-prover-se
 
 # Main pipeline rule
 # TODO: Replace ETH_SEPOLIA with all EVM networks when the `evm_deploy_token` rule doesn't crash on Base and Arbitrum (the issue is not in the pipeline)
-rule all:
+rule bridge_token_all:
     input:
         expand(call_dir / "{network}-verify-bridge-token-report.txt", 
                network=list([const.EvmNetwork.ETH_SEPOLIA]))

--- a/e2e-testing/snakefiles/03_transfer_near_to_evm.smk
+++ b/e2e-testing/snakefiles/03_transfer_near_to_evm.smk
@@ -1,0 +1,206 @@
+import pathlib
+import const
+import time
+from const import NearContract as NC, NearTestAccount as NTA, EvmContract as EC, get_evm_account_dir
+from utils import progress_wait, get_json_field, extract_tx_hash, get_mkdir_cmd
+
+module bridge_token_near_to_evm:
+    snakefile: "./01_bridge_token_near_to_evm.smk"
+use rule * from bridge_token_near_to_evm
+
+evm_deploy_results_dir = pathlib.Path(const.get_evm_deploy_results_dir("{network}"))
+evm_bridge_contract_file = evm_deploy_results_dir / f"{EC.OMNI_BRIDGE}.json"
+evm_account_file = pathlib.Path(get_evm_account_dir("{network}")) / f"{EC.USER_ACCOUNT}.json"
+
+near_token_owner_credentials_file = const.near_account_dir / f"{NTA.INIT_ACCOUNT}.json"
+near_sender_account_file = const.near_account_dir / f"{NTA.SENDER_ACCOUNT}.json"
+near_bridge_contract_file = const.near_deploy_results_dir / f"{NC.OMNI_BRIDGE}.json"
+near_test_token_file = const.near_deploy_results_dir / f"{NC.MOCK_TOKEN}.json"
+
+call_dir = const.common_generated_dir / "03-transfer-near-to-{network}"
+
+storage_deposit_file = call_dir / "00_storage-deposit.json"
+fund_sender_file = call_dir / "01_fund-sender.json"
+init_transfer_file = call_dir / "02_init-transfer.json"
+sign_transfer_file = call_dir / "03_sign-transfer.json"
+fin_transfer_file = call_dir / "04_fin-transfer.json"
+
+# Main pipeline rule
+# TODO: Replace ETH_SEPOLIA with all EVM networks when the `evm_deploy_token` rule doesn't crash on Base and Arbitrum (the issue is not in the pipeline)
+rule transfer_near_to_evm_all:
+    input:
+        expand(call_dir / "verify-transfer-report.txt", 
+               network=list([const.EvmNetwork.ETH_SEPOLIA]))
+            #    network=list(const.EvmNetwork))
+    message: "Transfer Near to EVM pipeline completed"
+    default_target: True
+
+rule near_storage_deposit:
+    message: "Transfer token from Near to {wildcards.network}. Step 0: Storage deposit for bridge and sender accounts"
+    input:
+        rules.verify_bridge_token_near_to_evm.output,
+        near_sender_account = near_sender_account_file,
+        near_bridge_contract = near_bridge_contract_file,
+        near_test_token = near_test_token_file,
+        near_owner_account = near_token_owner_credentials_file
+    output: storage_deposit_file
+    params:
+        mkdir = get_mkdir_cmd(call_dir),
+        token_id = lambda wc, input: get_json_field(input.near_test_token, "contract_id"),
+        sender_account_id = lambda wc, input: get_json_field(input.near_sender_account, "account_id"),
+        bridge_account_id = lambda wc, input: get_json_field(input.near_bridge_contract, "contract_id"),
+        extract_tx = lambda wc, output: extract_tx_hash("near", output)
+    shell: """
+    {params.mkdir} && \
+    {const.common_scripts_dir}/call-near-contract.sh -c {params.token_id} \
+        -m storage_deposit \
+        -a '{{\"account_id\": \"{params.sender_account_id}\"}}' \
+        -f {input.near_owner_account} \
+        -d 0.00235NEAR \
+        -n testnet 2>&1 | tee {output} && \
+    {const.common_scripts_dir}/call-near-contract.sh -c {params.token_id} \
+        -m storage_deposit \
+        -a '{{\"account_id\": \"{params.bridge_account_id}\"}}' \
+        -f {input.near_owner_account} \
+        -d 0.00235NEAR \
+        -n testnet 2>&1 | tee {output} && \
+    {params.extract_tx}
+    """
+
+rule near_fund_sender:
+    message: "Transfer token from Near to {wildcards.network}. Step 1: Fund sender account with test tokens"
+    input:
+        rules.near_storage_deposit.output,
+        near_sender_account = near_sender_account_file,
+        near_test_token = near_test_token_file,
+        near_owner_account = near_token_owner_credentials_file
+    output: fund_sender_file
+    params:
+        mkdir = get_mkdir_cmd(call_dir),
+        token_id = lambda wc, input: get_json_field(input.near_test_token, "contract_id"),
+        sender_account_id = lambda wc, input: get_json_field(input.near_sender_account, "account_id"),
+        extract_tx = lambda wc, output: extract_tx_hash("near", output)
+    shell: """
+    {params.mkdir} && \
+    {const.common_scripts_dir}/call-near-contract.sh -c {params.token_id} \
+        -m ft_transfer \
+        -a '{{\"receiver_id\": \"{params.sender_account_id}\", \"amount\":\"1000000000000\"}}' \
+        -f {input.near_owner_account} \
+        -d 1YOCTONEAR \
+        -n testnet 2>&1 | tee {output} && \
+    {params.extract_tx}
+    """
+
+
+rule near_init_transfer:
+    message: "Transfer token from Near to {wildcards.network}. Step 2: Init transfer on Near"
+    input:
+        rules.near_fund_sender.output,
+        sender_account = near_sender_account_file,
+        bridge_contract = near_bridge_contract_file,
+        test_token = near_test_token_file,
+        evm_account = evm_account_file
+    output: init_transfer_file
+    params:
+        config_file = const.common_bridge_sdk_config_file,
+        mkdir = get_mkdir_cmd(call_dir),
+        token_id = lambda wc, input: get_json_field(input.test_token, "contract_id"),
+        sender_account_id = lambda wc, input: get_json_field(input.sender_account, "account_id"),
+        sender_private_key = lambda wc, input: get_json_field(input.sender_account, "private_key"),
+        recipient_address = lambda wc, input: get_json_field(input.evm_account, "address"),
+        token_locker_id = lambda wc, input: get_json_field(input.bridge_contract, "contract_id"),
+        extract_tx = lambda wc, output: extract_tx_hash("bridge", output)
+    shell: """
+    {params.mkdir} && \
+    bridge-cli testnet near-init-transfer \
+        --token {params.token_id} \
+        --amount 23000000000 \
+        --recipient {params.recipient_address} \
+        --near-signer {params.sender_account_id} \
+        --near-private-key {params.sender_private_key} \
+        --near-token-locker-id {params.token_locker_id} \
+        --config {params.config_file} > {output} && \
+    {params.extract_tx}
+    """
+
+rule near_sign_transfer:
+    message: "Transfer token from Near to {wildcards.network}. Step 3: Sign transfer on Near"
+    input:
+        near_init_transfer = rules.near_init_transfer.output,
+        sender_account = near_sender_account_file,
+        bridge_contract = near_bridge_contract_file,
+    output: sign_transfer_file
+    params:
+        config_file = const.common_bridge_sdk_config_file,
+        mkdir = get_mkdir_cmd(call_dir),
+        sender_account_id = lambda wc, input: get_json_field(input.sender_account, "account_id"),
+        sender_private_key = lambda wc, input: get_json_field(input.sender_account, "private_key"),
+        token_locker_id = lambda wc, input: get_json_field(input.bridge_contract, "contract_id"),
+        init_transfer_tx_hash = lambda wc, input: get_json_field(input.near_init_transfer, "tx_hash"),
+        extract_tx = lambda wc, output: extract_tx_hash("bridge", output)
+    shell: """
+    {params.mkdir} && \
+    NONCE=$(yarn --cwd {const.common_tools_dir} --silent get-near-transfer-nonce \
+        --tx-hash {params.init_transfer_tx_hash}) && \
+    bridge-cli testnet near-sign-transfer \
+        --origin-chain Near \
+        --origin-nonce $NONCE \
+        --fee 0 \
+        --native-fee 0 \
+        --near-signer {params.sender_account_id} \
+        --near-private-key {params.sender_private_key} \
+        --near-token-locker-id {params.token_locker_id} \
+        --config {params.config_file} > {output} && \
+    {params.extract_tx}
+    """
+
+rule evm_fin_transfer:
+    message: "Transfer token from Near to {wildcards.network}. Step 4: Fin transfer on EVM"
+    input:
+        near_sign_transfer = rules.near_sign_transfer.output,
+        evm_bridge = evm_bridge_contract_file,
+    output: fin_transfer_file
+    params:
+        config_file = const.common_bridge_sdk_config_file,
+        mkdir = get_mkdir_cmd(call_dir),
+        evm_chain_str = lambda wc: const.Chain.from_evm_network(wc.network),
+        sign_transfer_tx_hash = lambda wc, input: get_json_field(input.near_sign_transfer, "tx_hash"),
+        evm_bridge_address = lambda wc, input: get_json_field(input.evm_bridge, "bridgeAddress"),
+        progress_wait_cmd = progress_wait(20),
+        extract_tx = lambda wc, output: extract_tx_hash("bridge", output)
+    shell:"""
+        {params.mkdir} && \
+        {params.progress_wait_cmd} \
+        bridge-cli testnet evm-fin-transfer \
+            --chain {params.evm_chain_str} \
+            --tx-hash {params.sign_transfer_tx_hash} \
+            --eth-bridge-token-factory-address {params.evm_bridge_address} \
+            --config {params.config_file} > {output} && \
+        {params.extract_tx}
+        """
+
+rule verify_transfer_near_to_evm:
+    message: "Transfer token from Near to {wildcards.network}. Verification"
+    input:
+        rules.evm_fin_transfer.output,
+        test_token = near_test_token_file,
+        bridge_contract = near_bridge_contract_file,
+        evm_account = evm_account_file
+    output: call_dir / "verify-transfer-report.txt"
+    params:
+        mkdir = get_mkdir_cmd(call_dir),
+        call_dir = lambda wildcards: str(call_dir).format(network=wildcards.network),
+        evm_chain_str = lambda wc: const.Chain.from_evm_network(wc.network),
+        token_locker_id = lambda wc, input: get_json_field(input.bridge_contract, "contract_id"),
+        near_token_id = lambda wc, input: get_json_field(input.test_token, "contract_id"),
+        recipient_address = lambda wc, input: get_json_field(input.evm_account, "address"),
+    shell: """
+    {params.mkdir} && \
+    yarn --cwd {const.common_tools_dir} --silent verify-transfer-near-to-evm \
+        --tx-dir {params.call_dir} \
+        --receiver {params.recipient_address} \
+        --near-token {params.near_token_id} \
+        --chain-kind {params.evm_chain_str} \
+        --near-locker {params.token_locker_id} \
+        | tee {output}
+    """

--- a/e2e-testing/snakefiles/const.py
+++ b/e2e-testing/snakefiles/const.py
@@ -75,6 +75,7 @@ class EvmContract(StrEnum):
     OMNI_BRIDGE = "omni_bridge"
     TEST_TOKEN = "test_token"
     ENEAR = "e_near"
+    USER_ACCOUNT = "user_account"
 
 
 class EvmNetwork(StrEnum):

--- a/e2e-testing/snakefiles/evm.smk
+++ b/e2e-testing/snakefiles/evm.smk
@@ -40,6 +40,9 @@ def evm_deploy_test_token(network, name, symbol):
 def evm_create_eoa(network):
     return f"yarn --silent --cwd {const.common_tools_dir} hardhat create-eoa --network {network}"
 
+def evm_get_current_eoa(network):
+    return f"yarn --silent --cwd {const.common_tools_dir} hardhat get-current-eoa --network {network}"
+
 def get_mkdir_cmd(wildcards):
     return f"mkdir -p {get_evm_deploy_results_dir(wildcards.network)}"
 
@@ -69,10 +72,10 @@ rule evm_build:
 
 rule evm_create_eoa_account:
     message: "Creating EOA account"
-    output: pathlib.Path(get_evm_account_dir("{network}")) / "{account}.json"
+    output: pathlib.Path(get_evm_account_dir("{network}")) / f"{EC.USER_ACCOUNT}.json"
     params:
         evm_account_dir = lambda wc: get_evm_account_dir(wc.network),
-        create_cmd = lambda wc: evm_create_eoa(wc.network)
+        create_cmd = lambda wc: evm_get_current_eoa(wc.network)
     shell: """
     mkdir -p {params.evm_account_dir} && \
     {params.create_cmd} 2>/dev/stderr 1> {output}

--- a/e2e-testing/snakefiles/utils.py
+++ b/e2e-testing/snakefiles/utils.py
@@ -51,7 +51,7 @@ def extract_tx_hash(pattern_type, output_file):
     """
     elif pattern_type == "bridge":
         return f"""
-    TX_HASH=$(grep -o 'tx_hash="[^"]*"' {output_file} | cut -d'"' -f2) && \\
+    TX_HASH=$(grep -o 'tx_hash="[^"]*"' {output_file} | tail -1 | cut -d'"' -f2) && \\
     echo '{{\"tx_hash\": \"'$TX_HASH'\"}}' > {output_file}
     """
     else:

--- a/e2e-testing/tools/hardhat.config.ts
+++ b/e2e-testing/tools/hardhat.config.ts
@@ -97,6 +97,16 @@ task("mint-test-token", "Mints tokens to a specified address")
     }));
   });
 
+task("get-current-eoa", "Gets the EOA address of a current signer")
+  .setAction(async (_, hre) => {
+    const { ethers } = hre;
+
+    const wallet = new ethers.Wallet(EVM_PRIVATE_KEY);
+    console.log(JSON.stringify({
+      address: wallet.address,
+      privateKey: wallet.privateKey,
+    }, null, 2));
+  });
 
 task("create-eoa", "Creates a new EOA account and prints its credentials")
   .setAction(async (_, hre) => {

--- a/e2e-testing/tools/package.json
+++ b/e2e-testing/tools/package.json
@@ -40,6 +40,8 @@
     "build": "tsc",
     "verify-bridge-token-near-to-evm": "ts-node src/scripts/verify-bridge-token-near-to-evm.ts",
     "verify-pipeline-2": "ts-node src/scripts/verify-pipeline-2.ts",
+    "verify-transfer-near-to-evm": "ts-node src/scripts/verify-transfer-near-to-evm.ts",
+    "get-near-transfer-nonce": "ts-node src/scripts/get-near-transfer-nonce.ts",
     "test": "yarn hardhat test",
     "coverage": "yarn hardhat coverage",
     "lint:js": "biome check",

--- a/e2e-testing/tools/src/lib/evm.ts
+++ b/e2e-testing/tools/src/lib/evm.ts
@@ -75,3 +75,28 @@ export async function verifyEvmTokenBalance(tokenAddress: string, accountAddress
         );
     }
 } 
+
+export async function getEvmLog(txHash: string, event_signature: string): Promise<ethers.Log> {
+    const provider = getInfuraProvider();
+    const receipt = await provider.getTransactionReceipt(txHash);
+    if (!receipt) {
+        throw new VerificationError(`Transaction ${txHash} not found`);
+    }
+    const logEntry = receipt.logs.find(l => l.topics.includes(ethers.id(event_signature)));
+    if (!logEntry) {
+        throw new VerificationError(`Event ${event_signature} not found in transaction ${txHash}`);
+    }
+    return logEntry;
+}
+
+export function addressToPaddedHex(address: string): string {
+    const cleanAddress = address.startsWith('0x') ? address.slice(2) : address;
+    
+    if (cleanAddress.length !== 40) {
+        throw new Error('Invalid address length. Expected 40 hex characters.');
+    }
+    
+    const paddedAddress = cleanAddress.toLowerCase().padStart(64, '0');
+    
+    return '0x' + paddedAddress;
+}

--- a/e2e-testing/tools/src/lib/near.ts
+++ b/e2e-testing/tools/src/lib/near.ts
@@ -11,6 +11,18 @@ class NearClient {
         });
     }
 
+    async getNearLog(txHash: string, receiptIdx: number, logIdx: number): Promise<string> {
+        const txStatus = await this.provider.txStatus(txHash, 'system');
+
+        // Check main transaction status
+        const status = txStatus.status as { SuccessValue?: string; Failure?: unknown };
+        if (status.Failure) {
+            throw new VerificationError(`NEAR transaction ${txHash} failed: ${JSON.stringify(status.Failure)}`);
+        }
+
+        return txStatus.receipts_outcome[receiptIdx].outcome.logs[logIdx];
+    }
+
     async verifyNearReceipt(txHash: string): Promise<void> {
         const txStatus = await this.provider.txStatus(txHash, 'system');
 
@@ -76,3 +88,4 @@ const nearClient = new NearClient();
 export const verifyNearReceipt = (txHash: string) => nearClient.verifyNearReceipt(txHash);
 export const getNearTokenMetadata = (tokenAddress: string) => nearClient.getTokenMetadata(tokenAddress);
 export const getLockerTokenAddress = (lockerAddress: string, nearToken: string, evmChainKind: string) => nearClient.getLockerTokenAddress(lockerAddress, nearToken, evmChainKind); 
+export const getNearLog = (txHash: string, receiptIdx: number, logIdx: number) => nearClient.getNearLog(txHash, receiptIdx, logIdx);

--- a/e2e-testing/tools/src/scripts/get-near-transfer-nonce.ts
+++ b/e2e-testing/tools/src/scripts/get-near-transfer-nonce.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { Command } from 'commander';
+import { getNearLog } from '../lib/near';
+
+async function main() {
+    const program = new Command();
+
+    program
+        .requiredOption('-t, --tx-hash <dir>', 'Directory containing transaction receipts')
+        .parse(process.argv);
+
+    const options = program.opts();
+
+    try {
+        const initTransferLog = await getNearLog(options.txHash, 1, 0);
+        const log = JSON.parse(initTransferLog);
+        console.log(log.InitTransferEvent.transfer_message.origin_nonce);
+    } catch (error) {
+        process.exit(1);
+    }
+}
+
+main();

--- a/e2e-testing/tools/src/scripts/verify-transfer-near-to-evm.ts
+++ b/e2e-testing/tools/src/scripts/verify-transfer-near-to-evm.ts
@@ -1,0 +1,53 @@
+import 'dotenv/config';
+import { Command } from 'commander';
+import { getLockerTokenAddress } from '../lib/near';
+import { getEvmLog, addressToPaddedHex } from '../lib/evm';
+import { loadTransactions, verifyTransactions } from '../lib/common';
+import { VerificationError } from '../lib/types';
+
+async function main() {
+    const program = new Command();
+
+    program
+        .requiredOption('-d, --tx-dir <dir>', 'Directory containing transaction receipts')
+        .requiredOption('-r, --receiver <receiverAddress>', 'Receiver address on the EVM chain')
+        .requiredOption('-n, --near-token <address>', 'NEAR token address')
+        .requiredOption('-c, --chain-kind <chain-kind>', 'Chain kind')
+        .requiredOption('-l, --near-locker <address>', 'NEAR locker address')
+        .parse(process.argv);
+
+    const options = program.opts();
+
+    try {
+        const transactions = await loadTransactions(options.txDir);
+
+        await verifyTransactions(transactions);
+        console.log('Transactions verified successfully!');
+
+        const log = await getEvmLog(transactions[transactions.length - 1].hash, 'Transfer(address,address,uint256)');
+
+        const evmTokenAddress = await getLockerTokenAddress(options.nearLocker, options.nearToken, options.chainKind);
+
+        if (`eth:${log.address.toLowerCase()}` !== evmTokenAddress) {
+            throw new VerificationError(`Token address in log (${log.address}) does not match expected token address (${evmTokenAddress})`);
+        }
+        if (log.topics[1] !== '0x0000000000000000000000000000000000000000000000000000000000000000') {
+            throw new VerificationError('Tokens were not minted, expected zero address in log topic 1');
+        }
+        if (log.topics[2] !== addressToPaddedHex(options.receiver)) {
+            throw new VerificationError(`Receiver address in log (${log.topics[2]}) does not match expected receiver address (${options.receiver})`);
+        }
+        console.log('Tokens transferred successfully!');
+
+        console.log('All verifications passed successfully!');
+    } catch (error) {
+        if (error instanceof VerificationError) {
+            console.error('Verification failed:', error.message);
+        } else {
+            console.error('Unexpected error:', error);
+        }
+        process.exit(1);
+    }
+}
+
+main(); 


### PR DESCRIPTION
This is related to [#319](https://github.com/Near-One/omni-bridge/issues/319)

In order to do fast transfers we need the necessary accounts to have tokens on both chains. I figured the best way to achieve that, is to write a test for init/fin transfer.

Fast transfer test will have a dependency on this one, just like this test has a dependency on deploy token test.