### PR TITLE
feat: added flag to enable/disable `sign_btc_transaction` call

### DIFF
--- a/omni-relayer/Cargo.lock
+++ b/omni-relayer/Cargo.lock
@@ -6853,7 +6853,7 @@ dependencies = [
 
 [[package]]
 name = "omni-relayer"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "alloy",
  "anyhow",

--- a/omni-relayer/Cargo.toml
+++ b/omni-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-relayer"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 resolver = "2"
 repository = "https://github.com/Near-One/omni-bridge"

--- a/omni-relayer/example-devnet-config.toml
+++ b/omni-relayer/example-devnet-config.toml
@@ -1,5 +1,10 @@
 [redis]
 url = "redis://127.0.0.1/"
+keep_insufficient_fee_transfers_for = 1209600 # 60 * 60 * 24 * 14
+check_insufficient_fee_transfers_every_secs = 1800 # 60 * 30
+sleep_time_after_events_process_secs = 1
+query_retry_attempts = 10
+query_retry_sleep_secs = 1
 
 [bridge_indexer]
 # Used to check if provided fee is sufficient to complete the transfer

--- a/omni-relayer/example-devnet-config.toml
+++ b/omni-relayer/example-devnet-config.toml
@@ -85,6 +85,8 @@ finalize_transfer_sol_discriminator = [104, 27, 121, 69, 3, 70, 217, 66]
 
 [btc]
 rpc_http_url = "https://bitcoin-testnet-rpc.publicnode.com"
+# If this is set to true, then omni relayer will call `sign_btc_transaction`
+signing_enabled = false
 
 [wormhole]
 api_url = "https://api.testnet.wormholescan.io/"

--- a/omni-relayer/example-mainnet-config.toml
+++ b/omni-relayer/example-mainnet-config.toml
@@ -85,6 +85,8 @@ finalize_transfer_sol_discriminator = [104, 27, 121, 69, 3, 70, 217, 66]
 
 [btc]
 rpc_http_url = "https://bitcoin-rpc.publicnode.com"
+# If this is set to true, then omni relayer will call `sign_btc_transaction`
+signing_enabled = false
 
 [wormhole]
 api_url = "https://api.wormholescan.io/"

--- a/omni-relayer/example-mainnet-config.toml
+++ b/omni-relayer/example-mainnet-config.toml
@@ -1,5 +1,10 @@
 [redis]
 url = "redis://127.0.0.1/"
+keep_insufficient_fee_transfers_for = 1209600 # 60 * 60 * 24 * 14
+check_insufficient_fee_transfers_every_secs = 1800 # 60 * 30
+sleep_time_after_events_process_secs = 1
+query_retry_attempts = 10
+query_retry_sleep_secs = 1
 
 [bridge_indexer]
 # Used to check if provided fee is sufficient to complete the transfer

--- a/omni-relayer/example-testnet-config.toml
+++ b/omni-relayer/example-testnet-config.toml
@@ -87,6 +87,8 @@ finalize_transfer_sol_discriminator = [104, 27, 121, 69, 3, 70, 217, 66]
 
 [btc]
 rpc_http_url = "https://bitcoin-testnet-rpc.publicnode.com"
+# If this is set to true, then omni relayer will call `sign_btc_transaction`
+signing_enabled = false
 
 [wormhole]
 api_url = "https://api.testnet.wormholescan.io/"

--- a/omni-relayer/example-testnet-config.toml
+++ b/omni-relayer/example-testnet-config.toml
@@ -1,5 +1,10 @@
 [redis]
 url = "redis://127.0.0.1/"
+keep_insufficient_fee_transfers_for = 1209600 # 60 * 60 * 24 * 14
+check_insufficient_fee_transfers_every_secs = 1800 # 60 * 30
+sleep_time_after_events_process_secs = 1
+query_retry_attempts = 10
+query_retry_sleep_secs = 1
 
 [bridge_indexer]
 # Used to check if provided fee is sufficient to complete the transfer

--- a/omni-relayer/src/config.rs
+++ b/omni-relayer/src/config.rs
@@ -119,6 +119,12 @@ impl Config {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Redis {
     pub url: String,
+
+    pub keep_insufficient_fee_transfers_for: i64,
+    pub check_insufficient_fee_transfers_every_secs: i64,
+    pub sleep_time_after_events_process_secs: u64,
+    pub query_retry_attempts: u64,
+    pub query_retry_sleep_secs: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/omni-relayer/src/config.rs
+++ b/omni-relayer/src/config.rs
@@ -112,10 +112,7 @@ impl Config {
     }
 
     pub fn is_signing_btc_transaction_enabled(&self) -> bool {
-        self.btc
-            .as_ref()
-            .map(|btc| btc.signing_enabled)
-            .unwrap_or_default()
+        self.btc.as_ref().is_some_and(|btc| btc.signing_enabled)
     }
 }
 

--- a/omni-relayer/src/config.rs
+++ b/omni-relayer/src/config.rs
@@ -110,6 +110,13 @@ impl Config {
     pub fn is_fast_relayer_enabled(&self) -> bool {
         self.near.fast_relayer_enabled
     }
+
+    pub fn is_signing_btc_transaction_enabled(&self) -> bool {
+        self.btc
+            .as_ref()
+            .map(|btc| btc.signing_enabled)
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -201,6 +208,7 @@ pub struct Solana {
 #[derive(Debug, Clone, Deserialize)]
 pub struct Btc {
     pub rpc_http_url: String,
+    pub signing_enabled: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/omni-relayer/src/main.rs
+++ b/omni-relayer/src/main.rs
@@ -215,7 +215,7 @@ async fn main() -> Result<()> {
                 let redis_client = redis_client.clone();
                 async move {
                     startup::solana::start_indexer(
-                        config,
+                        &config,
                         redis_client,
                         args.solana_start_signature,
                     )
@@ -225,7 +225,7 @@ async fn main() -> Result<()> {
             handles.push(tokio::spawn({
                 let config = config.clone();
                 let redis_client = redis_client.clone();
-                async move { startup::solana::process_signature(config, redis_client).await }
+                async move { startup::solana::process_signature(&config, redis_client).await }
             }));
         }
     }

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -213,7 +213,7 @@ async fn process_recent_blocks(
 
         for log in logs {
             process_log(
-                &config,
+                config,
                 chain_kind,
                 redis_connection,
                 http_provider,
@@ -229,6 +229,7 @@ async fn process_recent_blocks(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_log(
     config: &config::Config,
     chain_kind: ChainKind,

--- a/omni-relayer/src/startup/evm.rs
+++ b/omni-relayer/src/startup/evm.rs
@@ -64,9 +64,15 @@ pub async fn start_indexer(
         expected_finalization_time,
         safe_confirmations,
     ) = match chain_kind {
-        ChainKind::Eth => extract_evm_config(config.eth.context("Failed to get Eth config")?)?,
-        ChainKind::Base => extract_evm_config(config.base.context("Failed to get Base config")?)?,
-        ChainKind::Arb => extract_evm_config(config.arb.context("Failed to get Arb config")?)?,
+        ChainKind::Eth => {
+            extract_evm_config(config.eth.clone().context("Failed to get Eth config")?)?
+        }
+        ChainKind::Base => {
+            extract_evm_config(config.base.clone().context("Failed to get Base config")?)?
+        }
+        ChainKind::Arb => {
+            extract_evm_config(config.arb.clone().context("Failed to get Arb config")?)?
+        }
         _ => anyhow::bail!("Unsupported chain kind: {chain_kind:?}"),
     };
 
@@ -98,7 +104,7 @@ pub async fn start_indexer(
         };
 
         crate::skip_fail!(
-            process_recent_blocks(params)
+            process_recent_blocks(&config, params)
                 .await
                 .map_err(|err| hide_api_key(&err)),
             format!("Failed to process recent blocks for {chain_kind:?} indexer"),
@@ -130,6 +136,7 @@ pub async fn start_indexer(
 
         while let Some(log) = stream.next().await {
             process_log(
+                &config,
                 chain_kind,
                 &mut redis_connection,
                 &http_provider,
@@ -148,7 +155,10 @@ pub async fn start_indexer(
     }
 }
 
-async fn process_recent_blocks(params: ProcessRecentBlocksParams<'_>) -> Result<()> {
+async fn process_recent_blocks(
+    config: &config::Config,
+    params: ProcessRecentBlocksParams<'_>,
+) -> Result<()> {
     let ProcessRecentBlocksParams {
         redis_connection,
         http_provider,
@@ -167,6 +177,7 @@ async fn process_recent_blocks(params: ProcessRecentBlocksParams<'_>) -> Result<
         Some(block) => block,
         None => {
             if let Some(block) = utils::redis::get_last_processed::<&str, u64>(
+                config,
                 redis_connection,
                 &last_processed_block_key,
             )
@@ -175,6 +186,7 @@ async fn process_recent_blocks(params: ProcessRecentBlocksParams<'_>) -> Result<
                 block + 1
             } else {
                 utils::redis::update_last_processed(
+                    config,
                     redis_connection,
                     &last_processed_block_key,
                     latest_block + 1,
@@ -201,6 +213,7 @@ async fn process_recent_blocks(params: ProcessRecentBlocksParams<'_>) -> Result<
 
         for log in logs {
             process_log(
+                &config,
                 chain_kind,
                 redis_connection,
                 http_provider,
@@ -217,6 +230,7 @@ async fn process_recent_blocks(params: ProcessRecentBlocksParams<'_>) -> Result<
 }
 
 async fn process_log(
+    config: &config::Config,
     chain_kind: ChainKind,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     http_provider: &DynProvider,
@@ -269,6 +283,7 @@ async fn process_log(
         };
 
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::EVENTS,
             tx_hash.to_string(),
@@ -286,6 +301,7 @@ async fn process_log(
 
         if is_fast_relayer_enabled {
             utils::redis::add_event(
+                config,
                 redis_connection,
                 utils::redis::EVENTS,
                 format!("{tx_hash}_fast"),
@@ -319,6 +335,7 @@ async fn process_log(
         };
 
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::EVENTS,
             tx_hash.to_string(),
@@ -341,6 +358,7 @@ async fn process_log(
         };
 
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::EVENTS,
             tx_hash.to_string(),
@@ -359,6 +377,7 @@ async fn process_log(
     }
 
     utils::redis::update_last_processed(
+        config,
         redis_connection,
         &utils::redis::get_last_processed_key(chain_kind),
         block_number,

--- a/omni-relayer/src/startup/near.rs
+++ b/omni-relayer/src/startup/near.rs
@@ -63,6 +63,7 @@ async fn create_lake_config(
     let start_block_height = match start_block {
         Some(block) => block,
         None => utils::redis::get_last_processed::<&str, u64>(
+            config,
             redis_connection,
             &utils::redis::get_last_processed_key(ChainKind::Near),
         )
@@ -118,6 +119,7 @@ pub async fn start_indexer(
                 .await;
 
                 utils::redis::update_last_processed(
+                    &config,
                     &mut redis_connection,
                     &utils::redis::get_last_processed_key(ChainKind::Near),
                     streamer_message.block.header.height,

--- a/omni-relayer/src/startup/solana.rs
+++ b/omni-relayer/src/startup/solana.rs
@@ -34,11 +34,11 @@ pub fn get_keypair(file: Option<&String>) -> Keypair {
 }
 
 pub async fn start_indexer(
-    config: config::Config,
+    config: &config::Config,
     redis_client: redis::Client,
     mut start_signature: Option<Signature>,
 ) -> Result<()> {
-    let Some(solana_config) = config.solana else {
+    let Some(solana_config) = config.solana.clone() else {
         anyhow::bail!("Failed to get Solana config");
     };
 
@@ -51,6 +51,7 @@ pub async fn start_indexer(
     loop {
         crate::skip_fail!(
             process_recent_signatures(
+                config,
                 &mut redis_connection,
                 rpc_http_url.clone(),
                 &program_id,
@@ -64,7 +65,7 @@ pub async fn start_indexer(
         info!("All historical logs processed, starting Solana WS subscription");
 
         let filter = RpcTransactionLogsFilter::Mentions(vec![program_id.to_string()]);
-        let config = RpcTransactionLogsConfig {
+        let rpc_config = RpcTransactionLogsConfig {
             commitment: Some(CommitmentConfig::confirmed()),
         };
 
@@ -76,7 +77,7 @@ pub async fn start_indexer(
 
         let (mut log_stream, _) = crate::skip_fail!(
             ws_client
-                .logs_subscribe(filter.clone(), config.clone())
+                .logs_subscribe(filter.clone(), rpc_config.clone())
                 .await,
             "Subscription to logs on Solana chain failed",
             5
@@ -88,6 +89,7 @@ pub async fn start_indexer(
             if let Ok(signature) = Signature::from_str(&log.value.signature) {
                 info!("Found a signature on Solana: {signature:?}");
                 utils::redis::add_event(
+                    config,
                     &mut redis_connection,
                     utils::redis::SOLANA_EVENTS,
                     signature.to_string(),
@@ -107,6 +109,7 @@ pub async fn start_indexer(
 }
 
 async fn process_recent_signatures(
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     rpc_http_url: String,
     program_id: &Pubkey,
@@ -116,6 +119,7 @@ async fn process_recent_signatures(
 
     let from_signature = if let Some(signature) = start_signature {
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::SOLANA_EVENTS,
             signature.to_string(),
@@ -127,6 +131,7 @@ async fn process_recent_signatures(
         signature
     } else {
         let Some(signature) = utils::redis::get_last_processed::<&str, String>(
+            config,
             redis_connection,
             &utils::redis::get_last_processed_key(ChainKind::Sol),
         )
@@ -152,6 +157,7 @@ async fn process_recent_signatures(
 
     for signature_status in &signatures {
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::SOLANA_EVENTS,
             signature_status.signature.clone(),
@@ -164,8 +170,8 @@ async fn process_recent_signatures(
     Ok(())
 }
 
-pub async fn process_signature(config: config::Config, redis_client: redis::Client) -> Result<()> {
-    let Some(solana_config) = config.solana else {
+pub async fn process_signature(config: &config::Config, redis_client: redis::Client) -> Result<()> {
+    let Some(solana_config) = config.solana.clone() else {
         anyhow::bail!("Failed to get Solana config");
     };
 
@@ -184,13 +190,14 @@ pub async fn process_signature(config: config::Config, redis_client: redis::Clie
         let mut redis_connection = redis_connection.clone();
 
         let Some(events) = utils::redis::get_events(
+            config,
             &mut redis_connection,
             utils::redis::SOLANA_EVENTS.to_string(),
         )
         .await
         else {
             tokio::time::sleep(tokio::time::Duration::from_secs(
-                utils::redis::SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS,
+                config.redis.sleep_time_after_events_process_secs,
             ))
             .await;
             continue;
@@ -200,6 +207,7 @@ pub async fn process_signature(config: config::Config, redis_client: redis::Clie
 
         for (key, _) in events {
             handlers.push(tokio::spawn({
+                let config = config.clone();
                 let mut redis_connection = redis_connection.clone();
                 let solana = solana_config.clone();
                 let http_client = http_client.clone();
@@ -224,6 +232,7 @@ pub async fn process_signature(config: config::Config, redis_client: redis::Clie
                             {
                                 if let UiMessage::Raw(ref raw) = tx.message {
                                     utils::solana::process_message(
+                                        &config,
                                         &mut redis_connection,
                                         &solana,
                                         &transaction,
@@ -235,12 +244,14 @@ pub async fn process_signature(config: config::Config, redis_client: redis::Clie
                             }
 
                             utils::redis::remove_event(
+                                &config,
                                 &mut redis_connection,
                                 utils::redis::SOLANA_EVENTS,
                                 &signature.to_string(),
                             )
                             .await;
                             utils::redis::update_last_processed(
+                                &config,
                                 &mut redis_connection,
                                 &utils::redis::get_last_processed_key(ChainKind::Sol),
                                 &signature.to_string(),
@@ -258,7 +269,7 @@ pub async fn process_signature(config: config::Config, redis_client: redis::Clie
         join_all(handlers).await;
 
         tokio::time::sleep(tokio::time::Duration::from_secs(
-            utils::redis::SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS,
+            config.redis.sleep_time_after_events_process_secs,
         ))
         .await;
     }

--- a/omni-relayer/src/utils/bridge_api.rs
+++ b/omni-relayer/src/utils/bridge_api.rs
@@ -70,7 +70,7 @@ impl TransferFee {
             };
 
             if let Some(historical_fee) =
-                utils::redis::get_fee(redis_connection, &transfer_id).await
+                utils::redis::get_fee(config, redis_connection, &transfer_id).await
             {
                 if historical_fee.is_fee_sufficient(config, provided_fee) {
                     info!(
@@ -82,6 +82,7 @@ impl TransferFee {
                 }
             } else {
                 utils::redis::add_event(
+                    config,
                     redis_connection,
                     utils::redis::FEE_MAPPING,
                     transfer_id,

--- a/omni-relayer/src/utils/near.rs
+++ b/omni-relayer/src/utils/near.rs
@@ -147,6 +147,7 @@ pub async fn handle_streamer_message(
             OmniBridgeEvent::InitTransferEvent { transfer_message }
             | OmniBridgeEvent::UpdateFeeEvent { transfer_message } => {
                 utils::redis::add_event(
+                    config,
                     redis_connection,
                     utils::redis::EVENTS,
                     transfer_message.origin_nonce.to_string(),
@@ -163,6 +164,7 @@ pub async fn handle_streamer_message(
                 ..
             } => {
                 utils::redis::add_event(
+                    config,
                     redis_connection,
                     utils::redis::EVENTS,
                     message_payload.transfer_id.origin_nonce.to_string(),
@@ -173,6 +175,7 @@ pub async fn handle_streamer_message(
             OmniBridgeEvent::FinTransferEvent { transfer_message } => {
                 if transfer_message.recipient.get_chain() != ChainKind::Near {
                     utils::redis::add_event(
+                        config,
                         redis_connection,
                         utils::redis::EVENTS,
                         transfer_message.origin_nonce.to_string(),

--- a/omni-relayer/src/utils/redis.rs
+++ b/omni-relayer/src/utils/redis.rs
@@ -16,9 +16,9 @@ pub const FEE_MAPPING: &str = "fee_mapping";
 pub const KEEP_INSUFFICIENT_FEE_TRANSFERS_FOR: i64 = 60 * 60 * 24 * 14; // 14 days
 pub const CHECK_INSUFFICIENT_FEE_TRANSFERS_EVERY_SECS: i64 = 60 * 30; // 30 minutes
 
-pub const SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS: u64 = 10;
+pub const SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS: u64 = 1;
 
-const QUERY_RETRY_ATTEMPTS: u64 = 10;
+const QUERY_RETRY_ATTEMPTS: u64 = 1;
 const QUERY_RETRY_SLEEP_SECS: u64 = 1;
 
 pub async fn get_fee(

--- a/omni-relayer/src/utils/redis.rs
+++ b/omni-relayer/src/utils/redis.rs
@@ -2,6 +2,8 @@ use omni_types::ChainKind;
 use redis::{AsyncCommands, aio::MultiplexedConnection};
 use tracing::warn;
 
+use crate::config;
+
 use super::bridge_api::TransferFee;
 
 pub const MONGODB_OMNI_EVENTS_RT: &str = "mongodb_omni_events_rt";
@@ -13,19 +15,12 @@ pub const STUCK_EVENTS: &str = "stuck_events";
 
 pub const FEE_MAPPING: &str = "fee_mapping";
 
-pub const KEEP_INSUFFICIENT_FEE_TRANSFERS_FOR: i64 = 60 * 60 * 24 * 14; // 14 days
-pub const CHECK_INSUFFICIENT_FEE_TRANSFERS_EVERY_SECS: i64 = 60 * 30; // 30 minutes
-
-pub const SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS: u64 = 1;
-
-const QUERY_RETRY_ATTEMPTS: u64 = 1;
-const QUERY_RETRY_SLEEP_SECS: u64 = 1;
-
 pub async fn get_fee(
+    config: &config::Config,
     redis_connection: &mut MultiplexedConnection,
     transfer_id: &str,
 ) -> Option<TransferFee> {
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         match redis_connection
             .hget::<&str, &str, Option<String>>(FEE_MAPPING, transfer_id)
             .await
@@ -41,13 +36,17 @@ pub async fn get_fee(
                 return None;
             }
             Err(_) => {
-                tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(
+                    config.redis.query_retry_sleep_secs,
+                ))
+                .await;
             }
         }
     }
 
     warn!(
-        "Failed to get fee for transfer_id {transfer_id} from redis after {QUERY_RETRY_ATTEMPTS} attempts"
+        "Failed to get fee for transfer_id {transfer_id} from redis after {} attempts",
+        config.redis.query_retry_attempts
     );
     None
 }
@@ -60,6 +59,7 @@ pub fn get_last_processed_key(chain_kind: ChainKind) -> String {
 }
 
 pub async fn get_last_processed<K, V>(
+    config: &config::Config,
     redis_connection: &mut MultiplexedConnection,
     key: K,
 ) -> Option<V>
@@ -67,12 +67,15 @@ where
     K: redis::ToRedisArgs + Copy + Send + Sync,
     V: redis::FromRedisValue + Send + Sync,
 {
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         if let Ok(res) = redis_connection.get::<K, V>(key).await {
             return Some(res);
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            config.redis.query_retry_sleep_secs,
+        ))
+        .await;
     }
 
     warn!("Failed to get last processed block from redis db");
@@ -80,6 +83,7 @@ where
 }
 
 pub async fn update_last_processed<K, V>(
+    config: &config::Config,
     redis_connection: &mut MultiplexedConnection,
     key: K,
     value: V,
@@ -87,22 +91,26 @@ pub async fn update_last_processed<K, V>(
     K: redis::ToRedisArgs + Copy + Send + Sync,
     V: redis::ToRedisArgs + Copy + Send + Sync,
 {
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         if redis_connection.set::<K, V, ()>(key, value).await.is_ok() {
             return;
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            config.redis.query_retry_sleep_secs,
+        ))
+        .await;
     }
 
     warn!("Failed to update last processed block in redis db");
 }
 
 pub async fn get_events(
+    config: &config::Config,
     redis_connection: &mut MultiplexedConnection,
     key: String,
 ) -> Option<Vec<(String, String)>> {
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         if let Ok(mut iter) = redis_connection
             .hscan::<String, (String, String)>(key.clone())
             .await
@@ -116,7 +124,10 @@ pub async fn get_events(
             return Some(events);
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            config.redis.query_retry_sleep_secs,
+        ))
+        .await;
     }
 
     warn!("Failed to get events from redis db");
@@ -124,6 +135,7 @@ pub async fn get_events(
 }
 
 pub async fn add_event<F, E>(
+    config: &config::Config,
     redis_connection: &mut MultiplexedConnection,
     key: &str,
     field: F,
@@ -137,7 +149,7 @@ pub async fn add_event<F, E>(
         return;
     };
 
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         if redis_connection
             .hset::<&str, F, String, ()>(key, field.clone(), serialized_event.clone())
             .await
@@ -146,17 +158,24 @@ pub async fn add_event<F, E>(
             return;
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            config.redis.query_retry_sleep_secs,
+        ))
+        .await;
     }
 
     warn!("Failed to add event to redis db");
 }
 
-pub async fn remove_event<F>(redis_connection: &mut MultiplexedConnection, key: &str, field: F)
-where
+pub async fn remove_event<F>(
+    config: &config::Config,
+    redis_connection: &mut MultiplexedConnection,
+    key: &str,
+    field: F,
+) where
     F: redis::ToRedisArgs + Clone + Send + Sync,
 {
-    for _ in 0..QUERY_RETRY_ATTEMPTS {
+    for _ in 0..config.redis.query_retry_attempts {
         if redis_connection
             .hdel::<&str, F, ()>(key, field.clone())
             .await
@@ -165,7 +184,10 @@ where
             return;
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(QUERY_RETRY_SLEEP_SECS)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(
+            config.redis.query_retry_sleep_secs,
+        ))
+        .await;
     }
 
     warn!("Failed to remove event from redis db");

--- a/omni-relayer/src/utils/solana.rs
+++ b/omni-relayer/src/utils/solana.rs
@@ -23,6 +23,7 @@ struct InitTransferPayload {
 }
 
 pub async fn process_message(
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     solana: &config::Solana,
     transaction: &EncodedTransactionWithStatusMeta,
@@ -37,6 +38,7 @@ pub async fn process_message(
             .collect::<Vec<_>>();
 
         if let Err(err) = decode_instruction(
+            config,
             redis_connection,
             solana,
             signature,
@@ -52,6 +54,7 @@ pub async fn process_message(
 }
 
 async fn decode_instruction(
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     solana: &config::Solana,
     signature: Signature,
@@ -153,6 +156,7 @@ async fn decode_instruction(
                         };
 
                         utils::redis::add_event(
+                            config,
                             redis_connection,
                             utils::redis::EVENTS,
                             signature.to_string(),
@@ -218,6 +222,7 @@ async fn decode_instruction(
                     };
 
                     utils::redis::add_event(
+                        config,
                         redis_connection,
                         utils::redis::EVENTS,
                         signature.to_string(),
@@ -252,6 +257,7 @@ async fn decode_instruction(
                     };
 
                     utils::redis::add_event(
+                        config,
                         redis_connection,
                         utils::redis::EVENTS,
                         signature.to_string(),

--- a/omni-relayer/src/workers/evm.rs
+++ b/omni-relayer/src/workers/evm.rs
@@ -26,7 +26,7 @@ use super::{EventAction, Transfer};
 
 #[allow(clippy::too_many_lines)]
 pub async fn process_init_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     omni_connector: Arc<OmniConnector>,
     jsonrpc_client: near_jsonrpc_client::JsonRpcClient,
@@ -53,7 +53,7 @@ pub async fn process_init_transfer_event(
     }
 
     if current_timestamp - last_update_timestamp.unwrap_or_default()
-        < utils::redis::CHECK_INSUFFICIENT_FEE_TRANSFERS_EVERY_SECS
+        < config.redis.check_insufficient_fee_transfers_every_secs
     {
         return Ok(EventAction::Retry);
     }
@@ -154,18 +154,10 @@ pub async fn process_init_transfer_event(
 
             if block_number > light_client_latest_block_number {
                 warn!("ETH light client is not synced yet");
-                tokio::time::sleep(tokio::time::Duration::from_secs(
-                    utils::redis::SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS,
-                ))
-                .await;
                 return Ok(EventAction::Retry);
             }
         } else {
             warn!("VAA is not ready yet");
-            tokio::time::sleep(tokio::time::Duration::from_secs(
-                utils::redis::SLEEP_TIME_AFTER_EVENTS_PROCESS_SECS,
-            ))
-            .await;
             return Ok(EventAction::Retry);
         }
     }
@@ -293,7 +285,7 @@ pub async fn process_init_transfer_event(
 }
 
 pub async fn process_evm_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     omni_connector: Arc<OmniConnector>,
     jsonrpc_client: JsonRpcClient,
     fin_transfer: FinTransfer,
@@ -388,7 +380,7 @@ pub async fn process_evm_transfer_event(
         }
         Err(err) => {
             if current_timestamp - creation_timestamp
-                > utils::redis::KEEP_INSUFFICIENT_FEE_TRANSFERS_FOR
+                > config.redis.keep_insufficient_fee_transfers_for
             {
                 anyhow::bail!("Transfer is too old");
             }
@@ -412,7 +404,7 @@ pub async fn process_evm_transfer_event(
 }
 
 pub async fn process_deploy_token_event(
-    config: config::Config,
+    config: &config::Config,
     omni_connector: Arc<OmniConnector>,
     jsonrpc_client: JsonRpcClient,
     deploy_token_event: DeployToken,
@@ -502,7 +494,7 @@ pub async fn process_deploy_token_event(
         }
         Err(err) => {
             if current_timestamp - creation_timestamp
-                > utils::redis::KEEP_INSUFFICIENT_FEE_TRANSFERS_FOR
+                > config.redis.keep_insufficient_fee_transfers_for
             {
                 anyhow::bail!("Transfer is too old");
             }

--- a/omni-relayer/src/workers/evm.rs
+++ b/omni-relayer/src/workers/evm.rs
@@ -102,7 +102,7 @@ pub async fn process_init_transfer_event(
                 })?;
 
         let Ok(needed_fee) = utils::bridge_api::TransferFee::get_transfer_fee(
-            &config,
+            config,
             &sender,
             &log.recipient,
             &token,
@@ -120,7 +120,7 @@ pub async fn process_init_transfer_event(
 
         if let Some(event_action) = needed_fee
             .check_fee(
-                &config,
+                config,
                 redis_connection,
                 &transfer,
                 transfer_id,
@@ -341,7 +341,7 @@ pub async fn process_evm_transfer_event(
     }
 
     let Some(prover_args) = utils::evm::construct_prover_args(
-        &config,
+        config,
         vaa,
         transaction_hash,
         H256::from_slice(topic.as_slice()),
@@ -460,7 +460,7 @@ pub async fn process_deploy_token_event(
     }
 
     let Some(prover_args) = utils::evm::construct_prover_args(
-        &config,
+        config,
         vaa,
         transaction_hash,
         H256::from_slice(topic.as_slice()),

--- a/omni-relayer/src/workers/near.rs
+++ b/omni-relayer/src/workers/near.rs
@@ -80,7 +80,7 @@ pub async fn process_transfer_event(
             .is_some_and(|list| list.contains(&transfer_message.sender))
     {
         let Ok(needed_fee) = utils::bridge_api::TransferFee::get_transfer_fee(
-            &config,
+            config,
             &transfer_message.sender,
             &transfer_message.recipient,
             &transfer_message.token,
@@ -93,7 +93,7 @@ pub async fn process_transfer_event(
 
         if let Some(event_action) = needed_fee
             .check_fee(
-                &config,
+                config,
                 redis_connection,
                 &transfer_message,
                 transfer_message.get_transfer_id(),
@@ -250,7 +250,7 @@ pub async fn process_sign_transfer_event(
         };
 
         let Ok(needed_fee) = utils::bridge_api::TransferFee::get_transfer_fee(
-            &config,
+            config,
             &transfer_message.sender,
             &transfer_message.recipient,
             &transfer_message.token,
@@ -263,7 +263,7 @@ pub async fn process_sign_transfer_event(
 
         if let Some(event_action) = needed_fee
             .check_fee(
-                &config,
+                config,
                 redis_connection,
                 &transfer_message,
                 transfer_message.get_transfer_id(),

--- a/omni-relayer/src/workers/near.rs
+++ b/omni-relayer/src/workers/near.rs
@@ -29,7 +29,7 @@ pub struct UnverifiedTrasfer {
 }
 
 pub async fn process_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     key: String,
     omni_connector: Arc<OmniConnector>,
@@ -49,7 +49,7 @@ pub async fn process_transfer_event(
     let current_timestamp = chrono::Utc::now().timestamp();
 
     if current_timestamp - last_update_timestamp.unwrap_or_default()
-        < utils::redis::CHECK_INSUFFICIENT_FEE_TRANSFERS_EVERY_SECS
+        < config.redis.check_insufficient_fee_transfers_every_secs
     {
         return Ok(EventAction::Retry);
     }
@@ -128,6 +128,7 @@ pub async fn process_transfer_event(
     {
         Ok(tx_hash) => {
             utils::redis::add_event(
+                config,
                 redis_connection,
                 utils::redis::EVENTS,
                 tx_hash.to_string(),
@@ -153,7 +154,7 @@ pub async fn process_transfer_event(
         }
         Err(err) => {
             if current_timestamp - creation_timestamp
-                > utils::redis::KEEP_INSUFFICIENT_FEE_TRANSFERS_FOR
+                > config.redis.keep_insufficient_fee_transfers_for
             {
                 anyhow::bail!("Transfer ({}) is too old", transfer_message.origin_nonce);
             }
@@ -186,7 +187,7 @@ pub async fn process_transfer_event(
 }
 
 pub async fn process_sign_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     omni_connector: Arc<OmniConnector>,
     signer: AccountId,
@@ -342,11 +343,13 @@ pub async fn process_sign_transfer_event(
 }
 
 pub async fn process_unverified_transfer_event(
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     jsonrpc_client: JsonRpcClient,
     unverified_event: UnverifiedTrasfer,
 ) {
     utils::redis::remove_event(
+        config,
         redis_connection,
         utils::redis::EVENTS,
         unverified_event.tx_hash.to_string(),
@@ -362,6 +365,7 @@ pub async fn process_unverified_transfer_event(
     .await
     {
         utils::redis::add_event(
+            config,
             redis_connection,
             utils::redis::EVENTS,
             unverified_event.original_key,

--- a/omni-relayer/src/workers/solana.rs
+++ b/omni-relayer/src/workers/solana.rs
@@ -79,7 +79,7 @@ pub async fn process_init_transfer_event(
             })?;
 
         let Ok(needed_fee) =
-            utils::bridge_api::TransferFee::get_transfer_fee(&config, sender, recipient, &token)
+            utils::bridge_api::TransferFee::get_transfer_fee(config, sender, recipient, &token)
                 .await
         else {
             warn!("Failed to get transfer fee for transfer: {transfer:?}");
@@ -93,7 +93,7 @@ pub async fn process_init_transfer_event(
 
         if let Some(event_action) = needed_fee
             .check_fee(
-                &config,
+                config,
                 redis_connection,
                 &transfer,
                 transfer_id,

--- a/omni-relayer/src/workers/solana.rs
+++ b/omni-relayer/src/workers/solana.rs
@@ -20,7 +20,7 @@ use crate::{config, utils};
 use super::{DeployToken, EventAction, FinTransfer, Transfer};
 
 pub async fn process_init_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     redis_connection: &mut redis::aio::MultiplexedConnection,
     key: String,
     omni_connector: Arc<OmniConnector>,
@@ -48,7 +48,7 @@ pub async fn process_init_transfer_event(
     let current_timestamp = chrono::Utc::now().timestamp();
 
     if current_timestamp - last_update_timestamp.unwrap_or_default()
-        < utils::redis::CHECK_INSUFFICIENT_FEE_TRANSFERS_EVERY_SECS
+        < config.redis.check_insufficient_fee_transfers_every_secs
     {
         return Ok(EventAction::Retry);
     }
@@ -131,8 +131,14 @@ pub async fn process_init_transfer_event(
     {
         Ok(actions) => actions,
         Err(err) => {
-            utils::redis::add_event(redis_connection, utils::redis::STUCK_EVENTS, &key, transfer)
-                .await;
+            utils::redis::add_event(
+                config,
+                redis_connection,
+                utils::redis::STUCK_EVENTS,
+                &key,
+                transfer,
+            )
+            .await;
             anyhow::bail!("Failed to get storage deposit actions: {}", err);
         }
     };
@@ -179,7 +185,7 @@ pub async fn process_init_transfer_event(
 }
 
 pub async fn process_fin_transfer_event(
-    config: config::Config,
+    config: &config::Config,
     omni_connector: Arc<OmniConnector>,
     fin_transfer: FinTransfer,
     near_nonce: Arc<utils::nonce::NonceManager>,
@@ -250,7 +256,7 @@ pub async fn process_fin_transfer_event(
 }
 
 pub async fn process_deploy_token_event(
-    config: config::Config,
+    config: &config::Config,
     omni_connector: Arc<OmniConnector>,
     deploy_token_event: DeployToken,
     near_nonce: Arc<utils::nonce::NonceManager>,


### PR DESCRIPTION
This feature is needed to prevent double signing from omni relayer and satoshi relayer. Normally satoshi's relayer would sign a transaction, but if their relayer will have any issues, we can manually allow our relayer to sign transactions