### PR TITLE
fix: config env replacement

### DIFF
--- a/omni-relayer/Cargo.lock
+++ b/omni-relayer/Cargo.lock
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "omni-relayer"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "alloy",
  "anyhow",

--- a/omni-relayer/Cargo.toml
+++ b/omni-relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-relayer"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2024"
 resolver = "2"
 repository = "https://github.com/Near-One/omni-bridge"

--- a/omni-relayer/src/config.rs
+++ b/omni-relayer/src/config.rs
@@ -70,7 +70,6 @@ where
     for key in ["INFURA_API_KEY", "TATUM_API_KEY", "FASTNEAR_API_KEY"] {
         if let Ok(val) = std::env::var(key) {
             url = url.replace(key, &val);
-            break;
         }
     }
 


### PR DESCRIPTION
Break would've worked if we somehow checked that `replace` operation was successful, but `replace` method doesn't return anything. Instead, we're just checking that env variable is there, which is incorrect. Let's say we want to replace `TATUM_API_KEY`. Right now we will just retrieve `INFURA_API_KEY` from env since it's first in the loop, replace nothing and break, leaving other api placeholders untouched
