### PR TITLE
Add the ability to increase gas for Bitcoin transactions

### DIFF
--- a/near/omni-bridge/src/btc.rs
+++ b/near/omni-bridge/src/btc.rs
@@ -1,13 +1,14 @@
 use crate::storage::NEP141_DEPOSIT;
 use crate::{
-    ext_token, ext_utxo_connector, Contract, ContractExt, Role, FT_TRANSFER_CALL_GAS, ONE_YOCTO, STORAGE_DEPOSIT_GAS,
+    ext_token, ext_utxo_connector, Contract, ContractExt, Role, FT_TRANSFER_CALL_GAS, ONE_YOCTO,
+    STORAGE_DEPOSIT_GAS,
 };
 use near_plugins::{access_control_any, pause, AccessControllable, Pausable};
 use near_sdk::json_types::U128;
 use near_sdk::{
     env, near, require, serde_json, AccountId, Gas, Promise, PromiseError, PromiseOrValue,
 };
-use omni_types::btc::{TokenReceiverMessage, UTXOChainConfig, TxOut};
+use omni_types::btc::{TokenReceiverMessage, TxOut, UTXOChainConfig};
 use omni_types::{ChainKind, Fee, OmniAddress, TransferId, TransferMessage};
 
 const SUBMIT_TRANSFER_TO_BTC_CONNECTOR_CALLBACK_GAS: Gas = Gas::from_tgas(5);
@@ -154,7 +155,12 @@ impl Contract {
     }
 
     #[access_control_any(roles(Role::DAO, Role::RbfOperator))]
-    pub fn rbf_increase_gas_fee(&self, chain_kind: ChainKind, original_btc_pending_verify_id: String, output: Vec<TxOut>) -> Promise {
+    pub fn rbf_increase_gas_fee(
+        &self,
+        chain_kind: ChainKind,
+        original_btc_pending_verify_id: String,
+        output: Vec<TxOut>,
+    ) -> Promise {
         ext_utxo_connector::ext(self.get_utxo_chain_connector(chain_kind))
             .with_static_gas(WITHDRAW_RBF_GAS)
             .withdraw_rbf(original_btc_pending_verify_id, output)

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -16,7 +16,7 @@ use near_sdk::{
     env, ext_contract, near, require, serde_json, AccountId, BorshStorageKey, CryptoHash, Gas,
     GasWeight, NearToken, PanicOnDefault, Promise, PromiseError, PromiseOrValue, PromiseResult,
 };
-use omni_types::btc::{UTXOChainConfig, TxOut};
+use omni_types::btc::{TxOut, UTXOChainConfig};
 use omni_types::locker_args::{
     AddDeployedTokenArgs, BindTokenArgs, ClaimFeeArgs, DeployTokenArgs, FinTransferArgs,
     StorageDepositAction,


### PR DESCRIPTION
I haven’t tested it yet. I checked, basically all the necessary checks are already in btc_connector. The only thing we don’t check is max_gas.

We could also add a check to make sure gas isn’t increased too often, so as not to exceed the limit.