### PR TITLE
E2E tests: add the ability to run tests for deployed contracts.

### DIFF
--- a/e2e-testing/bridge-sdk-config.example.json
+++ b/e2e-testing/bridge-sdk-config.example.json
@@ -1,6 +1,6 @@
 {
     "near_rpc": "https://test.rpc.fastnear.com",
-    "near_token_locker_id": "omni-locker.testnet",
+    "near_token_locker_id": "omni.n-bridge.testnet",
     "near_light_client_eth_address": "0x202cdf10bfa45a3d2190901373edd864f071d707",
     "near_signer": "omni-sender.testnet",
     "near_private_key": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -21,5 +21,6 @@
     "eth_rpc": "<ETH_RPC>",
     "eth_private_key": "<ETH_PRIVATE_KEY>",
     "base_private_key": "<ETH_PRIVATE_KEY>",
-    "arb_private_key": "<ETH_PRIVATE_KEY>"
+    "arb_private_key": "<ETH_PRIVATE_KEY>",
+    "btc": "nbtc.n-bridge.testnet"
 }

--- a/e2e-testing/snakefiles/04_btc_transfer.smk
+++ b/e2e-testing/snakefiles/04_btc_transfer.smk
@@ -249,6 +249,18 @@ rule send_btc_transfer:
     > {output} \
     """
 
+rule get_btc_tx_hash_from_logs:
+    message: "Get BTC transaction hash from logs"
+    input:
+        prev_step = call_dir / "04_ft_transfer_btc_to_omni_bridge.json",
+    output: call_dir / "btc_tx_hash_from_logs.json"
+    params:
+        scripts_dir = const.common_scripts_dir,
+        near_tx_hash = lambda wc, input: get_json_field(input.prev_step, "tx_hash"),
+    shell: """
+    node {params.scripts_dir}/get_btc_tx_from_logs.js {params.near_tx_hash} {output}
+    """
+
 rule all:
     input:
         const.common_generated_dir / "04-btc-transfer-test" / "07_send_btc_transfer.json",
@@ -256,4 +268,4 @@ rule all:
 
 rule btc_transfer_default_contracts:
     input:
-        const.common_generated_dir / "04-btc-transfer-default" / "04_ft_transfer_btc_to_omni_bridge.json",
+        const.common_generated_dir / "04-btc-transfer-default" / "btc_tx_hash_from_logs.json",

--- a/e2e-testing/snakefiles/04_btc_transfer.smk
+++ b/e2e-testing/snakefiles/04_btc_transfer.smk
@@ -261,6 +261,19 @@ rule get_btc_tx_hash_from_logs:
     node {params.scripts_dir}/get_btc_tx_from_logs.js {params.near_tx_hash} {output}
     """
 
+rule wait_final_tx:
+    message: "Wait for Final BTC transaction"
+    input:
+        prev_step = call_dir / "btc_tx_hash_from_logs.json",
+    output: call_dir / "wait_final_tx.json"
+    params:
+        scripts_dir = const.common_scripts_dir,
+        btc_tx_hash = lambda wc, input: get_json_field(input.prev_step, "btc_pending_sign_id"),
+    shell: """
+    node {params.scripts_dir}/wait_btc.js {params.btc_tx_hash} {output}
+    """
+
+
 rule all:
     input:
         const.common_generated_dir / "04-btc-transfer-test" / "07_send_btc_transfer.json",
@@ -268,4 +281,4 @@ rule all:
 
 rule btc_transfer_default_contracts:
     input:
-        const.common_generated_dir / "04-btc-transfer-default" / "btc_tx_hash_from_logs.json",
+        const.common_generated_dir / "04-btc-transfer-default" / "wait_final_tx.json",

--- a/e2e-testing/snakefiles/04_btc_transfer.smk
+++ b/e2e-testing/snakefiles/04_btc_transfer.smk
@@ -11,7 +11,7 @@ module btc_setup:
 use rule * from btc_setup
 
 # Directories
-call_dir = const.common_generated_dir / "04-btc-transfer"
+call_dir = const.common_generated_dir / "04-btc-transfer-{mode}"
 
 # Account files
 near_init_account_file = const.near_account_dir / f"{NTA.INIT_ACCOUNT}.json"
@@ -24,25 +24,37 @@ btc_connector_file = const.near_deploy_results_dir / f"btc_connector.json"
 rule get_btc_user_deposit_address:
     message: "Get BTC user deposit address"
     input:
-        rules.sync_btc_connector.output,
-        btc_connector_file = btc_connector_file,
         user_account_file = user_account_file
-    output: call_dir / "01_btc_user_deposit_address.json"
+    output:
+        call_dir / "01_btc_user_deposit_address.json"
     params:
-        mkdir = get_mkdir_cmd(call_dir),
-        btc_connector = lambda wc, input: get_json_field(input.btc_connector_file, "contract_id"),
-        user_account_id = lambda wc, input: get_json_field(input.user_account_file, "account_id"),
-        bridge_sdk_config_file = const.common_bridge_sdk_config_file
+        mkdir = lambda wc: get_mkdir_cmd(call_dir),
+        bridge_sdk_config_file = const.common_bridge_sdk_config_file,
+        btc_connector_arg = "",
+        user_account_id = lambda wc, input: get_json_field(input.user_account_file, "account_id")
     shell: """
     {params.mkdir} && \
-         bridge-cli testnet get-bitcoin-address \
-         --chain btc \
-         --btc-connector {params.btc_connector} \
-         -r near:{params.user_account_id} \
-         --near-signer {params.user_account_id} \
-         --config {params.bridge_sdk_config_file} \
-         > {output} \
+    bridge-cli testnet get-bitcoin-address \
+      --chain btc \
+      {params.btc_connector_arg} \
+      -r near:{params.user_account_id} \
+      --amount 0 \
+      --near-signer {params.user_account_id} \
+      --config {params.bridge_sdk_config_file} \
+      > {output}
     """
+
+use rule get_btc_user_deposit_address as get_btc_user_deposit_address_test with:
+    wildcard_constraints:
+        mode = "test"
+    input:
+        rules.sync_btc_connector.output,
+        btc_connector_file = btc_connector_file,
+    params:
+        btc_connector_arg = lambda wc, input: (
+            f"--btc-connector {get_json_field(input.btc_connector_file, 'contract_id')}"
+        ),
+
 
 rule send_btc_to_deposit_address:
     message: "Send BTC to user deposit address on Bitcoin"
@@ -60,12 +72,10 @@ rule fin_btc_transfer_on_near:
     message: "Finalizing BTC transfer on Near"
     input:
         step_2 = rules.send_btc_to_deposit_address.output,
-        nbtc_file = nbtc_file,
-        btc_connector_file = btc_connector_file,
         user_account_file = user_account_file
     output: call_dir / "03_fin_btc_transfer_on_near.json"
     params:
-        btc_connector = lambda wc, input: get_json_field(input.btc_connector_file, "contract_id"),
+        btc_connector_arg = "",
         user_account_id = lambda wc, input: get_json_field(input.user_account_file, "account_id"),
         user_private_key = lambda wc, input: get_json_field(input.user_account_file, "private_key"),
         bridge_sdk_config_file = const.common_bridge_sdk_config_file,
@@ -76,27 +86,36 @@ rule fin_btc_transfer_on_near:
         -b {params.btc_tx_hash} \
         -v 0 \
         -r near:{params.user_account_id} \
-        --btc-connector {params.btc_connector} \
+        {params.btc_connector_arg} \
         --near-signer {params.user_account_id} \
         --near-private-key {params.user_private_key} \
         --config {params.bridge_sdk_config_file} \
          > {output} \
     """
 
+use rule fin_btc_transfer_on_near as fin_btc_transfer_on_near_test with:
+    wildcard_constraints:
+        mode = "test"
+    input:
+        nbtc_file = nbtc_file,
+        btc_connector_file = btc_connector_file,
+    params:
+        btc_connector_arg = lambda wc, input: (
+            f"--btc-connector {get_json_field(input.btc_connector_file, 'contract_id')}"
+        ),
+
+
 rule ft_transfer_btc_to_omni_bridge:
     message: "Init BTC transfer to OmniBridge on Near"
     input:
-        add_utxo_chain = rules.add_utxo_chain_connector.output,
-        omni_bridge_storage_deposit = rules.omni_bridge_storage_deposit.output,
-        step_3 = rules.fin_btc_transfer_on_near.output,
-        nbtc_file = nbtc_file,
-        omni_bridge_file = omni_bridge_file,
+        step_3 =  call_dir / "03_fin_btc_transfer_on_near.json",
+        omni_bridge_storage_deposit = call_dir / "omni_bridge_storage_deposit.json",
         user_account_file = user_account_file,
     output: call_dir / "04_ft_transfer_btc_to_omni_bridge.json"
     params:
         scripts_dir = const.common_scripts_dir,
-        nbtc_account = lambda wc, input: get_json_field(input.nbtc_file, "contract_id"),
-        omni_bridge_account = lambda wc, input: get_json_field(input.omni_bridge_file, "contract_id"),
+        nbtc_account = lambda wc, input: get_json_field(const.common_bridge_sdk_config_file, "btc"),
+        omni_bridge_account = lambda wc, input: get_json_field(const.common_bridge_sdk_config_file, "near_token_locker_id"),
     shell: """
     {params.scripts_dir}/call-near-contract.sh -c {params.nbtc_account} \
         -m ft_transfer_call \
@@ -107,6 +126,19 @@ rule ft_transfer_btc_to_omni_bridge:
         TX_HASH=$(grep -o 'Transaction ID: [^ ]*' {output} | cut -d' ' -f3) && \
         echo '{{\"tx_hash\": \"'$TX_HASH'\", \"contract_id\": \"{params.nbtc_account}\"}}' > {output}
     """
+
+use rule ft_transfer_btc_to_omni_bridge as ft_transfer_btc_to_omni_bridge_test with:
+    wildcard_constraints:
+        mode = "test"
+    input:
+        add_utxo_chain = rules.add_utxo_chain_connector.output,
+        nbtc_file = nbtc_file,
+        omni_bridge_file = omni_bridge_file,
+        btc_connector_file = btc_connector_file,
+    params:
+        nbtc_account = lambda wc, input: get_json_field(input.nbtc_file, "contract_id"),
+        omni_bridge_account = lambda wc, input: get_json_field(input.omni_bridge_file, "contract_id"),
+
 
 rule submit_transfer_to_btc_connector:
     message: "Sign BTC transfer on OmniBridge"
@@ -185,5 +217,9 @@ rule send_btc_transfer:
 
 rule all:
     input:
-        rules.send_btc_transfer.output,
+        const.common_generated_dir / "04-btc-transfer-test" / "07_send_btc_transfer.json",
     default_target: True
+
+rule btc_transfer_default_contracts:
+    input:
+        const.common_generated_dir / "04-btc-transfer-default" / "04_ft_transfer_btc_to_omni_bridge.json",

--- a/e2e-testing/snakefiles/btc_setup.smk
+++ b/e2e-testing/snakefiles/btc_setup.smk
@@ -151,13 +151,12 @@ rule add_omni_bridge_to_whitelist:
 rule omni_bridge_storage_deposit:
     message: "Depositing storage for User on Omni Bridge"
     input:
-        omni_bridge_contract_file = omni_bridge_file,
         user_account_file = user_account_file
     output:
-        const.common_generated_dir / "omni_bridge_storage_deposit.json"
+        const.common_generated_dir / "{test_id}-{mode}" / "omni_bridge_storage_deposit.json"
     params:
         scripts_dir = const.common_scripts_dir,
-        omni_bridge_address = lambda wc, input: get_json_field(input.omni_bridge_contract_file, "contract_id"),
+        omni_bridge_address = lambda wc, input: get_json_field(const.common_bridge_sdk_config_file, "near_token_locker_id"),
         user_account_id = lambda wc, input: get_json_field(input.user_account_file, "account_id"),
         extract_tx = lambda wc, output: extract_tx_hash("near", output)
     shell: """
@@ -169,3 +168,13 @@ rule omni_bridge_storage_deposit:
         -n testnet 2>&1 | tee {output} && \
         {params.extract_tx}
     """
+
+use rule omni_bridge_storage_deposit as omni_bridge_storage_deposit_test with:
+    wildcard_constraints:
+        mode = "test"
+    input:
+        omni_bridge_contract_file = omni_bridge_file,
+        btc_connector_file = btc_connector_file,
+    params:
+        omni_bridge_address = lambda wc, input: get_json_field(input.omni_bridge_contract_file, "contract_id"),
+

--- a/e2e-testing/snakefiles/btc_setup.smk
+++ b/e2e-testing/snakefiles/btc_setup.smk
@@ -149,6 +149,8 @@ rule add_omni_bridge_to_whitelist:
     """
 
 rule omni_bridge_storage_deposit:
+    wildcard_constraints:
+        mode = "default"
     message: "Depositing storage for User on Omni Bridge"
     input:
         user_account_file = user_account_file
@@ -175,6 +177,10 @@ use rule omni_bridge_storage_deposit as omni_bridge_storage_deposit_test with:
     input:
         omni_bridge_contract_file = omni_bridge_file,
         btc_connector_file = btc_connector_file,
+        user_account_file = user_account_file
     params:
         omni_bridge_address = lambda wc, input: get_json_field(input.omni_bridge_contract_file, "contract_id"),
+        scripts_dir = const.common_scripts_dir,
+        user_account_id = lambda wc, input: get_json_field(input.user_account_file, "account_id"),
+        extract_tx = lambda wc, output: extract_tx_hash("near", output)
 

--- a/e2e-testing/snakefiles/evm.smk
+++ b/e2e-testing/snakefiles/evm.smk
@@ -47,7 +47,7 @@ def get_mkdir_cmd(wildcards):
     return f"mkdir -p {get_evm_deploy_results_dir(wildcards.network)}"
 
 def get_full_path(file_name):
-    return f"{get_evm_deploy_results_dir("{network}")}/{file_name}"
+    return f"{get_evm_deploy_results_dir('{network}')}/{file_name}"
 
 
 # Rule to deploy all networks

--- a/e2e-testing/tools/src/scripts/get_btc_tx_from_logs.js
+++ b/e2e-testing/tools/src/scripts/get_btc_tx_from_logs.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const axios = require("axios");
+
+const BRIDGE_BASE =
+  "https://testnet.api.bridge.nearone.org/api/v2/transfers/transfer";
+const NEAR_RPC = "https://rpc.testnet.near.org";
+
+async function fetchBridgeTransfer(txHashNear) {
+  const url = `${BRIDGE_BASE}?transaction_hash=${txHashNear}`;
+  const { data } = await axios.get(url);
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error("Bridge API: empty response");
+  }
+  return data[0];
+}
+
+async function fetchNearTx(txHash, signerId) {
+  const body = {
+    jsonrpc: "2.0",
+    id: "dontcare",
+    method: "EXPERIMENTAL_tx_status",
+    params: [txHash, signerId],
+  };
+  const { data } = await axios.post(NEAR_RPC, body, {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (data.error) {
+    throw new Error(
+      `NEAR RPC error: ${data.error.code} ${data.error.message}`,
+    );
+  }
+  return data.result;
+}
+
+function extractBtcPendingSignId(txResult) {
+  const receipts = txResult.receipts || [];
+  for (const r of receipts) {
+    const actions = r?.receipt?.Action?.actions || [];
+    for (const action of actions) {
+      if (!action.FunctionCall) continue;
+      const fc = action.FunctionCall;
+      const decoded = Buffer.from(fc.args, "base64").toString("utf-8");
+      let parsed;
+      try {
+        parsed = JSON.parse(decoded);
+      } catch (_) {
+        continue;
+      }
+      if (parsed.btc_pending_sign_id) {
+        return parsed.btc_pending_sign_id;
+      }
+    }
+  }
+  return null;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(
+      "Usage: node get_btc_pending_sign_id.js <near_tx_hash> <output_json>",
+    );
+    process.exit(1);
+  }
+
+  const [initTxHash, outputPath] = args;
+
+  console.log(
+    `[1/3] Fetching bridge transfer by initial tx: ${initTxHash} ...`,
+  );
+  const transfer = await fetchBridgeTransfer(initTxHash);
+
+  const signedTxHash =
+    transfer?.signed?.NearReceipt?.transaction_hash ||
+    transfer?.signed?.Near?.transaction_hash;
+  if (!signedTxHash) {
+    throw new Error("No signed transaction hash in bridge transfer");
+  }
+
+  const signerId = transfer?.utxo_transfer?.sender;
+  if (!signerId) {
+    throw new Error("No sender account_id in transfer.utxo_transfer.sender");
+  }
+
+  console.log(
+    `[2/3] Fetching NEAR tx ${signedTxHash} (signer: ${signerId}) ...`,
+  );
+  const nearTx = await fetchNearTx(signedTxHash, signerId);
+
+  console.log("[3/3] Extracting btc_pending_sign_id ...");
+  const btcPendingSignId = extractBtcPendingSignId(nearTx);
+
+  if (!btcPendingSignId) {
+    console.error("btc_pending_sign_id not found in transaction actions");
+  }
+
+  const result = { btc_pending_sign_id: btcPendingSignId };
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+  console.log(`✅ Written to ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/e2e-testing/tools/src/scripts/wait_btc.js
+++ b/e2e-testing/tools/src/scripts/wait_btc.js
@@ -48,6 +48,7 @@ async function waitForConfirmations(txid, outputPath) {
           JSON.stringify({ txid, confirmations: confs }, null, 2),
         );
 
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
         console.log(`Result saved to: ${outputPath}`);
         return;
       }

--- a/e2e-testing/tools/src/scripts/wait_btc.js
+++ b/e2e-testing/tools/src/scripts/wait_btc.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const axios = require("axios");
+
+const REQUIRED_CONFIRMATIONS = 3;
+const POLL_INTERVAL = 30_000; // 30 seconds
+
+async function getTipHeight() {
+  const res = await axios.get(`https://blockstream.info/testnet/api/blocks/tip/height`);
+  return Number(res.data);
+}
+
+async function getConfirmations(txid) {
+  const url = `https://blockstream.info/testnet/api/tx/${txid}`;
+  const res = await axios.get(url);
+  const data = res.data;
+  const tipHeight = await getTipHeight();
+
+  if (data && data.status) {
+    if (data.status.confirmed) {
+      return tipHeight - data.status.block_height + 1;
+    } else {
+      return 0;
+    }
+  }
+  return 0;
+}
+
+async function waitForConfirmations(txid, outputPath) {
+  console.log(
+    `Waiting for BTC transaction ${txid} to reach ${REQUIRED_CONFIRMATIONS} confirmations...`,
+  );
+
+  while (true) {
+    try {
+      const confs = await getConfirmations(txid);
+      console.log(
+        `[${new Date().toISOString()}] confirmations = ${confs}`,
+      );
+
+      if (confs >= REQUIRED_CONFIRMATIONS) {
+        console.log(
+          `✅ Transaction ${txid} has ${confs} confirmations!`,
+        );
+
+        fs.writeFileSync(
+          outputPath,
+          JSON.stringify({ txid, confirmations: confs }, null, 2),
+        );
+
+        console.log(`Result saved to: ${outputPath}`);
+        return;
+      }
+    } catch (err) {
+      console.error(
+        `[${new Date().toISOString()}] Error fetching tx: ${err.message}`,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error("Usage: node wait_btc_confirmations.js <txid> <output_json>");
+    process.exit(1);
+  }
+
+  const [txid, outputPath] = args;
+
+  if (!txid) {
+    console.error("Error: txid is empty");
+    process.exit(1);
+  }
+
+  await waitForConfirmations(txid, outputPath);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
So far, I’ve only modified one test: the BTC <-> NEAR transfer.
* Waiting for a sufficient number of Bitcoin transaction confirmations.
* Running for the default contracts and verifying the results via the API.