### PR TITLE
feat(tests): covered `ChainKind`/`OmniAddress` enum stability

### DIFF
--- a/near/omni-types/src/tests/lib_test.rs
+++ b/near/omni-types/src/tests/lib_test.rs
@@ -115,10 +115,7 @@ fn test_omni_address_borsh_discriminants_are_stable() {
 #[test]
 fn test_omni_address_borsh_variants_are_covered() {
     let addresses = omni_addresses_for_borsh();
-    let mut covered_chains: Vec<ChainKind> = addresses
-        .iter()
-        .map(|address| address.get_chain())
-        .collect();
+    let mut covered_chains: Vec<ChainKind> = addresses.iter().map(OmniAddress::get_chain).collect();
 
     covered_chains.sort_unstable();
     covered_chains.dedup();


### PR DESCRIPTION
Recently, I've accidentally put `Pol` variant in the middle of `OmniAddress` which resulted to corrupted state and [separate fix](https://github.com/Near-One/omni-bridge/pull/498) had to be implemented. So in order to catch same mistake in the future we can check that the current schema is correct. The only downside of this test case is that we need to remember to update it after every new variant, but I'm not sure how to do it without this
