### PR TITLE
ci: use WarpBuild cache provider for faster Rust CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -39,10 +39,13 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: warpbuild
+          shared-key: "rust-lint"
           workspaces: |
             near
             omni-relayer
           cache-on-failure: true
+          cache-all-crates: true
 
       - name: Install cargo-near
         run: |
@@ -76,11 +79,14 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: warpbuild
+          shared-key: "rust-build-test"
           workspaces: |
             near
             omni-relayer
           cache-on-failure: true
-          
+          cache-all-crates: true
+
       - name: Install cargo-near
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh


### PR DESCRIPTION
Use WarpBuild's native cache instead of GitHub's remote cache for Rust dependencies.

- Add `cache-provider: warpbuild` to use local cache on WarpBuild runners
- Add `shared-key` for better cache isolation between jobs
- Add `cache-all-crates: true` for improved cache coverage