### PR TITLE
fix(omni-relayer): transfer message is not stored when both fees are zero

### DIFF
--- a/omni-relayer/example-testnet-config.toml
+++ b/omni-relayer/example-testnet-config.toml
@@ -1,5 +1,3 @@
-enable_orchard = true
-
 [redis]
 url = "redis://127.0.0.1/"
 sleep_time_after_events_process_secs = 1

--- a/omni-relayer/src/workers/solana.rs
+++ b/omni-relayer/src/workers/solana.rs
@@ -5,7 +5,10 @@ use bridge_connector_common::result::BridgeSdkError;
 use tracing::{info, warn};
 
 use near_bridge_client::{NearBridgeClient, TransactionOptions};
-use near_jsonrpc_client::errors::JsonRpcError;
+use near_jsonrpc_client::{
+    errors::{JsonRpcError, JsonRpcServerError},
+    methods::query::RpcQueryError,
+};
 use near_primitives::views::TxExecutionStatus;
 use near_rpc_client::NearRpcError;
 
@@ -205,15 +208,16 @@ pub async fn process_fin_transfer_event(
     );
 
     if let Some(transfer_id) = transfer_id {
-        match omni_connector.near_get_transfer_message(transfer_id).await {
-            Ok(transfer_message) if transfer_message.fee.is_zero() => {
+        if let Err(BridgeSdkError::NearRpcError(NearRpcError::RpcQueryError(
+            JsonRpcError::ServerError(JsonRpcServerError::HandlerError(
+                RpcQueryError::ContractExecutionError { vm_error, .. },
+            )),
+        ))) = omni_connector.near_get_transfer_message(transfer_id).await
+        {
+            // TODO: refactor when enum errors will become available on mainnet
+            if vm_error.contains("The transfer does not exist") {
                 info!("No fee to claim for FinTransfer ({transfer_id:?})");
                 return Ok(EventAction::Remove);
-            }
-            Ok(_) => {}
-            Err(err) => {
-                warn!("Failed to get transfer message for FinTransfer ({transfer_id:?}): {err:?}",);
-                return Ok(EventAction::Retry);
             }
         }
     }


### PR DESCRIPTION
```txt
2026-02-05T22:07:45.942255468+00:00  WARN Failed to get transfer message for FinTransfer (TransferId { origin_chain: Near, origin_nonce: 1097 }): NearRpcError(RpcQueryError(ServerError(HandlerError(ContractExecutionError { vm_error: "wasm execution failed with error: HostError(GuestPanic { panic_msg: \"The transfer does not exist\" })", block_height: 235464781, block_hash: D48opTEUQYGniAPCA5fHapoTA3K6sEpg8RQK6mT55QW6 }))))
```