### PR TITLE
fix(ci): install liblzma-dev and bust poisoned cache

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -60,6 +60,9 @@ jobs:
   build-and-test:
     runs-on: warp-ubuntu-2204-x64-16x
     steps:
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y liblzma-dev
+
       - name: Setup SSH
         uses: webfactory/ssh-agent@v0.7.0
         with:
@@ -81,6 +84,7 @@ jobs:
         with:
           cache-provider: warpbuild
           shared-key: "rust-build-test"
+          prefix-key: "v1-rust"
           workspaces: |
             near
             omni-relayer


### PR DESCRIPTION
## Summary
- Adds `apt-get install liblzma-dev` to the `build-and-test` job so the linker can find `-llzma` regardless of runner state
- Bumps the rust-cache prefix key to `v1-rust` to invalidate the poisoned cache entry left by a previous failed build

The root cause: a runner missing `liblzma-dev` caused a linker failure, and `cache-on-failure: true` saved the broken build artifacts. Subsequent runs restored that cache and failed with "can't find crate" errors for `near_sdk`, `borsh`, etc.

## Test plan
- CI should pass on this PR