### PR TITLE
fix(evm): canonicalize initTransfer amount to actual received tokens

### DIFF
--- a/evm/src/omni-bridge/contracts/test/TestFeeOnTransferToken.sol
+++ b/evm/src/omni-bridge/contracts/test/TestFeeOnTransferToken.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestFeeOnTransferToken is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address initialHolder,
+        uint256 initialSupply,
+        uint256 feeBps_
+    ) ERC20(name_, symbol_) {
+        require(feeBps_ <= 10_000, "invalid fee bps");
+        feeBps = feeBps_;
+        _mint(initialHolder, initialSupply);
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        // Do not charge transfer fee on mint/burn.
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+
+        uint256 fee = (value * feeBps) / 10_000;
+        uint256 net = value - fee;
+
+        if (fee > 0) {
+            super._update(from, address(0), fee);
+        }
+        super._update(from, to, net);
+    }
+}


### PR DESCRIPTION
## Summary
Hardens EVM `initTransfer` accounting for fee-on-transfer/deflationary ERC20 tokens by canonicalizing amount to actual tokens received on the lock path.

Closes #546.

## TDD / Evidence
### 1) Repro tests added first
- Added a dedicated fee-on-transfer test token:
  - `evm/src/omni-bridge/contracts/test/TestFeeOnTransferToken.sol`
- Added regression tests:
  - `uses received token amount for fee-on-transfer assets`
  - `reverts when bridge fee is >= received amount for fee-on-transfer assets`

### 2) Baseline failure before patch
Before patch, tests failed with:
- `InitTransfer` emitted `1000` instead of expected `900`
- No revert when `fee (950) >= received (900)`

### 3) Patch
- In `OmniBridge.initTransfer` standard ERC20 path:
  - measure `balanceBefore` / `balanceAfter`
  - compute canonical amount from delta
- Use canonical amount in:
  - `initTransferExtension(...)`
  - `InitTransfer` event
- Validate `fee < canonicalAmount` after canonicalization.

## Files Changed
- `evm/src/omni-bridge/contracts/OmniBridge.sol`
- `evm/src/omni-bridge/contracts/test/TestFeeOnTransferToken.sol`
- `evm/tests/BridgeToken.ts`

## Validation
Executed:
```bash
cd evm && ./node_modules/.bin/hardhat test tests/BridgeToken.ts
cd evm && ./node_modules/.bin/hardhat test
```

Result:
- `BridgeToken.ts`: passing
- Full EVM suite: `40 passing`

## Notes
- Change is scoped to standard ERC20 lock path (`!isBridgeToken` and no custom minter).
- Bridge token and custom-minter flows preserve prior behavior.
