### PR TITLE
feat(starknet): add admin rotation for derived-address signer

### DIFF
--- a/starknet/src/bridge_types.cairo
+++ b/starknet/src/bridge_types.cairo
@@ -97,3 +97,11 @@ pub struct PauseStateChanged {
     #[key]
     pub admin: ContractAddress,
 }
+
+#[derive(Drop, starknet::Event)]
+pub struct SignerUpdated {
+    pub old_signer: felt252,
+    pub new_signer: felt252,
+    #[key]
+    pub admin: ContractAddress,
+}


### PR DESCRIPTION
## Summary
Adds a dedicated admin-governed signer rotation path on Starknet OmniBridge for bridge signature verification.

Closes #552.

## TDD / Evidence
### 1) Tests added
In `starknet/tests/test_contract.cairo`:
- `test_set_omni_bridge_derived_address_accepts_signatures_from_new_signer`
- `test_set_omni_bridge_derived_address_non_owner_fails`

### 2) Patch
- ABI/interface: added `set_omni_bridge_derived_address(...)`.
- Contract: admin-only implementation updates signer storage and emits event.
- Events: added `SignerUpdated` event type to capture old/new signer and admin.

## Files Changed
- `starknet/src/bridge_types.cairo`
- `starknet/src/omni_bridge.cairo`
- `starknet/tests/test_contract.cairo`

## Validation
Executed:
```bash
cd starknet && scarb test
```

Result:
- `24 passed, 0 failed`

## Notes
- This PR introduces a dedicated operational control, separate from upgrade flow.
- Existing signature verification logic remains the same, with signer source now rotatable under admin controls.
