### PR TITLE
feat: read mpc prover (#565)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ OMNI_RELAYER_MANIFEST := $(MAKEFILE_DIR)/omni-relayer/Cargo.toml
 clippy: clippy-near clippy-omni-relayer
 
 clippy-near:
-	cargo clippy --manifest-path $(NEAR_MANIFEST) -- $(LINT_OPTIONS)
+	cargo clippy --manifest-path $(NEAR_MANIFEST) --all-features -- $(LINT_OPTIONS)
 
 fmt-near:
 	cargo fmt --all --check --manifest-path $(NEAR_MANIFEST)
@@ -77,4 +77,4 @@ solana-deploy-dev solana-deploy:
 	anchor deploy --verifiable --program-name bridge_token_factory --provider.cluster $(ENV)
 
 rust-run-tests:
-	cargo nextest run --manifest-path $(NEAR_MANIFEST)
+	cargo nextest run --manifest-path $(NEAR_MANIFEST) --all-features

--- a/near/CLAUDE.md
+++ b/near/CLAUDE.md
@@ -11,6 +11,7 @@ cargo near build non-reproducible-wasm --manifest-path omni-token/Cargo.toml
 cargo near build non-reproducible-wasm --manifest-path token-deployer/Cargo.toml
 cargo near build non-reproducible-wasm --manifest-path omni-prover/evm-prover/Cargo.toml
 cargo near build non-reproducible-wasm --manifest-path omni-prover/wormhole-omni-prover-proxy/Cargo.toml
+cargo near build non-reproducible-wasm --manifest-path omni-prover/mpc-omni-prover/Cargo.toml
 
 # Testing (run from near/ directory)
 cargo nextest run -p omni-tests test_native_fee     # Example: run specific test
@@ -31,7 +32,8 @@ near/
 ├── token-deployer/    # Token deployment factory
 ├── omni-prover/
 │   ├── evm-prover/                    # EVM light client verification
-│   └── wormhole-omni-prover-proxy/    # Wormhole VAA verification
+│   ├── wormhole-omni-prover-proxy/    # Wormhole VAA verification
+│   └── mpc-omni-prover/              # MPC read-RPC signature verification
 ├── omni-tests/        # Integration tests (near-workspaces)
 └── mock/              # Test mocks
 ```
@@ -78,6 +80,7 @@ Shared types library - defines core types used across all contracts.
 **Modules:**
 - `errors.rs` - Error types
 - `evm/` - EVM-specific types (BlockHeader, Receipt, LogEntry)
+- `prover_args.rs` - Prover input structs (`EvmVerifyProofArgs`, `WormholeVerifyProofArgs`, `MpcVerifyProofArgs`)
 - `prover_result.rs` - Prover verification results
 - `btc.rs` - Bitcoin/UTXO types
 - `locker_args.rs` - Function argument structs
@@ -137,6 +140,26 @@ Proxy to Wormhole protocol for chains without light clients (Solana, BNB, EVM L2
 3. Parse VAA payload in callback
 4. Return typed `ProverResult`
 
+### mpc-omni-prover
+Verifies foreign chain events by calling the NEAR MPC network's `verify_foreign_transaction` API on-chain. The prover initiates the MPC verification as a cross-contract call and validates the response in a callback. Each deployed instance is configured for a specific chain and finality level via `MpcFinality`. Supports any chain supported by the MPC network (currently EVM chains and Starknet, extensible to others).
+
+**State:**
+- `mpc_contract_id` — AccountId of the MPC signer contract (e.g. `v1.signer`)
+- `finality` — `MpcFinality::Evm(EvmFinality)` or `MpcFinality::Starknet(StarknetFinality)`
+- `chain_kind` — the chain this prover instance verifies
+
+**Flow:**
+1. Deserialize `MpcVerifyProofArgs` containing `sign_payload`, `proof_kind`, `derivation_path`, `domain_id`, `payload_version`
+2. Validate the `sign_payload` (chain and finality must match the prover's configuration)
+3. Construct `VerifyForeignTransactionRequestArgs` from the payload's request + the provided derivation fields
+4. Cross-contract call to `mpc_contract.verify_foreign_transaction(request_args)` with 1 yoctoNEAR deposit
+5. In callback: verify `SHA-256(borsh(sign_payload)) == response.payload_hash`
+6. For EVM chains: extract the EVM log, convert to RLP, parse via `parse_evm_event`
+7. For Starknet: extract the Starknet log, parse via `parse_starknet_proof` (felt-based event decoding)
+8. Return typed `ProverResult`
+
+**Dependencies:** Uses `near-mpc-sdk` crate from the MPC repo (pinned git rev) for MPC types (`ForeignTxSignPayload`, `VerifyForeignTransactionRequestArgs`, `VerifyForeignTransactionResponse`, `EvmLog`, `StarknetLog`, etc.).
+
 ## Code Style
 
 - Rust 2021 edition, 4-space indentation
@@ -150,6 +173,8 @@ Proxy to Wormhole protocol for chains without light clients (Solana, BNB, EVM L2
 - `near-plugins` - Access control (roles) and upgradeable patterns
 - `omni-utils` - Shared utilities (external repo)
 - `alloy` - EVM types and RLP encoding
+- `near-mpc-sdk` - MPC SDK for cross-contract calls to the MPC signer contract (used by mpc-omni-prover)
+- `contract-interface` - MPC network types from `github.com/near/mpc` (used by mpc-omni-prover via near-mpc-sdk)
 - `near-workspaces` - Integration testing
 
 ## Security Audit Notes

--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.8.2"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -297,11 +297,11 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.8.2"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -331,6 +331,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "bounded-collections"
+version = "3.5.1"
+source = "git+https://github.com/near/mpc?rev=24634d774923986f6835a2ca196c2ebcacba0729#24634d774923986f6835a2ca196c2ebcacba0729"
+dependencies = [
+ "borsh",
+ "derive_more",
+ "hex",
+ "schemars 0.8.22",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -532,10 +545,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "contract-interface"
+version = "3.5.1"
+source = "git+https://github.com/near/mpc?rev=24634d774923986f6835a2ca196c2ebcacba0729#24634d774923986f6835a2ca196c2ebcacba0729"
+dependencies = [
+ "borsh",
+ "bounded-collections",
+ "bs58 0.5.1",
+ "derive_more",
+ "schemars 0.8.22",
+ "serde",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -708,7 +746,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
  "syn 2.0.106",
 ]
 
@@ -788,21 +825,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 2.0.106",
  "unicode-xid",
 ]
@@ -938,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1909,6 +1948,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-omni-prover"
+version = "0.4.5"
+dependencies = [
+ "alloy",
+ "borsh",
+ "getrandom 0.2.16",
+ "hex",
+ "near-mpc-sdk",
+ "near-sdk",
+ "omni-types",
+ "omni-utils",
+ "serde_json",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879ac02b2e8d6498294adce1de7a2424a5474b35a73e9262c851be39c89d7f92"
 dependencies = [
  "anyhow",
- "convert_case",
+ "convert_case 0.5.0",
  "near-abi-client-impl",
  "near-abi-client-macros",
  "prettyplease 0.1.25",
@@ -1979,19 +2033,20 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "2.5.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f75ff8eee73815c247d0e17f3c0b705f0e993922a5548acd2ad377aeb67fca"
+checksum = "359c8ca02a3d0ef676a5baf9474b16a50b4137360664b15031977708989342ef"
 dependencies = [
  "borsh",
+ "schemars 0.8.22",
  "serde",
 ]
 
 [[package]]
 name = "near-chain-configs"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a32782a43e0ce3ad5e34ae58557cfd0cd1938cf474cb79a387cd6d8c75309bf2"
+checksum = "3281a54d5bc02d88116eafe44fb76ff8f6c0257165a95c341e500309c9e5ba21"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2014,30 +2069,30 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d501df6fa01064f325daaf19329183a4cd1ad54b7a1b5b8b0281b07f7e7c540"
+checksum = "5abe35e6d4b5e7575706ad607412e0f1e628e1786fcffc96c6e16aea10cebfe4"
 dependencies = [
  "anyhow",
  "json_comments",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-contract-standards"
-version = "5.24.0"
+version = "5.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284205bef7d7140d9754897729c6d04e47b3dec4bd7de83dd818e3ac7f58418a"
+checksum = "d59d3d4fd5d6cb11907c69b57f1c15e30acd48d775be5b5c4ccc79ffd6a35ab5"
 dependencies = [
  "near-sdk",
 ]
 
 [[package]]
 name = "near-crypto"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8bfbd0f159e817402936e188bdd1d38167b0679c7693652f5199b5a36bc804"
+checksum = "705d23809bf4847ccb7d0fc2141a12b68e0d950cd425fb1cb1cffc547b73f08a"
 dependencies = [
  "blake2",
  "borsh",
@@ -2056,14 +2111,14 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb22e3081a4d0de5795cf0f44b1152ec70bb31a95d6f463e723d9a81e9aac50"
+checksum = "84560d0ae50f85dbaca950bd9a8377061080f95ba04f095eb67a1d2e84a3b51c"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2095,14 +2150,14 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7e6277cb8b2808a424c775de2eec683c04dcef5909d8a6cc4fbe8b5ee1dc43"
+checksum = "9b92d4f7a02aac0f00a7dc06667a9218e481ce80cbdb88be72d2669570807cf6"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2112,15 +2167,27 @@ dependencies = [
  "near-time",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
 ]
 
 [[package]]
+name = "near-mpc-sdk"
+version = "3.5.1"
+source = "git+https://github.com/near/mpc?rev=24634d774923986f6835a2ca196c2ebcacba0729#24634d774923986f6835a2ca196c2ebcacba0729"
+dependencies = [
+ "borsh",
+ "bounded-collections",
+ "contract-interface",
+ "derive_more",
+ "signature-verifier",
+]
+
+[[package]]
 name = "near-parameters"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10010e4e9badbb7608bf7feddf99027a954dcdfc64439f0f86a014c6277bfe53"
+checksum = "99bf2f0e9bfaa5b7410feac9470d27661a9fcbedcda961f11efbb04d0b5ec068"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2132,7 +2199,7 @@ dependencies = [
  "serde_repr",
  "serde_yaml",
  "strum 0.24.1",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2160,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffba1d49adc30ec0808d1aef3cc2a3395ade82a99216ef3cf387355c7b46658"
+checksum = "08bdbe402627f4df3471390c6c44e66a56999a533eedadc324f6f54301667f8b"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2195,16 +2262,16 @@ dependencies = [
  "smallvec",
  "smart-default",
  "strum 0.24.1",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "zstd",
 ]
 
 [[package]]
 name = "near-primitives-core"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becb94101c8b7883231a027a0aec85e4f92b4366a17a665d9b68a852937d2bdd"
+checksum = "132139fea1933ee3d5050abb092ab7af022c374df26ad181dd0e22302c74ddc0"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2221,14 +2288,14 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "near-sandbox"
-version = "0.3.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478a37f1c52dae2c8ac63a92ab4258401b79d99a881efd243cacd08b748ea7cf"
+checksum = "2da726a5ef6df27cc804719a5a011fe49560596520ec22f12916b2f31c597d5b"
 dependencies = [
  "binary-install",
  "fs4",
@@ -2238,7 +2305,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "ureq",
@@ -2246,15 +2313,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5700f8f5b38507eb01769c3f761a481aa0ff5ab18fd98d8c3c9d14f231e04b"
+checksum = "d3652cdf9b13de96d9b23b4ad954652aaa84bdeec5168d8b8c7c229c7d36f41a"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd90923ed5ef5e6ed2c18e2effeaa4bf53398f6dfd25493fc1494d6e44df6b57"
+checksum = "8de81b55e49e8a0bf679f87aee27c6521d5b9a4a73474f753b2a127529ecf78a"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2262,20 +2329,21 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff9a4b5c2a27926b14465dd7cc06a9f801f8892de9ee8576b421c7d00f6320"
+checksum = "79d63d022e686c6b92426c98f011908037730d557e815d6c813d5686030a6b53"
 
 [[package]]
 name = "near-sdk"
-version = "5.24.0"
+version = "5.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5188eba9ee0383c2a28afee994e65c21e98823d18a32b8b3a7c8d6cdedfb119"
+checksum = "0f3fa35758aba48e4f13528ba2f603e860dad03233d446e5c65ebd619296b607"
 dependencies = [
  "base64 0.22.1",
  "borsh",
  "bs58 0.5.1",
  "hex",
+ "near-abi",
  "near-account-id",
  "near-crypto",
  "near-gas",
@@ -2287,6 +2355,7 @@ dependencies = [
  "near-token",
  "near-vm-runner",
  "once_cell",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_with",
@@ -2295,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-macros"
-version = "5.24.0"
+version = "5.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4339b75a514ca2e6b67379be62a441f7e99a2c3813278f1b23d233b300f9f4f"
+checksum = "bb141510850a842d010d706c00bcbf31beba188c706415cc9392ffd62a127e09"
 dependencies = [
  "Inflector",
  "darling 0.20.11",
@@ -2312,21 +2381,21 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28b47d44e10c45054bcc023dfda154f13f5b8e980ad25ee94cd32207d463b78"
+checksum = "a501d5074c5c341725fe801ed191f45ef97e0a4d54d6ef5c3e87363930d4d0b1"
 
 [[package]]
 name = "near-sys"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99e9ce0020190ea152f70d1849e54fc8fc123738e7447800ad818c78f5167cc"
+checksum = "f4ea77bb86969ff09c83faa517b2209c4876928381ed31e29c06cae2de0a216b"
 
 [[package]]
 name = "near-time"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5974d008afcd280363411fc1bde76b2c3d36d6c707694bd93d68ceb2a25f2dfe"
+checksum = "5458c180f75aba82c50aca6411d46ca085a6e8535895fa1aa84bd15f560cbd43"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2340,14 +2409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34de6b54d82d0790b2a56b677e7b4ecb7f021a7e8559f8611065c890d56cfcda"
 dependencies = [
  "borsh",
+ "schemars 0.8.22",
  "serde",
 ]
 
 [[package]]
 name = "near-vm-runner"
-version = "0.34.3"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a806f05174cc99052ad974d054aa4416dc4c6b09be728ab0a02b07539643f8c9"
+checksum = "9adf070bf3d12c6ab1799b382de13f23d5190963b293d2068d4842012430fb3a"
 dependencies = [
  "blst",
  "borsh",
@@ -2371,7 +2441,7 @@ dependencies = [
  "sha3",
  "strum 0.24.1",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tracing",
  "zeropool-bn",
 ]
@@ -2566,6 +2636,7 @@ dependencies = [
  "borsh",
  "ethereum-types",
  "hex",
+ "near-mpc-sdk",
  "near-sdk",
  "num_enum",
  "omni-utils",
@@ -3230,7 +3301,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3315,9 +3386,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3396,18 +3467,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.206"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.206"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3427,15 +3508,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.11.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3463,19 +3545,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.11.0",
+ "schemars 0.8.22",
  "schemars 0.9.0",
- "schemars 1.0.4",
- "serde",
- "serde_derive",
+ "schemars 1.1.0",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -3483,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.1"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -3560,10 +3642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 
 [[package]]
+name = "signature-verifier"
+version = "3.5.1"
+source = "git+https://github.com/near/mpc?rev=24634d774923986f6835a2ca196c2ebcacba0729#24634d774923986f6835a2ca196c2ebcacba0729"
+dependencies = [
+ "contract-interface",
+ "near-sdk",
+]
+
+[[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
@@ -3801,7 +3892,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3815,11 +3906,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3835,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4153,6 +4244,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"
@@ -4914,13 +5011,19 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "sha1",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time",
  "xz2",
  "zeroize",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zopfli"

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "token-deployer",
     "omni-prover/wormhole-omni-prover-proxy",
     "omni-prover/evm-prover",
+    "omni-prover/mpc-omni-prover",
     "omni-token",
     "omni-types",
     "omni-tests",
@@ -31,8 +32,8 @@ overflow-checks = true
 
 [workspace.dependencies]
 cargo-near-build = "0.9.0"
-near-sdk = "=5.24.0"
-near-contract-standards = "=5.24.0"
+near-sdk = "=5.24.1"
+near-contract-standards = "=5.24.1"
 hex = "0.4.2"
 borsh = "1.6.0"
 serde = { version = "1.0.200", features = ["derive"] }
@@ -51,4 +52,6 @@ ethereum-types = { version = "0.15.1", default-features = false, features = ["rl
 rlp = "0.6"
 sha3 = "0.10.0"
 sha2 = "0.10.0"
+k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 rstest = "0.26.1"
+near-mpc-sdk = { git = "https://github.com/near/mpc", rev = "24634d774923986f6835a2ca196c2ebcacba0729" }

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -77,7 +77,7 @@ const FAST_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(10);
 const NO_DEPOSIT: NearToken = NearToken::from_near(0);
 const ONE_YOCTO: NearToken = NearToken::from_yoctonear(1);
 const SEND_TOKENS_CALLBACK_GAS: Gas = Gas::from_tgas(15);
-const VERIFY_PROOF_GAS: Gas = Gas::from_tgas(20);
+const VERIFY_PROOF_GAS: Gas = Gas::from_tgas(30);
 const INIT_TRANSFER_RESUME_GAS: Gas = Gas::from_tgas(10);
 const SIGN_PATH: &str = "bridge-1";
 

--- a/near/omni-prover/evm-prover/src/lib.rs
+++ b/near/omni-prover/evm-prover/src/lib.rs
@@ -3,11 +3,12 @@ use near_sdk::{
     env, ext_contract, near, near_bindgen, require, AccountId, Gas, PanicOnDefault, Promise,
 };
 use omni_types::errors::ProverError;
-use omni_types::evm::events::parse_evm_event;
+use omni_types::evm::events::parse_evm_proof;
 use omni_types::evm::header::BlockHeader;
 use omni_types::evm::receipt::{LogEntry, Receipt};
 use omni_types::prover_args::EvmVerifyProofArgs;
-use omni_types::prover_result::{ProofKind, ProverResult};
+use omni_types::prover_result::ProofKind;
+use omni_types::prover_result::ProverResult;
 use omni_types::utils::keccak256;
 use omni_types::ChainKind;
 use rlp::Rlp;
@@ -17,7 +18,7 @@ const BLOCK_HASH_SAFE_GAS: Gas = Gas::from_tgas(5);
 
 type H256 = [u8; 32];
 
-/// Defines an interface to call EthClient contract to get the safe block hash for a given block
+/// Defines an interface to call `EthClient` contract to get the safe block hash for a given block
 /// number. It returns Some(hash) if the block hash is present in the safe canonical chain, or
 /// None if the block number is not part of the canonical chain yet.
 #[ext_contract(evm_client)]
@@ -118,39 +119,22 @@ impl EvmProver {
             return Err(ProverError::InvalidBlockHash.to_string());
         }
 
-        match kind {
-            ProofKind::InitTransfer => Ok(ProverResult::InitTransfer(parse_evm_event(
-                self.chain_kind,
-                log_entry_data,
-            )?)),
-            ProofKind::FinTransfer => Ok(ProverResult::FinTransfer(parse_evm_event(
-                self.chain_kind,
-                log_entry_data,
-            )?)),
-            ProofKind::DeployToken => Ok(ProverResult::DeployToken(parse_evm_event(
-                self.chain_kind,
-                log_entry_data,
-            )?)),
-            ProofKind::LogMetadata => Ok(ProverResult::LogMetadata(parse_evm_event(
-                self.chain_kind,
-                log_entry_data,
-            )?)),
-        }
+        parse_evm_proof(kind, self.chain_kind, log_entry_data)
     }
 
     /// Verify the proof recursively traversing through the key.
     /// Return the value at the end of the key, in case the proof is valid.
     ///
-    /// @param expected_root is the expected root of the current node.
+    /// @param `expected_root` is the expected root of the current node.
     /// @param key is the key for which we are proving the value.
     /// @param proof contains relevant information to verify data is valid
     ///
-    /// Patricia Trie: https://eth.wiki/en/fundamentals/patricia-tree
-    /// Patricia Img:  https://ethereum.stackexchange.com/questions/268/ethereum-block-architecture/6413#6413
+    /// Patricia Trie: <https://eth.wiki/en/fundamentals/patricia-tree>
+    /// Patricia Img:  <https://ethereum.stackexchange.com/questions/268/ethereum-block-architecture/6413#6413>
     ///
-    /// Verification:  https://github.com/slockit/in3/wiki/Ethereum-Verification-and-MerkleProof#receipt-proof
-    /// Article:       https://medium.com/@ouvrard.pierre.alain/merkle-proof-verification-for-ethereum-patricia-tree-48f29658eec
-    /// Python impl:   https://gist.github.com/mfornet/0ff283274c0162f1cca45966bccf69ee
+    /// Verification:  <https://github.com/slockit/in3/wiki/Ethereum-Verification-and-MerkleProof#receipt-proof>
+    /// Article:       <https://medium.com/@ouvrard.pierre.alain/merkle-proof-verification-for-ethereum-patricia-tree-48f29658eec>
+    /// Python impl:   <https://gist.github.com/mfornet/0ff283274c0162f1cca45966bccf69ee>
     ///
     fn verify_trie_proof(expected_root: H256, key: Vec<u8>, proof: &Vec<Vec<u8>>) -> Vec<u8> {
         let mut actual_key = vec![];

--- a/near/omni-prover/mpc-omni-prover/.catalog-info.yaml
+++ b/near/omni-prover/mpc-omni-prover/.catalog-info.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mpc-omni-prover
+  title: "MPC Omni Prover"
+  description: |-
+    Verifies MPC read-RPC signed attestations of foreign chain transaction events.
+    Uses the NEAR MPC network's verify_foreign_transaction API for proof verification.
+    Supports any chain supported by the MPC network.
+  tags:
+    - contract
+    - near
+  links: []
+  annotations:
+    aurora.dev/security-tier: "1"
+spec:
+  owner: nearone-team
+  type: contract
+  lifecycle: production
+  system: omnibridge-protocol
+  deployedAt: []
+  interactsWith: []

--- a/near/omni-prover/mpc-omni-prover/Cargo.toml
+++ b/near/omni-prover/mpc-omni-prover/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "mpc-omni-prover"
+version.workspace = true
+authors = ["Near One <info@nearone.org>"]
+edition = "2021"
+repository.workspace = true
+
+# fields to configure build with WASM reproducibility, according to specs
+# in https://github.com/near/NEPs/blob/master/neps/nep-0330.md
+[package.metadata.near.reproducible_build]
+# docker image, descriptor of build environment
+image = "sourcescan/cargo-near:0.16.0-rust-1.86.0"
+# tag after colon above serves only descriptive purpose; image is identified by digest
+image_digest = "sha256:3220302ebb7036c1942e772810f21edd9381edf9a339983da43487c77fbad488"
+# list of environment variables names, whose values, if set, will be used as external build parameters
+# in a reproducible manner
+# supported by `sourcescan/cargo-near:0.10.1-rust-1.82.0` image or later images
+passed_env = []
+# build command inside of docker container
+# if docker image from default gallery is used https://hub.docker.com/r/sourcescan/cargo-near/tags,
+# the command may be any combination of flags of `cargo-near`,
+# supported by respective version of binary inside the container besides `--no-locked` flag
+container_build_command = ["cargo", "near", "build", "non-reproducible-wasm", "--locked"]
+
+[features]
+abi = ["borsh/unstable__schema", "near-mpc-sdk/abi"]
+__abi-generate = ["near-sdk/__abi-generate"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+near-sdk.workspace = true
+borsh.workspace = true
+omni-types.workspace = true
+omni-utils.workspace = true
+alloy.workspace = true
+hex.workspace = true
+near-mpc-sdk.workspace = true
+
+serde_json = "1"
+getrandom = { version = "0.2", features = ["custom"] }

--- a/near/omni-prover/mpc-omni-prover/src/lib.rs
+++ b/near/omni-prover/mpc-omni-prover/src/lib.rs
@@ -1,0 +1,240 @@
+use std::collections::HashMap;
+
+use alloy::{
+    primitives::{Address, Bytes, Log, B256},
+    rlp::Encodable,
+};
+use borsh::BorshDeserialize;
+use near_mpc_sdk::{
+    contract_interface::types::{
+        EvmExtractedValue, EvmFinality, ExtractedValue, ForeignChainRpcRequest,
+        ForeignTxSignPayload, ForeignTxSignPayloadV1, StarknetExtractedValue, StarknetFinality,
+        VerifyForeignTransactionRequestArgs, VerifyForeignTransactionResponse,
+    },
+    sign::DomainId,
+};
+use near_sdk::{ext_contract, near, require, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+use omni_types::{
+    errors::ProverError,
+    evm::events::parse_evm_proof,
+    prover_args::MpcVerifyProofArgs,
+    prover_result::{ProofKind, ProverResult},
+    starknet::events::parse_starknet_proof,
+    ChainKind,
+};
+use omni_utils::near_expect::NearExpect;
+
+#[cfg(test)]
+mod tests;
+
+const FOREIGN_TX_DOMAIN_ID: u64 = 3;
+const PAYLOAD_VERSION: u8 = 1;
+
+const VERIFY_FOREIGN_TX_GAS: Gas = Gas::from_tgas(20);
+const VERIFY_CALLBACK_GAS: Gas = Gas::from_tgas(7);
+const ONE_YOCTO: NearToken = NearToken::from_yoctonear(1);
+
+#[ext_contract(ext_mpc_contract)]
+pub trait MpcContract {
+    fn verify_foreign_transaction(&mut self, request: VerifyForeignTransactionRequestArgs);
+}
+
+/// Finality enum that supports both EVM and Starknet chains.
+#[near(serializers = [borsh, json])]
+#[derive(Debug, Clone, PartialEq)]
+pub enum MpcFinality {
+    Evm(EvmFinality),
+    Starknet(StarknetFinality),
+}
+
+#[near(contract_state)]
+#[derive(PanicOnDefault)]
+pub struct MpcOmniProver {
+    pub mpc_contract_id: AccountId,
+    pub finalities: HashMap<ChainKind, MpcFinality>,
+}
+
+#[near]
+impl MpcOmniProver {
+    #[init]
+    #[private]
+    #[must_use]
+    pub fn init(mpc_contract_id: AccountId) -> Self {
+        let mut finalities = HashMap::new();
+        finalities.insert(ChainKind::Abs, MpcFinality::Evm(EvmFinality::Safe));
+        finalities.insert(
+            ChainKind::Strk,
+            MpcFinality::Starknet(StarknetFinality::AcceptedOnL2),
+        );
+
+        Self {
+            mpc_contract_id,
+            finalities,
+        }
+    }
+
+    pub fn get_finalities(&self) -> Vec<(&ChainKind, &MpcFinality)> {
+        self.finalities.iter().collect()
+    }
+
+    #[private]
+    pub fn set_finality(&mut self, chain_kind: ChainKind, finality: MpcFinality) {
+        self.finalities.insert(chain_kind, finality);
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn verify_proof(&self, #[serializer(borsh)] input: Vec<u8>) -> Promise {
+        let args = MpcVerifyProofArgs::try_from_slice(&input).near_expect(ProverError::ParseArgs);
+
+        let sign_payload = ForeignTxSignPayload::try_from_slice(&args.sign_payload)
+            .near_expect(ProverError::ParseArgs);
+
+        let ForeignTxSignPayload::V1(ref payload_v1) = sign_payload;
+
+        let chain_kind = Self::request_to_chain_kind(&payload_v1.request)
+            .near_expect(ProverError::UnsupportedChain);
+
+        let finality = self
+            .finalities
+            .get(&chain_kind)
+            .near_expect(ProverError::UnsupportedChain);
+
+        require!(
+            Self::request_matches_finality(&payload_v1.request, finality),
+            ProverError::FinalityMismatch.as_ref()
+        );
+
+        let request_args = VerifyForeignTransactionRequestArgs {
+            request: payload_v1.request.clone(),
+            derivation_path: String::new(),
+            domain_id: DomainId(FOREIGN_TX_DOMAIN_ID),
+            payload_version: PAYLOAD_VERSION,
+        };
+
+        ext_mpc_contract::ext(self.mpc_contract_id.clone())
+            .with_static_gas(VERIFY_FOREIGN_TX_GAS)
+            .with_attached_deposit(ONE_YOCTO)
+            .verify_foreign_transaction(request_args)
+            .then(
+                Self::ext(near_sdk::env::current_account_id())
+                    .with_static_gas(VERIFY_CALLBACK_GAS)
+                    .verify_callback(args.proof_kind, args.sign_payload, chain_kind),
+            )
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    #[private]
+    #[handle_result]
+    #[result_serializer(borsh)]
+    pub fn verify_callback(
+        &self,
+        #[serializer(borsh)] proof_kind: ProofKind,
+        #[serializer(borsh)] sign_payload_bytes: Vec<u8>,
+        #[serializer(borsh)] chain_kind: ChainKind,
+        #[callback_result] call_result: Result<
+            VerifyForeignTransactionResponse,
+            near_sdk::PromiseError,
+        >,
+    ) -> Result<ProverResult, String> {
+        let mpc_response = call_result.map_err(|_| ProverError::InvalidProof.to_string())?;
+
+        let sign_payload = ForeignTxSignPayload::try_from_slice(&sign_payload_bytes)
+            .map_err(|_| ProverError::ParseArgs.to_string())?;
+
+        let expected_hash = sign_payload
+            .compute_msg_hash()
+            .map_err(|_| ProverError::InvalidPayloadHash.to_string())?;
+
+        if expected_hash != mpc_response.payload_hash {
+            return Err(ProverError::InvalidPayloadHash.to_string());
+        }
+
+        let ForeignTxSignPayload::V1(ref payload_v1) = sign_payload;
+
+        if chain_kind == ChainKind::Strk {
+            Self::parse_starknet_result(proof_kind, chain_kind, payload_v1)
+        } else {
+            let log_entry_data = Self::extract_evm_log(payload_v1)?;
+            parse_evm_proof(proof_kind, chain_kind, log_entry_data)
+        }
+    }
+
+    fn request_to_chain_kind(request: &ForeignChainRpcRequest) -> Option<ChainKind> {
+        match request {
+            ForeignChainRpcRequest::Abstract(_) => Some(ChainKind::Abs),
+            ForeignChainRpcRequest::Ethereum(_) => Some(ChainKind::Eth),
+            ForeignChainRpcRequest::Starknet(_) => Some(ChainKind::Strk),
+            _ => None,
+        }
+    }
+
+    fn request_matches_finality(request: &ForeignChainRpcRequest, finality: &MpcFinality) -> bool {
+        match (request, finality) {
+            (
+                ForeignChainRpcRequest::Ethereum(args) | ForeignChainRpcRequest::Abstract(args),
+                MpcFinality::Evm(finality),
+            ) => args.finality == *finality,
+            (ForeignChainRpcRequest::Starknet(args), MpcFinality::Starknet(finality)) => {
+                args.finality == *finality
+            }
+            _ => false,
+        }
+    }
+
+    fn extract_evm_log(payload: &ForeignTxSignPayloadV1) -> Result<Vec<u8>, String> {
+        if payload.values.len() != 1 {
+            return Err(ProverError::InvalidPayloadValuesLength.to_string());
+        }
+
+        let Some(ExtractedValue::EvmExtractedValue(EvmExtractedValue::Log(evm_log))) =
+            payload.values.first()
+        else {
+            return Err(ProverError::InvalidProof.to_string());
+        };
+
+        evm_log_to_rlp(evm_log)
+    }
+
+    fn parse_starknet_result(
+        kind: ProofKind,
+        chain_kind: ChainKind,
+        payload: &ForeignTxSignPayloadV1,
+    ) -> Result<ProverResult, String> {
+        if payload.values.len() != 1 {
+            return Err(ProverError::InvalidPayloadValuesLength.to_string());
+        }
+
+        let Some(ExtractedValue::StarknetExtractedValue(StarknetExtractedValue::Log(starknet_log))) =
+            payload.values.first()
+        else {
+            return Err(ProverError::InvalidProof.to_string());
+        };
+
+        let keys: Vec<[u8; 32]> = starknet_log.keys.iter().map(|k| k.0).collect();
+        let data: Vec<[u8; 32]> = starknet_log.data.iter().map(|d| d.0).collect();
+
+        parse_starknet_proof(kind, chain_kind, &starknet_log.from_address.0, &keys, &data)
+    }
+}
+
+fn evm_log_to_rlp(
+    evm_log: &near_mpc_sdk::contract_interface::types::EvmLog,
+) -> Result<Vec<u8>, String> {
+    let address = Address::from_slice(&evm_log.address.0);
+
+    let topics: Vec<B256> = evm_log
+        .topics
+        .iter()
+        .map(|t| B256::from_slice(&t.0))
+        .collect();
+
+    let data_str = evm_log.data.strip_prefix("0x").unwrap_or(&evm_log.data);
+    let data_bytes = hex::decode(data_str).map_err(|_| ProverError::InvalidProof.to_string())?;
+
+    let log = Log::new_unchecked(address, topics, Bytes::from(data_bytes));
+
+    let mut buf = Vec::new();
+    log.encode(&mut buf);
+
+    Ok(buf)
+}

--- a/near/omni-prover/mpc-omni-prover/src/tests.rs
+++ b/near/omni-prover/mpc-omni-prover/src/tests.rs
@@ -1,0 +1,513 @@
+use borsh::BorshDeserialize;
+
+use near_mpc_sdk::contract_interface::types::{
+    EvmExtractedValue, EvmExtractor, EvmFinality, EvmLog, EvmRpcRequest, EvmTxId, ExtractedValue,
+    ForeignChainRpcRequest, ForeignTxSignPayload, ForeignTxSignPayloadV1, Hash160, Hash256,
+    SolanaFinality, SolanaRpcRequest, SolanaTxId, StarknetExtractedValue, StarknetExtractor,
+    StarknetFelt, StarknetFinality, StarknetLog, StarknetRpcRequest, StarknetTxId,
+};
+
+use near_sdk::base64::Engine;
+use omni_types::prover_args::MpcVerifyProofArgs;
+use omni_types::prover_result::ProofKind;
+
+use omni_types::ChainKind;
+
+use crate::{evm_log_to_rlp, MpcFinality, MpcOmniProver};
+
+fn hex_to_hash256(hex_str: &str) -> Hash256 {
+    let bytes: [u8; 32] = hex::decode(hex_str).unwrap().try_into().unwrap();
+    Hash256(bytes)
+}
+
+fn hex_to_hash160(hex_str: &str) -> Hash160 {
+    let bytes: [u8; 20] = hex::decode(hex_str).unwrap().try_into().unwrap();
+    Hash160(bytes)
+}
+
+fn test_evm_log() -> EvmLog {
+    EvmLog {
+        removed: false,
+        log_index: 0,
+        transaction_index: 0,
+        transaction_hash: Hash256([1u8; 32]),
+        block_hash: Hash256([2u8; 32]),
+        block_number: 100,
+        address: Hash160([3u8; 20]),
+        data: "0x".to_string(),
+        topics: vec![],
+    }
+}
+
+/// Real InitTransfer log from Abstract testnet tx:
+/// https://sepolia.abscan.org/tx/0x8d286a01fa892903128228cdca896de68c7b774ccbd1b46b25867ef9499c6fc3
+/// Log index 3 — InitTransfer event from bridge contract 0x1a7Eba78B12F2A82D812f25155e6c7FC2aB1eD32
+/// initTransfer(tokenAddress=0x6641415a..., amount=1, fee=0, nativeFee=0, recipient="near:frolik.testnet")
+fn abs_testnet_evm_log() -> EvmLog {
+    EvmLog {
+        removed: false,
+        log_index: 3,
+        transaction_index: 0,
+        transaction_hash: hex_to_hash256(
+            "8d286a01fa892903128228cdca896de68c7b774ccbd1b46b25867ef9499c6fc3",
+        ),
+        block_hash: hex_to_hash256(
+            "45471ca1210369f7e2062ea93a4a173c4573460497f01303bc3b6c8b6a84dec1",
+        ),
+        block_number: 0xfee757,
+        address: hex_to_hash160("1a7eba78b12f2a82d812f25155e6c7fc2ab1ed32"),
+        data: "0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000136e6561723a66726f6c696b2e746573746e6574000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            .to_string(),
+        topics: vec![
+            hex_to_hash256(
+                "aa7e1f77d43faa300bc5ae8f012f0b7cf80174f4c0b1cffeab250cb4966bb88c",
+            ),
+            hex_to_hash256(
+                "000000000000000000000000cf6462b9fce5af3e6c660c83453eca18ff468773",
+            ),
+            hex_to_hash256(
+                "0000000000000000000000006641415a61bce80d97a715054d1334360ab833eb",
+            ),
+            hex_to_hash256(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            ),
+        ],
+    }
+}
+
+fn abs_testnet_tx_id() -> EvmTxId {
+    let bytes: [u8; 32] =
+        hex::decode("8d286a01fa892903128228cdca896de68c7b774ccbd1b46b25867ef9499c6fc3")
+            .unwrap()
+            .try_into()
+            .unwrap();
+    EvmTxId(bytes)
+}
+
+fn test_evm_request() -> EvmRpcRequest {
+    EvmRpcRequest {
+        tx_id: EvmTxId([0xab; 32]),
+        extractors: vec![EvmExtractor::Log { log_index: 0 }],
+        finality: EvmFinality::Finalized,
+    }
+}
+
+fn abs_testnet_evm_request() -> EvmRpcRequest {
+    EvmRpcRequest {
+        tx_id: abs_testnet_tx_id(),
+        extractors: vec![EvmExtractor::Log { log_index: 3 }],
+        finality: EvmFinality::Latest,
+    }
+}
+
+fn test_starknet_request() -> StarknetRpcRequest {
+    StarknetRpcRequest {
+        tx_id: StarknetTxId(StarknetFelt([0xcc; 32])),
+        finality: StarknetFinality::AcceptedOnL1,
+        extractors: vec![StarknetExtractor::Log { log_index: 0 }],
+    }
+}
+
+fn test_sign_payload() -> ForeignTxSignPayload {
+    ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Abstract(test_evm_request()),
+        values: vec![ExtractedValue::EvmExtractedValue(EvmExtractedValue::Log(
+            test_evm_log(),
+        ))],
+    })
+}
+
+#[test]
+fn test_payload_hash_computation() {
+    let payload = test_sign_payload();
+    let hash = payload.compute_msg_hash().unwrap();
+    assert_eq!(hash.0.len(), 32);
+
+    let hash2 = payload.compute_msg_hash().unwrap();
+    assert_eq!(hash.0, hash2.0);
+}
+
+#[test]
+fn test_payload_serialization_roundtrip() {
+    let payload = test_sign_payload();
+    let bytes = borsh::to_vec(&payload).unwrap();
+    let deserialized = ForeignTxSignPayload::try_from_slice(&bytes).unwrap();
+
+    let original_hash = payload.compute_msg_hash().unwrap();
+    let roundtrip_hash = deserialized.compute_msg_hash().unwrap();
+    assert_eq!(original_hash.0, roundtrip_hash.0);
+}
+
+#[test]
+fn test_evm_log_to_rlp_basic() {
+    let log = test_evm_log();
+    let rlp_bytes = evm_log_to_rlp(&log).unwrap();
+    assert!(!rlp_bytes.is_empty());
+}
+
+#[test]
+fn test_evm_log_to_rlp_with_data() {
+    let log = EvmLog {
+        removed: false,
+        log_index: 5,
+        transaction_index: 2,
+        transaction_hash: Hash256([0xaa; 32]),
+        block_hash: Hash256([0xbb; 32]),
+        block_number: 12345,
+        address: Hash160([0xcc; 20]),
+        data: "0xdeadbeef".to_string(),
+        topics: vec![Hash256([0x11; 32]), Hash256([0x22; 32])],
+    };
+
+    let rlp_bytes = evm_log_to_rlp(&log).unwrap();
+    assert!(!rlp_bytes.is_empty());
+}
+
+#[test]
+fn test_evm_log_to_rlp_without_0x_prefix() {
+    let log = EvmLog {
+        removed: false,
+        log_index: 0,
+        transaction_index: 0,
+        transaction_hash: Hash256([0; 32]),
+        block_hash: Hash256([0; 32]),
+        block_number: 0,
+        address: Hash160([0; 20]),
+        data: "deadbeef".to_string(),
+        topics: vec![],
+    };
+
+    let rlp_bytes = evm_log_to_rlp(&log).unwrap();
+    assert!(!rlp_bytes.is_empty());
+}
+
+#[test]
+fn test_mpc_verify_proof_args_serialization() {
+    let payload = test_sign_payload();
+    let payload_bytes = borsh::to_vec(&payload).unwrap();
+
+    let args = MpcVerifyProofArgs {
+        proof_kind: ProofKind::InitTransfer,
+        sign_payload: payload_bytes.clone(),
+    };
+
+    let serialized = borsh::to_vec(&args).unwrap();
+    let deserialized = MpcVerifyProofArgs::try_from_slice(&serialized).unwrap();
+
+    assert_eq!(deserialized.sign_payload, payload_bytes);
+    assert_eq!(deserialized.proof_kind, ProofKind::InitTransfer);
+}
+
+#[test]
+fn test_payload_hash_mismatch_detected() {
+    let payload = test_sign_payload();
+    let computed_hash = payload.compute_msg_hash().unwrap();
+    let wrong_hash = [0xffu8; 32];
+    assert_ne!(
+        computed_hash.0, wrong_hash,
+        "Computed hash must differ from forged hash"
+    );
+}
+
+#[test]
+fn test_forged_payload_produces_different_hash() {
+    let original_payload = test_sign_payload();
+    let original_hash = original_payload.compute_msg_hash().unwrap();
+
+    let forged_payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Ethereum(test_evm_request()),
+        values: vec![ExtractedValue::EvmExtractedValue(EvmExtractedValue::Log(
+            test_evm_log(),
+        ))],
+    });
+    let forged_hash = forged_payload.compute_msg_hash().unwrap();
+
+    assert_ne!(
+        original_hash.0, forged_hash.0,
+        "Different chain requests must produce different hashes"
+    );
+}
+
+#[test]
+fn test_request_to_chain_kind_ethereum() {
+    let request = ForeignChainRpcRequest::Ethereum(test_evm_request());
+    assert_eq!(
+        MpcOmniProver::request_to_chain_kind(&request),
+        Some(ChainKind::Eth)
+    );
+}
+
+#[test]
+fn test_request_to_chain_kind_abstract() {
+    let request = ForeignChainRpcRequest::Abstract(test_evm_request());
+    assert_eq!(
+        MpcOmniProver::request_to_chain_kind(&request),
+        Some(ChainKind::Abs)
+    );
+}
+
+#[test]
+fn test_request_to_chain_kind_starknet() {
+    let request = ForeignChainRpcRequest::Starknet(test_starknet_request());
+    assert_eq!(
+        MpcOmniProver::request_to_chain_kind(&request),
+        Some(ChainKind::Strk)
+    );
+}
+
+#[test]
+fn test_request_to_chain_kind_unsupported() {
+    let solana_request = ForeignChainRpcRequest::Solana(SolanaRpcRequest {
+        tx_id: SolanaTxId([0u8; 64]),
+        finality: SolanaFinality::Confirmed,
+        extractors: vec![],
+    });
+    assert_eq!(MpcOmniProver::request_to_chain_kind(&solana_request), None);
+}
+
+#[test]
+fn test_request_matches_finality_ethereum_match() {
+    let request = ForeignChainRpcRequest::Ethereum(test_evm_request());
+    assert!(MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Finalized)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_abstract_match() {
+    let request = ForeignChainRpcRequest::Abstract(abs_testnet_evm_request());
+    assert!(MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Latest)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_ethereum_mismatch() {
+    let request = ForeignChainRpcRequest::Ethereum(test_evm_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Latest)
+    ));
+    assert!(!MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Safe)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_abstract_mismatch() {
+    let request = ForeignChainRpcRequest::Abstract(abs_testnet_evm_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Finalized)
+    ));
+    assert!(!MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Evm(EvmFinality::Safe)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_starknet_match() {
+    let request = ForeignChainRpcRequest::Starknet(test_starknet_request());
+    assert!(MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Starknet(StarknetFinality::AcceptedOnL1)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_starknet_mismatch() {
+    let request = ForeignChainRpcRequest::Starknet(test_starknet_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Starknet(StarknetFinality::AcceptedOnL2)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_cross_chain_mismatch() {
+    let evm_request = ForeignChainRpcRequest::Ethereum(test_evm_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &evm_request,
+        &MpcFinality::Starknet(StarknetFinality::AcceptedOnL1)
+    ));
+
+    let strk_request = ForeignChainRpcRequest::Starknet(test_starknet_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &strk_request,
+        &MpcFinality::Evm(EvmFinality::Finalized)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_non_evm_returns_false() {
+    let solana_request = ForeignChainRpcRequest::Solana(SolanaRpcRequest {
+        tx_id: SolanaTxId([0u8; 64]),
+        finality: SolanaFinality::Confirmed,
+        extractors: vec![],
+    });
+
+    assert!(!MpcOmniProver::request_matches_finality(
+        &solana_request,
+        &MpcFinality::Evm(EvmFinality::Latest)
+    ));
+    assert!(!MpcOmniProver::request_matches_finality(
+        &solana_request,
+        &MpcFinality::Starknet(StarknetFinality::AcceptedOnL1)
+    ));
+}
+
+#[test]
+fn test_starknet_sign_payload_roundtrip() {
+    let payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Starknet(test_starknet_request()),
+        values: vec![ExtractedValue::StarknetExtractedValue(
+            StarknetExtractedValue::Log(StarknetLog {
+                block_hash: StarknetFelt([0x01; 32]),
+                block_number: 100,
+                data: vec![StarknetFelt([0x02; 32])],
+                from_address: StarknetFelt([0x03; 32]),
+                keys: vec![StarknetFelt([0x04; 32])],
+            }),
+        )],
+    });
+
+    let bytes = borsh::to_vec(&payload).unwrap();
+    let deserialized = ForeignTxSignPayload::try_from_slice(&bytes).unwrap();
+
+    let hash1 = payload.compute_msg_hash().unwrap();
+    let hash2 = deserialized.compute_msg_hash().unwrap();
+    assert_eq!(hash1.0, hash2.0);
+}
+
+#[test]
+fn test_abs_testnet_verify_proof_args() {
+    let request = abs_testnet_evm_request();
+
+    let sign_payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Abstract(request),
+        values: vec![ExtractedValue::EvmExtractedValue(EvmExtractedValue::Log(
+            abs_testnet_evm_log(),
+        ))],
+    });
+
+    let args = MpcVerifyProofArgs {
+        proof_kind: ProofKind::InitTransfer,
+        sign_payload: borsh::to_vec(&sign_payload).unwrap(),
+    };
+
+    // Verify serialization roundtrip
+    let inner_bytes = borsh::to_vec(&args).unwrap();
+    let deserialized = MpcVerifyProofArgs::try_from_slice(&inner_bytes).unwrap();
+    assert_eq!(deserialized.proof_kind, ProofKind::InitTransfer);
+
+    // Verify payload hash is deterministic
+    let payload_from_args =
+        ForeignTxSignPayload::try_from_slice(&deserialized.sign_payload).unwrap();
+    let hash1 = sign_payload.compute_msg_hash().unwrap();
+    let hash2 = payload_from_args.compute_msg_hash().unwrap();
+    assert_eq!(hash1.0, hash2.0);
+
+    let call_bytes = borsh::to_vec(&inner_bytes).unwrap();
+    let base64_encoded = near_sdk::base64::engine::general_purpose::STANDARD.encode(&call_bytes);
+
+    assert!(!base64_encoded.is_empty());
+}
+
+fn hex_to_starknet_felt(hex_str: &str) -> StarknetFelt {
+    let stripped = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let padded = if stripped.len() % 2 == 1 {
+        format!("0{stripped}")
+    } else {
+        stripped.to_string()
+    };
+    let bytes = hex::decode(&padded).unwrap();
+    let mut felt = [0u8; 32];
+    felt[32 - bytes.len()..].copy_from_slice(&bytes);
+    StarknetFelt(felt)
+}
+
+/// Real InitTransfer event from Starknet sepolia tx:
+/// https://sepolia.starkscan.co/tx/0x0592d937f74565b8c42c5603083e5536fdcd8e585b5fef5cd5c2c04b65cd80e5
+/// Event index 3 from bridge contract `0x05a0ad01b...98bdc8f`
+/// `initTransfer`(token=STRK, sender=`0x01bc36c7a...`, amount=10, recipient="near:frolik.testnet")
+fn starknet_sepolia_log() -> StarknetLog {
+    StarknetLog {
+        block_hash: hex_to_starknet_felt(
+            "0x05eed39a16c3695b707b24ee75c43c0dc0ce94d07d73f39473d6871a60fd07a7",
+        ),
+        block_number: 6_389_548,
+        from_address: hex_to_starknet_felt(
+            "0x05a0ad01b18eba34432d22e4cb5c987560cae87a785b494ed58d9553a98bdc8f",
+        ),
+        keys: vec![
+            hex_to_starknet_felt(
+                "0xdf95b9d93d8073acda8a048cb25360af6f665c6dfd33d86af06c20b4573c75",
+            ),
+            hex_to_starknet_felt(
+                "0x1bc36c7a215b86ea1d8943d2addbfdd767d5d8ff1258cb03fc40f6d69e6008",
+            ),
+            hex_to_starknet_felt(
+                "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+            ),
+            hex_to_starknet_felt("0x1"),
+        ],
+        data: vec![
+            hex_to_starknet_felt("0x0a"),
+            hex_to_starknet_felt("0x0"),
+            hex_to_starknet_felt("0x0"),
+            hex_to_starknet_felt("0x0"),
+            hex_to_starknet_felt("0x6e6561723a66726f6c696b2e746573746e6574"),
+            hex_to_starknet_felt("0x13"),
+            hex_to_starknet_felt("0x0"),
+            hex_to_starknet_felt("0x0"),
+            hex_to_starknet_felt("0x0"),
+        ],
+    }
+}
+
+fn starknet_sepolia_request() -> StarknetRpcRequest {
+    StarknetRpcRequest {
+        tx_id: StarknetTxId(hex_to_starknet_felt(
+            "0x0592d937f74565b8c42c5603083e5536fdcd8e585b5fef5cd5c2c04b65cd80e5",
+        )),
+        finality: StarknetFinality::AcceptedOnL2,
+        extractors: vec![StarknetExtractor::Log { log_index: 3 }],
+    }
+}
+
+#[test]
+fn test_starknet_sepolia_verify_proof_args() {
+    let request = starknet_sepolia_request();
+
+    let starknet_log = starknet_sepolia_log();
+    let sign_payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Starknet(request),
+        values: vec![ExtractedValue::StarknetExtractedValue(
+            StarknetExtractedValue::Log(starknet_log),
+        )],
+    });
+
+    let args = MpcVerifyProofArgs {
+        proof_kind: ProofKind::InitTransfer,
+        sign_payload: borsh::to_vec(&sign_payload).unwrap(),
+    };
+
+    let inner_bytes = borsh::to_vec(&args).unwrap();
+    let deserialized = MpcVerifyProofArgs::try_from_slice(&inner_bytes).unwrap();
+    assert_eq!(deserialized.proof_kind, ProofKind::InitTransfer);
+
+    let payload_from_args =
+        ForeignTxSignPayload::try_from_slice(&deserialized.sign_payload).unwrap();
+    let hash1 = sign_payload.compute_msg_hash().unwrap();
+    let hash2 = payload_from_args.compute_msg_hash().unwrap();
+    assert_eq!(hash1.0, hash2.0);
+
+    let call_bytes = borsh::to_vec(&inner_bytes).unwrap();
+    let base64_encoded = near_sdk::base64::engine::general_purpose::STANDARD.encode(&call_bytes);
+
+    assert!(!base64_encoded.is_empty());
+}

--- a/near/omni-types/Cargo.toml
+++ b/near/omni-types/Cargo.toml
@@ -17,6 +17,7 @@ schemars.workspace = true
 num_enum.workspace = true
 alloy.workspace = true
 omni-utils.workspace = true
+near-mpc-sdk = { workspace = true, features = ["abi"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sha3.workspace = true

--- a/near/omni-types/src/errors.rs
+++ b/near/omni-types/src/errors.rs
@@ -115,10 +115,17 @@ pub enum TokenError {
 #[strum(serialize_all = "shouty_snake_case", prefix = "ERR_")]
 #[non_exhaustive]
 pub enum ProverError {
+    ChainMismatch,
+    FinalityMismatch,
     HashNotSet,
     InvalidBlockHash,
+    InvalidPayloadHash,
+    InvalidPayloadValuesLength,
     InvalidProof,
+    InvalidPublicKey,
+    InvalidSignature,
     ParseArgs,
+    UnsupportedChain,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, AsRefStr, ErrorDisplay)]

--- a/near/omni-types/src/evm/events.rs
+++ b/near/omni-types/src/evm/events.rs
@@ -2,7 +2,8 @@ use alloy::{primitives::Log, rlp::Decodable, sol, sol_types::SolEvent};
 
 use crate::{
     prover_result::{
-        DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
+        DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage, ProofKind,
+        ProverResult,
     },
     stringify, ChainKind, Fee, OmniAddress, H160,
 };
@@ -59,6 +60,32 @@ where
         T::decode_log_validate(&rlp_decoded).map_err(stringify)?,
     )
     .map_err(stringify)
+}
+
+/// Dispatches EVM log parsing based on `ProofKind`, returning a typed `ProverResult`.
+pub fn parse_evm_proof(
+    kind: ProofKind,
+    chain_kind: ChainKind,
+    log_entry_data: Vec<u8>,
+) -> Result<ProverResult, String> {
+    match kind {
+        ProofKind::InitTransfer => Ok(ProverResult::InitTransfer(parse_evm_event(
+            chain_kind,
+            log_entry_data,
+        )?)),
+        ProofKind::FinTransfer => Ok(ProverResult::FinTransfer(parse_evm_event(
+            chain_kind,
+            log_entry_data,
+        )?)),
+        ProofKind::DeployToken => Ok(ProverResult::DeployToken(parse_evm_event(
+            chain_kind,
+            log_entry_data,
+        )?)),
+        ProofKind::LogMetadata => Ok(ProverResult::LogMetadata(parse_evm_event(
+            chain_kind,
+            log_entry_data,
+        )?)),
+    }
 }
 
 pub trait TryFromLog<T>: Sized {

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -22,6 +22,7 @@ pub mod near_events;
 pub mod prover_args;
 pub mod prover_result;
 pub mod sol_address;
+pub mod starknet;
 pub mod utils;
 
 #[cfg(test)]
@@ -254,8 +255,8 @@ impl OmniAddress {
             Self::Bnb(address) => ("bnb", address.to_string()),
             Self::Pol(address) => ("pol", address.to_string()),
             Self::HyperEvm(address) => ("hlevm", address.to_string()),
-            Self::Btc(address) => ("btc", address.to_string()),
-            Self::Zcash(address) => ("zcash", address.to_string()),
+            Self::Btc(address) => ("btc", address.clone()),
+            Self::Zcash(address) => ("zcash", address.clone()),
             Self::Strk(address) => ("strk", address.to_string()),
             Self::Abs(address) => ("abs", address.to_string()),
         };

--- a/near/omni-types/src/prover_args.rs
+++ b/near/omni-types/src/prover_args.rs
@@ -16,6 +16,13 @@ pub struct WormholeVerifyProofArgs {
     pub vaa: String,
 }
 
+#[near(serializers=[borsh])]
+#[derive(Debug, Clone)]
+pub struct MpcVerifyProofArgs {
+    pub proof_kind: ProofKind,
+    pub sign_payload: Vec<u8>,
+}
+
 #[near(serializers=[borsh, json])]
 #[derive(Default, Debug, Clone)]
 pub struct EvmProof {

--- a/near/omni-types/src/starknet/events.rs
+++ b/near/omni-types/src/starknet/events.rs
@@ -1,0 +1,816 @@
+use crate::{
+    prover_result::{
+        DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage,
+    },
+    stringify, ChainKind, Fee, OmniAddress, H256,
+};
+
+/// Precomputed `sn_keccak("InitTransfer")` — keccak256 masked to 250 bits.
+const INIT_TRANSFER_SELECTOR: [u8; 32] = compute_sn_keccak(b"InitTransfer");
+
+/// Precomputed `sn_keccak("FinTransfer")`.
+const FIN_TRANSFER_SELECTOR: [u8; 32] = compute_sn_keccak(b"FinTransfer");
+
+/// Precomputed `sn_keccak("DeployToken")`.
+const DEPLOY_TOKEN_SELECTOR: [u8; 32] = compute_sn_keccak(b"DeployToken");
+
+/// Precomputed `sn_keccak("LogMetadata")`.
+const LOG_METADATA_SELECTOR: [u8; 32] = compute_sn_keccak(b"LogMetadata");
+
+/// Parses a Starknet log into an `InitTransferMessage`.
+///
+/// # Starknet `InitTransfer` event layout (from Cairo contract):
+/// ```text
+/// keys[0] = sn_keccak("InitTransfer")  (event selector)
+/// keys[1] = sender                      (ContractAddress)
+/// keys[2] = token_address               (ContractAddress)
+/// keys[3] = origin_nonce                (u64 as felt)
+/// data[0] = amount                      (u128 as felt)
+/// data[1] = fee                         (u128 as felt)
+/// data[2] = native_fee                  (u128 as felt)
+/// data[3..] = recipient                 (ByteArray: serialized as felts)
+/// data[..] = message                    (ByteArray: serialized as felts)
+/// ```
+pub fn parse_init_transfer(
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<InitTransferMessage, String> {
+    if keys.len() < 4 {
+        return Err(format!(
+            "InitTransfer: expected at least 4 keys, got {}",
+            keys.len()
+        ));
+    }
+    if keys[0] != INIT_TRANSFER_SELECTOR {
+        return Err("InitTransfer: selector mismatch".to_string());
+    }
+
+    let sender = OmniAddress::Strk(H256(keys[1]));
+    let token = OmniAddress::Strk(H256(keys[2]));
+    let origin_nonce = felt_to_u64(&keys[3])?;
+
+    let mut cursor = FeltCursor::new(data);
+    let amount = cursor.read_u128()?;
+    let fee = cursor.read_u128()?;
+    let native_fee = cursor.read_u128()?;
+    let recipient_str = cursor.read_byte_array()?;
+    let msg = cursor.read_byte_array()?;
+
+    let emitter_address = OmniAddress::Strk(H256(*from_address));
+    let recipient: OmniAddress = recipient_str.parse().map_err(stringify)?;
+
+    Ok(InitTransferMessage {
+        origin_nonce,
+        token,
+        amount: near_sdk::json_types::U128(amount),
+        recipient,
+        fee: Fee {
+            fee: near_sdk::json_types::U128(fee),
+            native_fee: near_sdk::json_types::U128(native_fee),
+        },
+        sender,
+        msg,
+        emitter_address,
+    })
+}
+
+/// Parses a Starknet log into a `FinTransferMessage`.
+///
+/// # Starknet `FinTransfer` event layout:
+/// ```text
+/// keys[0] = sn_keccak("FinTransfer")
+/// keys[1] = origin_chain                (u8 as felt)
+/// keys[2] = origin_nonce                (u64 as felt)
+/// data[0] = token_address               (ContractAddress as felt)
+/// data[1] = amount                      (u128 as felt)
+/// data[2] = recipient                   (ContractAddress as felt)
+/// data[3..] = fee_recipient             (Option<ByteArray>)
+/// data[..] = message                    (Option<ByteArray>)
+/// ```
+pub fn parse_fin_transfer(
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<FinTransferMessage, String> {
+    if keys.len() < 3 {
+        return Err(format!(
+            "FinTransfer: expected at least 3 keys, got {}",
+            keys.len()
+        ));
+    }
+    if keys[0] != FIN_TRANSFER_SELECTOR {
+        return Err("FinTransfer: selector mismatch".to_string());
+    }
+
+    let origin_chain: u8 = felt_to_u64(&keys[1])?.try_into().map_err(stringify)?;
+    let origin_nonce = felt_to_u64(&keys[2])?;
+
+    let mut cursor = FeltCursor::new(data);
+    let _token_address = cursor.read_felt()?; // ContractAddress (not used in FinTransferMessage)
+    let amount = cursor.read_u128()?;
+    let _recipient = cursor.read_felt()?; // ContractAddress (not used in message directly)
+    let fee_recipient_opt = cursor.read_option_byte_array()?;
+
+    let emitter_address = OmniAddress::Strk(H256(*from_address));
+
+    Ok(FinTransferMessage {
+        transfer_id: crate::TransferId {
+            origin_chain: origin_chain.try_into()?,
+            origin_nonce,
+        },
+        amount: near_sdk::json_types::U128(amount),
+        fee_recipient: fee_recipient_opt.and_then(|s| s.parse().ok()),
+        emitter_address,
+    })
+}
+
+/// Parses a Starknet log into a `DeployTokenMessage`.
+///
+/// # Starknet `DeployToken` event layout:
+/// ```text
+/// keys[0] = sn_keccak("DeployToken")
+/// keys[1] = token_address               (ContractAddress)
+/// data[0..] = near_token_id             (ByteArray)
+/// data[..] = name                       (ByteArray)
+/// data[..] = symbol                     (ByteArray)
+/// data[..] = decimals                   (u8 as felt)
+/// data[..] = origin_decimals            (u8 as felt)
+/// ```
+pub fn parse_deploy_token(
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<DeployTokenMessage, String> {
+    if keys.len() < 2 {
+        return Err(format!(
+            "DeployToken: expected at least 2 keys, got {}",
+            keys.len()
+        ));
+    }
+    if keys[0] != DEPLOY_TOKEN_SELECTOR {
+        return Err("DeployToken: selector mismatch".to_string());
+    }
+
+    let token_address = OmniAddress::Strk(H256(keys[1]));
+
+    let mut cursor = FeltCursor::new(data);
+    let near_token_id = cursor.read_byte_array()?;
+    let _name = cursor.read_byte_array()?;
+    let _symbol = cursor.read_byte_array()?;
+    let decimals: u8 = cursor.read_u64()?.try_into().map_err(stringify)?;
+    let origin_decimals: u8 = cursor.read_u64()?.try_into().map_err(stringify)?;
+
+    let emitter_address = OmniAddress::Strk(H256(*from_address));
+
+    Ok(DeployTokenMessage {
+        token: near_token_id.parse().map_err(stringify)?,
+        token_address,
+        decimals,
+        origin_decimals,
+        emitter_address,
+    })
+}
+
+/// Parses a Starknet log into a `LogMetadataMessage`.
+///
+/// # Starknet `LogMetadata` event layout:
+/// ```text
+/// keys[0] = sn_keccak("LogMetadata")
+/// keys[1] = address                     (ContractAddress)
+/// data[0..] = name                      (ByteArray)
+/// data[..] = symbol                     (ByteArray)
+/// data[..] = decimals                   (u8 as felt)
+/// ```
+pub fn parse_log_metadata(
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<LogMetadataMessage, String> {
+    if keys.len() < 2 {
+        return Err(format!(
+            "LogMetadata: expected at least 2 keys, got {}",
+            keys.len()
+        ));
+    }
+    if keys[0] != LOG_METADATA_SELECTOR {
+        return Err("LogMetadata: selector mismatch".to_string());
+    }
+
+    let token_address = OmniAddress::Strk(H256(keys[1]));
+
+    let mut cursor = FeltCursor::new(data);
+    let name = cursor.read_byte_array()?;
+    let symbol = cursor.read_byte_array()?;
+    let decimals: u8 = cursor.read_u64()?.try_into().map_err(stringify)?;
+
+    let emitter_address = OmniAddress::Strk(H256(*from_address));
+
+    Ok(LogMetadataMessage {
+        token_address,
+        name,
+        symbol,
+        decimals,
+        emitter_address,
+    })
+}
+
+/// Dispatches to the correct parser based on the event selector in `keys[0]`.
+pub fn parse_starknet_event(
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<StarknetEvent, String> {
+    if keys.is_empty() {
+        return Err("Empty keys array — no event selector".to_string());
+    }
+
+    match keys[0] {
+        INIT_TRANSFER_SELECTOR => {
+            parse_init_transfer(from_address, keys, data).map(StarknetEvent::InitTransfer)
+        }
+        FIN_TRANSFER_SELECTOR => {
+            parse_fin_transfer(from_address, keys, data).map(StarknetEvent::FinTransfer)
+        }
+        DEPLOY_TOKEN_SELECTOR => {
+            parse_deploy_token(from_address, keys, data).map(StarknetEvent::DeployToken)
+        }
+        LOG_METADATA_SELECTOR => {
+            parse_log_metadata(from_address, keys, data).map(StarknetEvent::LogMetadata)
+        }
+        _ => Err(format!("Unknown Starknet event selector: {:?}", &keys[0])),
+    }
+}
+
+/// Dispatches to the correct parser based on `ProofKind`, validating that the event selector
+/// matches the expected kind.
+pub fn parse_starknet_proof(
+    kind: crate::prover_result::ProofKind,
+    _chain_kind: ChainKind,
+    from_address: &[u8; 32],
+    keys: &[[u8; 32]],
+    data: &[[u8; 32]],
+) -> Result<crate::prover_result::ProverResult, String> {
+    use crate::prover_result::{ProofKind, ProverResult};
+
+    match kind {
+        ProofKind::InitTransfer => {
+            parse_init_transfer(from_address, keys, data).map(ProverResult::InitTransfer)
+        }
+        ProofKind::FinTransfer => {
+            parse_fin_transfer(from_address, keys, data).map(ProverResult::FinTransfer)
+        }
+        ProofKind::DeployToken => {
+            parse_deploy_token(from_address, keys, data).map(ProverResult::DeployToken)
+        }
+        ProofKind::LogMetadata => {
+            parse_log_metadata(from_address, keys, data).map(ProverResult::LogMetadata)
+        }
+    }
+}
+
+/// Parsed Starknet event variants.
+pub enum StarknetEvent {
+    InitTransfer(InitTransferMessage),
+    FinTransfer(FinTransferMessage),
+    DeployToken(DeployTokenMessage),
+    LogMetadata(LogMetadataMessage),
+}
+
+/// A cursor over a slice of 32-byte felts for sequential reading.
+struct FeltCursor<'a> {
+    data: &'a [[u8; 32]],
+    pos: usize,
+}
+
+impl<'a> FeltCursor<'a> {
+    fn new(data: &'a [[u8; 32]]) -> Self {
+        Self { data, pos: 0 }
+    }
+
+    fn read_felt(&mut self) -> Result<[u8; 32], String> {
+        if self.pos >= self.data.len() {
+            return Err(format!(
+                "FeltCursor: read past end at position {}",
+                self.pos
+            ));
+        }
+        let felt = self.data[self.pos];
+        self.pos += 1;
+        Ok(felt)
+    }
+
+    fn read_u64(&mut self) -> Result<u64, String> {
+        let felt = self.read_felt()?;
+        felt_to_u64(&felt)
+    }
+
+    fn read_u128(&mut self) -> Result<u128, String> {
+        let felt = self.read_felt()?;
+        felt_to_u128(&felt)
+    }
+
+    /// Reads a Cairo `ByteArray` serialized as felts.
+    ///
+    /// Cairo `ByteArray` Serde layout:
+    /// ```text
+    /// felt[0]    = num_full_words (u32)
+    /// felt[1..N] = full_words (each a felt containing 31 bytes of data)
+    /// felt[N]    = pending_word (felt with remaining bytes, right-aligned)
+    /// felt[N+1]  = pending_word_len (number of valid bytes in pending_word)
+    /// ```
+    #[allow(clippy::cast_possible_truncation)]
+    fn read_byte_array(&mut self) -> Result<String, String> {
+        let num_full_words = self.read_u64()? as usize;
+        let mut bytes = Vec::with_capacity(num_full_words * 31 + 31);
+
+        for _ in 0..num_full_words {
+            let word = self.read_felt()?;
+            bytes.extend_from_slice(&word[1..32]);
+        }
+
+        let pending_word = self.read_felt()?;
+        let pending_len = self.read_u64()? as usize;
+
+        if pending_len > 31 {
+            return Err(format!(
+                "ByteArray: pending_word_len {pending_len} exceeds 31"
+            ));
+        }
+
+        if pending_len > 0 {
+            let start = 32 - pending_len;
+            bytes.extend_from_slice(&pending_word[start..32]);
+        }
+
+        String::from_utf8(bytes).map_err(|e| format!("ByteArray: invalid UTF-8: {e}"))
+    }
+
+    /// Reads a Cairo `Option<ByteArray>`.
+    ///
+    /// Serde layout: `0` for None, `1` followed by `ByteArray` for Some.
+    fn read_option_byte_array(&mut self) -> Result<Option<String>, String> {
+        let discriminant = self.read_u64()?;
+        match discriminant {
+            0 => Ok(None),
+            1 => self.read_byte_array().map(Some),
+            _ => Err(format!("Option: unexpected discriminant {discriminant}")),
+        }
+    }
+}
+
+fn felt_to_u64(felt: &[u8; 32]) -> Result<u64, String> {
+    if felt[..24] != [0u8; 24] {
+        return Err(format!("Felt value too large for u64: {felt:?}"));
+    }
+    Ok(u64::from_be_bytes(felt[24..32].try_into().unwrap()))
+}
+
+/// Interprets a 32-byte big-endian felt as a u128.
+/// Fails if the value exceeds `u128::MAX`.
+fn felt_to_u128(felt: &[u8; 32]) -> Result<u128, String> {
+    if felt[..16] != [0u8; 16] {
+        return Err(format!("Felt value too large for u128: {felt:?}"));
+    }
+    Ok(u128::from_be_bytes(felt[16..32].try_into().unwrap()))
+}
+
+/// Computes `sn_keccak(input)` at compile time.
+/// `sn_keccak` = keccak256(input) with the top 6 bits cleared (250-bit truncation).
+const fn compute_sn_keccak(input: &[u8]) -> [u8; 32] {
+    let hash = const_keccak256(input);
+    let mut result = hash;
+    result[0] &= 0x03; // Clear top 6 bits
+    result
+}
+
+/// Minimal const-compatible Keccak-256 implementation.
+/// Based on the Keccak-f[1600] permutation.
+const fn const_keccak256(input: &[u8]) -> [u8; 32] {
+    let rate = 136; // rate in bytes for Keccak-256 (1088 bits / 8)
+    let mut state = [0u64; 25];
+
+    // Absorb phase: pad and process blocks
+    let mut offset = 0;
+    while offset + rate <= input.len() {
+        state = xor_block(state, input, offset, rate);
+        state = keccak_f1600(state);
+        offset += rate;
+    }
+
+    // Last block with padding
+    let remaining = input.len() - offset;
+    let mut last_block = [0u8; 136];
+    let mut i = 0;
+    while i < remaining {
+        last_block[i] = input[offset + i];
+        i += 1;
+    }
+    // Keccak padding: 0x01 ... 0x80
+    last_block[remaining] = 0x01;
+    last_block[rate - 1] |= 0x80;
+
+    state = xor_block(state, &last_block, 0, rate);
+    state = keccak_f1600(state);
+
+    // Squeeze: extract first 32 bytes
+    let mut output = [0u8; 32];
+    let mut j = 0;
+    while j < 32 {
+        let word = j / 8;
+        let byte_pos = j % 8;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            output[j] = (state[word] >> (8 * byte_pos)) as u8;
+        }
+        j += 1;
+    }
+    output
+}
+
+const fn xor_block(mut state: [u64; 25], data: &[u8], offset: usize, len: usize) -> [u64; 25] {
+    let mut i = 0;
+    while i < len / 8 {
+        let base = offset + i * 8;
+        let word = (data[base] as u64)
+            | ((data[base + 1] as u64) << 8)
+            | ((data[base + 2] as u64) << 16)
+            | ((data[base + 3] as u64) << 24)
+            | ((data[base + 4] as u64) << 32)
+            | ((data[base + 5] as u64) << 40)
+            | ((data[base + 6] as u64) << 48)
+            | ((data[base + 7] as u64) << 56);
+        state[i] ^= word;
+        i += 1;
+    }
+    state
+}
+
+const fn keccak_f1600(mut state: [u64; 25]) -> [u64; 25] {
+    const RC: [u64; 24] = [
+        0x0000_0000_0000_0001,
+        0x0000_0000_0000_8082,
+        0x8000_0000_0000_808A,
+        0x8000_0000_8000_8000,
+        0x0000_0000_0000_808B,
+        0x0000_0000_8000_0001,
+        0x8000_0000_8000_8081,
+        0x8000_0000_0000_8009,
+        0x0000_0000_0000_008A,
+        0x0000_0000_0000_0088,
+        0x0000_0000_8000_8009,
+        0x0000_0000_8000_000A,
+        0x0000_0000_8000_808B,
+        0x8000_0000_0000_008B,
+        0x8000_0000_0000_8089,
+        0x8000_0000_0000_8003,
+        0x8000_0000_0000_8002,
+        0x8000_0000_0000_0080,
+        0x0000_0000_0000_800A,
+        0x8000_0000_8000_000A,
+        0x8000_0000_8000_8081,
+        0x8000_0000_0000_8080,
+        0x0000_0000_8000_0001,
+        0x8000_0000_8000_8008,
+    ];
+    const ROTATIONS: [u32; 25] = [
+        0, 1, 62, 28, 27, 36, 44, 6, 55, 20, 3, 10, 43, 25, 39, 41, 45, 15, 21, 8, 18, 2, 61, 56,
+        14,
+    ];
+    const PI: [usize; 25] = [
+        0, 10, 20, 5, 15, 16, 1, 11, 21, 6, 7, 17, 2, 12, 22, 23, 8, 18, 3, 13, 14, 24, 9, 19, 4,
+    ];
+
+    let mut round = 0;
+    while round < 24 {
+        // θ step
+        let mut c = [0u64; 5];
+        let mut x = 0;
+        while x < 5 {
+            c[x] = state[x] ^ state[x + 5] ^ state[x + 10] ^ state[x + 15] ^ state[x + 20];
+            x += 1;
+        }
+        let mut d = [0u64; 5];
+        x = 0;
+        while x < 5 {
+            d[x] = c[(x + 4) % 5] ^ c[(x + 1) % 5].rotate_left(1);
+            x += 1;
+        }
+        x = 0;
+        while x < 25 {
+            state[x] ^= d[x % 5];
+            x += 1;
+        }
+
+        // ρ and π steps
+        let mut temp = [0u64; 25];
+        x = 0;
+        while x < 25 {
+            temp[PI[x]] = state[x].rotate_left(ROTATIONS[x]);
+            x += 1;
+        }
+
+        // χ step
+        x = 0;
+        while x < 25 {
+            let y_base = (x / 5) * 5;
+            state[x] = temp[x] ^ (!temp[y_base + (x + 1) % 5] & temp[y_base + (x + 2) % 5]);
+            x += 1;
+        }
+
+        // ι step
+        state[0] ^= RC[round];
+        round += 1;
+    }
+    state
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_const_keccak256_empty() {
+        // keccak256("") = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+        let result = const_keccak256(b"");
+        let expected =
+            hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+                .unwrap();
+        assert_eq!(&result[..], &expected[..], "keccak256('') mismatch");
+    }
+
+    #[test]
+    fn test_const_keccak256_hello() {
+        // keccak256("hello") = 1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8
+        let result = const_keccak256(b"hello");
+        let expected =
+            hex::decode("1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8")
+                .unwrap();
+        assert_eq!(&result[..], &expected[..], "keccak256('hello') mismatch");
+    }
+
+    #[test]
+    fn test_sn_keccak_selectors() {
+        // Verify that our const-computed selectors match runtime sha3::Keccak256
+        use sha3::{Digest, Keccak256};
+
+        for (name, expected) in [
+            ("InitTransfer", INIT_TRANSFER_SELECTOR),
+            ("FinTransfer", FIN_TRANSFER_SELECTOR),
+            ("DeployToken", DEPLOY_TOKEN_SELECTOR),
+            ("LogMetadata", LOG_METADATA_SELECTOR),
+        ] {
+            let mut hash = Keccak256::digest(name.as_bytes()).to_vec();
+            hash[0] &= 0x03;
+            assert_eq!(&hash[..], &expected[..], "sn_keccak({name}) mismatch");
+        }
+    }
+
+    #[test]
+    fn test_felt_to_u64() {
+        let mut felt = [0u8; 32];
+        felt[31] = 42;
+        assert_eq!(felt_to_u64(&felt).unwrap(), 42);
+
+        felt[24] = 1;
+        felt[31] = 0;
+        assert_eq!(felt_to_u64(&felt).unwrap(), 1 << 56);
+
+        // Too large
+        let mut big = [0u8; 32];
+        big[23] = 1;
+        assert!(felt_to_u64(&big).is_err());
+    }
+
+    #[test]
+    fn test_felt_to_u128() {
+        let mut felt = [0u8; 32];
+        felt[31] = 100;
+        assert_eq!(felt_to_u128(&felt).unwrap(), 100);
+
+        // Too large
+        let mut big = [0u8; 32];
+        big[15] = 1;
+        assert!(felt_to_u128(&big).is_err());
+    }
+
+    /// Helper to create a felt from a u64 value.
+    fn u64_felt(val: u64) -> [u8; 32] {
+        let mut felt = [0u8; 32];
+        let bytes = val.to_be_bytes();
+        felt[24..32].copy_from_slice(&bytes);
+        felt
+    }
+
+    /// Helper to create a felt from a u128 value.
+    fn u128_felt(val: u128) -> [u8; 32] {
+        let mut felt = [0u8; 32];
+        let bytes = val.to_be_bytes();
+        felt[16..32].copy_from_slice(&bytes);
+        felt
+    }
+
+    /// Helper to create a felt from a 32-byte hex string (no 0x prefix).
+    fn hex_felt(hex_str: &str) -> [u8; 32] {
+        let bytes = hex::decode(hex_str).unwrap();
+        let mut felt = [0u8; 32];
+        let start = 32 - bytes.len();
+        felt[start..32].copy_from_slice(&bytes);
+        felt
+    }
+
+    /// Encode a Cairo `ByteArray` into felts.
+    /// Each full word is 31 bytes right-padded in the felt (stored in bytes[1..32]).
+    fn encode_byte_array(s: &str) -> Vec<[u8; 32]> {
+        let bytes = s.as_bytes();
+        let num_full_words = bytes.len() / 31;
+        let pending_len = bytes.len() % 31;
+
+        let mut felts = Vec::new();
+        // num_full_words
+        felts.push(u64_felt(num_full_words as u64));
+        // full words
+        for i in 0..num_full_words {
+            let mut word = [0u8; 32];
+            word[1..32].copy_from_slice(&bytes[i * 31..(i + 1) * 31]);
+            felts.push(word);
+        }
+        // pending_word
+        let mut pending = [0u8; 32];
+        if pending_len > 0 {
+            let start = 32 - pending_len;
+            pending[start..32].copy_from_slice(&bytes[num_full_words * 31..]);
+        }
+        felts.push(pending);
+        // pending_word_len
+        felts.push(u64_felt(pending_len as u64));
+
+        felts
+    }
+
+    #[test]
+    fn test_byte_array_encoding_roundtrip() {
+        let test_str = "near:frolik.testnet";
+        let felts = encode_byte_array(test_str);
+        let mut cursor = FeltCursor::new(&felts);
+        let decoded = cursor.read_byte_array().unwrap();
+        assert_eq!(decoded, test_str);
+    }
+
+    #[test]
+    fn test_byte_array_empty() {
+        let felts = encode_byte_array("");
+        let mut cursor = FeltCursor::new(&felts);
+        let decoded = cursor.read_byte_array().unwrap();
+        assert_eq!(decoded, "");
+    }
+
+    #[test]
+    fn test_byte_array_long_string() {
+        // 62 chars = 2 full words (2 * 31) + 0 pending
+        let long_str = "a]".repeat(31);
+        let felts = encode_byte_array(&long_str);
+        let mut cursor = FeltCursor::new(&felts);
+        let decoded = cursor.read_byte_array().unwrap();
+        assert_eq!(decoded, long_str);
+    }
+
+    #[test]
+    fn test_parse_init_transfer() {
+        let sender = hex_felt("0000000000000000000000000000000000000000000000000000000000aa0001");
+        let token_addr =
+            hex_felt("0000000000000000000000000000000000000000000000000000000000bb0002");
+        let emitter = hex_felt("0000000000000000000000000000000000000000000000000000000000cc0003");
+
+        let keys = vec![
+            INIT_TRANSFER_SELECTOR,
+            sender,
+            token_addr,
+            u64_felt(7), // origin_nonce
+        ];
+
+        let mut data = Vec::new();
+        data.push(u128_felt(1000)); // amount
+        data.push(u128_felt(10)); // fee
+        data.push(u128_felt(5)); // native_fee
+        data.extend(encode_byte_array("near:frolik.testnet")); // recipient
+        data.extend(encode_byte_array("")); // message
+
+        let msg = parse_init_transfer(&emitter, &keys, &data).unwrap();
+        assert_eq!(msg.origin_nonce, 7);
+        assert_eq!(msg.amount.0, 1000);
+        assert_eq!(msg.fee.fee.0, 10);
+        assert_eq!(msg.fee.native_fee.0, 5);
+        assert_eq!(msg.msg, "");
+        assert_eq!(msg.emitter_address, OmniAddress::Strk(H256(emitter)));
+        assert_eq!(msg.sender, OmniAddress::Strk(H256(sender)));
+        assert_eq!(msg.token, OmniAddress::Strk(H256(token_addr)));
+    }
+
+    #[test]
+    fn test_parse_log_metadata() {
+        let token_addr =
+            hex_felt("0000000000000000000000000000000000000000000000000000000000dd0001");
+        let emitter = hex_felt("0000000000000000000000000000000000000000000000000000000000ee0002");
+
+        let keys = vec![LOG_METADATA_SELECTOR, token_addr];
+
+        let mut data = Vec::new();
+        data.extend(encode_byte_array("Wrapped ETH")); // name
+        data.extend(encode_byte_array("WETH")); // symbol
+        data.push(u64_felt(18)); // decimals
+
+        let msg = parse_log_metadata(&emitter, &keys, &data).unwrap();
+        assert_eq!(msg.name, "Wrapped ETH");
+        assert_eq!(msg.symbol, "WETH");
+        assert_eq!(msg.decimals, 18);
+        assert_eq!(msg.token_address, OmniAddress::Strk(H256(token_addr)));
+        assert_eq!(msg.emitter_address, OmniAddress::Strk(H256(emitter)));
+    }
+
+    #[test]
+    fn test_parse_deploy_token() {
+        let token_addr =
+            hex_felt("0000000000000000000000000000000000000000000000000000000000dd0001");
+        let emitter = hex_felt("0000000000000000000000000000000000000000000000000000000000ee0002");
+
+        let keys = vec![DEPLOY_TOKEN_SELECTOR, token_addr];
+
+        let mut data = Vec::new();
+        data.extend(encode_byte_array("wrap.testnet")); // near_token_id
+        data.extend(encode_byte_array("Wrapped ETH")); // name
+        data.extend(encode_byte_array("WETH")); // symbol
+        data.push(u64_felt(18)); // decimals
+        data.push(u64_felt(18)); // origin_decimals
+
+        let msg = parse_deploy_token(&emitter, &keys, &data).unwrap();
+        assert_eq!(msg.token.to_string(), "wrap.testnet");
+        assert_eq!(msg.decimals, 18);
+        assert_eq!(msg.origin_decimals, 18);
+        assert_eq!(msg.token_address, OmniAddress::Strk(H256(token_addr)));
+    }
+
+    #[test]
+    fn test_parse_fin_transfer() {
+        let emitter = hex_felt("0000000000000000000000000000000000000000000000000000000000ff0001");
+        let token_addr =
+            hex_felt("0000000000000000000000000000000000000000000000000000000000aa0001");
+        let recipient =
+            hex_felt("0000000000000000000000000000000000000000000000000000000000bb0001");
+
+        let keys = vec![
+            FIN_TRANSFER_SELECTOR,
+            u64_felt(ChainKind::Eth as u64), // origin_chain
+            u64_felt(42),                    // origin_nonce
+        ];
+
+        let mut data = vec![
+            token_addr,     // token_address
+            u128_felt(500), // amount
+            recipient,      // recipient
+            u64_felt(1),    // fee_recipient:
+        ];
+        data.extend(encode_byte_array("fee.testnet"));
+        // message: None
+        data.push(u64_felt(0)); // None discriminant
+
+        let msg = parse_fin_transfer(&emitter, &keys, &data).unwrap();
+        assert_eq!(msg.transfer_id.origin_chain, ChainKind::Eth);
+        assert_eq!(msg.transfer_id.origin_nonce, 42);
+        assert_eq!(msg.amount.0, 500);
+        assert_eq!(msg.fee_recipient.unwrap().to_string(), "fee.testnet");
+        assert_eq!(msg.emitter_address, OmniAddress::Strk(H256(emitter)));
+    }
+
+    #[test]
+    fn test_parse_starknet_event_dispatches() {
+        let emitter = [0x11u8; 32];
+        let token_addr = [0x22u8; 32];
+
+        let keys = vec![LOG_METADATA_SELECTOR, token_addr];
+        let mut data = Vec::new();
+        data.extend(encode_byte_array("TestToken"));
+        data.extend(encode_byte_array("TT"));
+        data.push(u64_felt(8));
+
+        let result = parse_starknet_event(&emitter, &keys, &data).unwrap();
+        match result {
+            StarknetEvent::LogMetadata(msg) => {
+                assert_eq!(msg.name, "TestToken");
+                assert_eq!(msg.symbol, "TT");
+                assert_eq!(msg.decimals, 8);
+            }
+            _ => panic!("Expected LogMetadata variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_starknet_event_unknown_selector() {
+        let emitter = [0x11u8; 32];
+        let keys = vec![[0xffu8; 32]]; // Unknown selector
+        let data = vec![];
+
+        let result = parse_starknet_event(&emitter, &keys, &data);
+        assert!(result.is_err());
+    }
+}

--- a/near/omni-types/src/starknet/mod.rs
+++ b/near/omni-types/src/starknet/mod.rs
@@ -1,0 +1,1 @@
+pub mod events;


### PR DESCRIPTION
* feat: initial version of read mpc prover

* chore: updated `CLAUDE.md`

* refactor: verify chain and use proper errors

* fix: hash comparison

* refactor: imports

* chore: switch to `mpc-sdk`

* refactor: use verification from mpc sdk

* fix: ci

* fix: fmt

* fix: wasm compilation

* refactor: store key as a string

* chore: removed unused file

* feat: call `verify_foreign_transaction` from prover

* fix: ci

* feat: provide `VerifyForeignTransactionRequestArgs` directly in borsh

Abi doesn't work yet

* chore: added tests with real abs transaction

* feat: added `finality` guard

* chore: removed panic in a callback

* chore: added tests to cover finality mismatch

* fix: abi

* fix: read mpc prover compatibility (#569)

* fix: testing a working config

* fix: try the trick to fix ci

* fix: some clippy issues found when using all-features

* chore: removed unused features

* Revert "chore: removed unused features"

This reverts commit 407dcf13c24d92bb860cfb163ff571b629987180.

* fix: ensure that `payload.values` length is exactly 1

* refactor: renamed `mpc-omni-prover` -> `evm-mpc-prover`

* chore: updated `CLAUDE.md`

* refactor: extract request args from `sign_payload`

* fix: fmt

* feat: add `starknet` support

* chore: removed abi from default features

* fix: clippy

* fix: fmt

* chore: removed `evm-mpc-prover`

* chore: removed `derivation_path` from args

* chore: hardcode domain id

* refactor: unified provers by having a set of finalities

* chore: removed `get_finality` method

* chore: added test for generating base64 args for starknet log verification

* fix(tests): finality

---------