### PR TITLE
feat: add external_id to InitTransferMsg and bound string fields

### DIFF
--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -546,7 +546,7 @@ impl Contract {
                 native_fee: init_transfer_msg.native_token_fee,
             },
             sender: OmniAddress::Near(sender_id),
-            msg: init_transfer_msg.msg.unwrap_or_default(),
+            msg: init_transfer_msg.msg.map(String::from).unwrap_or_default(),
             destination_nonce,
             origin_transfer_id: None,
         };
@@ -558,7 +558,8 @@ impl Contract {
         let required_storage_balance =
             self.required_balance_for_init_transfer_message(transfer_message.clone());
 
-        let message_storage_account_id = transfer_message.calculate_storage_account_id();
+        let message_storage_account_id = transfer_message
+            .calculate_storage_account_id(init_transfer_msg.external_id.map(String::from));
 
         // Choose storage payer or whether to yield execution until storage is available
         if self

--- a/near/omni-bridge/src/tests/lib_test.rs
+++ b/near/omni-bridge/src/tests/lib_test.rs
@@ -93,6 +93,7 @@ fn get_init_transfer_msg(recipient: &str, fee: u128, native_token_fee: u128) -> 
         fee: U128(fee),
         native_token_fee: U128(native_token_fee),
         msg: None,
+        external_id: None,
     }
 }
 
@@ -296,6 +297,7 @@ fn test_init_transfer_locks_other_tokens_for_deployed_token() {
             fee: U128(0),
             native_token_fee: U128(0),
             msg: None,
+            external_id: None,
         }),
     );
 

--- a/near/omni-tests/src/helpers.rs
+++ b/near/omni-tests/src/helpers.rs
@@ -3,7 +3,7 @@ pub mod tests {
     use std::path::Path;
 
     use near_sdk::{borsh, json_types::U128, serde_json, AccountId, CryptoHash};
-    use near_workspaces::types::NearToken;
+    use near_workspaces::{result::ExecutionSuccess, types::NearToken};
     use omni_types::{
         locker_args::{BindTokenArgs, ClaimFeeArgs, DeployTokenArgs},
         prover_result::{DeployTokenMessage, FinTransferMessage, LogMetadataMessage, ProverResult},
@@ -319,6 +319,16 @@ pub mod tests {
             .find(|log| log.contains(event_name))
             .map(|log| serde_json::from_str(log).map_err(anyhow::Error::from))
             .transpose()
+    }
+
+    /// Returns `true` if any log emitted across all receipt outcomes of `result`
+    /// contains `expected_substring` as a substring.
+    pub fn execution_contains_log(result: &ExecutionSuccess, expected_substring: &str) -> bool {
+        result
+            .receipt_outcomes()
+            .iter()
+            .flat_map(|outcome| &outcome.logs)
+            .any(|log| log.contains(expected_substring))
     }
 
     pub fn wasm_code_hash(wasm: &[u8]) -> CryptoHash {

--- a/near/omni-tests/src/init_transfer.rs
+++ b/near/omni-tests/src/init_transfer.rs
@@ -17,7 +17,8 @@ mod tests {
         environment::TestEnvBuilder,
         helpers::tests::{
             account_n, build_artifacts, eth_eoa_address, eth_factory_address,
-            get_claim_fee_args_near, get_event_data, relayer_account_id, BuildArtifacts,
+            execution_contains_log, get_claim_fee_args_near, get_event_data, relayer_account_id,
+            BuildArtifacts,
         },
     };
 
@@ -653,7 +654,7 @@ mod tests {
         let status_b = submit_ft_transfer_call(msg_b.clone()).await?;
 
         // Fast-forward a few blocks so both yield/resume callbacks are processed.
-        env.worker.fast_forward(5);
+        env.worker.fast_forward(5).await?;
 
         let required_balance_init_transfer: NearToken = env
             .locker_contract
@@ -679,6 +680,13 @@ mod tests {
         // Each ft_transfer_call should now unblock — resumed by its storage_deposit.
         let result_a = status_a.await?.into_result()?;
         let result_b = status_b.await?.into_result()?;
+
+        for result in [&result_a, &result_b] {
+            assert!(
+                execution_contains_log(result, "Yield init transfer until storage is available at"),
+                "Expected yield log not found in receipt outcomes"
+            );
+        }
 
         // Sign + claim fee for each transfer.
         for result in [&result_a, &result_b] {

--- a/near/omni-tests/src/init_transfer.rs
+++ b/near/omni-tests/src/init_transfer.rs
@@ -8,7 +8,8 @@ mod tests {
     use near_workspaces::{result::ExecutionSuccess, types::NearToken, AccountId};
     use omni_types::{
         near_events::OmniBridgeEvent, BoundedString, BridgeOnTransferMsg, ChainKind, Fee,
-        InitTransferMsg, OmniAddress, TransferId, TransferMessage, UpdateFee,
+        InitTransferMsg, OmniAddress, TransferId, TransferMessage, TransferMessageStorageAccount,
+        UpdateFee,
     };
     use rstest::rstest;
 
@@ -550,6 +551,15 @@ mod tests {
         Ok(())
     }
 
+    /// Exercises the yield/resume path of `init_transfer` and confirms that `external_id`
+    /// is threaded into the virtual storage account ID:
+    /// 1. Sender registers with the bridge at the bare minimum (no transfer-sized storage).
+    /// 2. Two `ft_transfer_call`s are submitted with otherwise-identical messages but
+    ///    different `external_id`s. Both yield because the signer lacks storage and the
+    ///    virtual accounts don't exist yet.
+    /// 3. Two `storage_deposit`s — one per predicted virtual account ID — resume each
+    ///    yielded transfer independently.
+    /// 4. Each resumed transfer is then signed and its fee claimed as usual.
     #[rstest]
     #[tokio::test]
     async fn test_init_transfer_with_external_id(
@@ -557,45 +567,171 @@ mod tests {
     ) -> anyhow::Result<()> {
         let sender_balance_token = 1_000_000;
         let transfer_amount = 5000;
-        let base_msg = InitTransferMsg {
-            native_token_fee: U128(NearToken::from_near(1).as_yoctonear()),
-            fee: U128(1000),
-            recipient: eth_eoa_address(),
-            msg: None,
-            external_id: Some(BoundedString::new("external-id-1").unwrap()),
-        };
+        let fee = U128(1000);
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
 
-        // First transfer with an external_id — full flow must succeed end-to-end.
-        init_transfer_flow_on_near(&env, transfer_amount, base_msg.clone(), None, None, true)
-            .await?;
+        // Register the sender with the bare-minimum bridge storage. This is enough to
+        // identify the signer during resume, but not enough to fund the transfer — so
+        // `init_transfer` must take the yield branch.
+        let required_balance_for_account: NearToken = env
+            .locker_contract
+            .view("required_balance_for_account")
+            .await?
+            .json()?;
+        env.sender_account
+            .call(env.locker_contract.id(), "storage_deposit")
+            .args_json(json!({ "account_id": env.sender_account.id() }))
+            .deposit(required_balance_for_account)
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?;
 
-        // Second transfer with an otherwise-identical message but a different external_id —
-        // this confirms external_id is threaded through and does not break the flow.
-        let second_msg = InitTransferMsg {
-            external_id: Some(BoundedString::new("external-id-2").unwrap()),
-            ..base_msg.clone()
+        // The yield branch charges the bridge contract's own storage balance (for the
+        // init_transfer_promises entry). Fund it so `init_transfer` can register the yield.
+        env.sender_account
+            .call(env.locker_contract.id(), "storage_deposit")
+            .args_json(json!({ "account_id": env.locker_contract.id() }))
+            .deposit(NearToken::from_millinear(100))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?;
+
+        // Build two InitTransferMsgs that differ only by external_id.
+        let msg_a = InitTransferMsg {
+            native_token_fee: U128(0),
+            fee,
+            recipient: eth_eoa_address(),
+            msg: None,
+            external_id: Some(BoundedString::new("external-id-a").unwrap()),
         };
-        init_transfer_flow_on_near(&env, transfer_amount, second_msg, None, None, true).await?;
+        let msg_b = InitTransferMsg {
+            external_id: Some(BoundedString::new("external-id-b").unwrap()),
+            ..msg_a.clone()
+        };
+
+        // Predict the virtual storage account each transfer will yield on. All the fields
+        // consumed by the hash are known in advance: the chain-side `TransferMessage` only
+        // adds nonces to this struct, and nonces are not part of the storage-account hash.
+        let storage_account = TransferMessageStorageAccount {
+            token: OmniAddress::Near(env.token_contract.id().clone()),
+            amount: U128(transfer_amount),
+            recipient: msg_a.recipient.clone(),
+            fee: Fee {
+                fee: msg_a.fee,
+                native_fee: msg_a.native_token_fee,
+            },
+            sender: OmniAddress::Near(env.sender_account.id().clone()),
+            msg: String::new(),
+        };
+        let virtual_a = storage_account.id(Some("external-id-a".to_string()));
+        let virtual_b = storage_account.id(Some("external-id-b".to_string()));
+        assert_ne!(
+            virtual_a, virtual_b,
+            "Different external_ids must yield different virtual storage accounts"
+        );
+
+        // Fire both ft_transfer_calls without awaiting final execution — each one yields
+        // inside ft_on_transfer, so the tx stays in "Started" state until resumed.
+        let submit_ft_transfer_call = |msg: InitTransferMsg| {
+            env.sender_account
+                .call(env.token_contract.id(), "ft_transfer_call")
+                .args_json(json!({
+                    "receiver_id": env.locker_contract.id(),
+                    "amount": U128(transfer_amount),
+                    "memo": None::<String>,
+                    "msg": serde_json::to_string(&BridgeOnTransferMsg::InitTransfer(msg))
+                        .unwrap(),
+                }))
+                .deposit(NearToken::from_yoctonear(1))
+                .max_gas()
+                .transact_async()
+        };
+        let status_a = submit_ft_transfer_call(msg_a.clone()).await?;
+        let status_b = submit_ft_transfer_call(msg_b.clone()).await?;
+
+        // Give the sandbox a few blocks to register both yielded promises before resuming.
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        let required_balance_init_transfer: NearToken = env
+            .locker_contract
+            .view("required_balance_for_init_transfer")
+            .args_json(json!({}))
+            .await?
+            .json()?;
+
+        // Depositing storage on each virtual account resumes its yielded transfer. The
+        // yield callback (`init_transfer_resume`) runs as part of the original
+        // ft_transfer_call's receipt chain, so the `InitTransferEvent` shows up there.
+        for virtual_id in [&virtual_a, &virtual_b] {
+            env.relayer_account
+                .call(env.locker_contract.id(), "storage_deposit")
+                .args_json(json!({ "account_id": virtual_id }))
+                .deposit(required_balance_init_transfer)
+                .max_gas()
+                .transact()
+                .await?
+                .into_result()?;
+        }
+
+        // Each ft_transfer_call should now unblock — resumed by its storage_deposit.
+        let result_a = status_a.await?.into_result()?;
+        let result_b = status_b.await?.into_result()?;
+
+        // Sign + claim fee for each transfer.
+        for result in [&result_a, &result_b] {
+            let transfer_message = get_transfer_message_from_event(result)?;
+            env.relayer_account
+                .call(env.locker_contract.id(), "sign_transfer")
+                .args_json(json!({
+                    "transfer_id": TransferId {
+                        origin_chain: ChainKind::Near,
+                        origin_nonce: transfer_message.origin_nonce,
+                    },
+                    "fee_recipient": env.relayer_account.id(),
+                    "fee": &Some(transfer_message.fee.clone()),
+                }))
+                .max_gas()
+                .transact()
+                .await?
+                .into_result()?;
+
+            let claim_fee_args = get_claim_fee_args_near(
+                ChainKind::Near,
+                ChainKind::Eth,
+                transfer_message.origin_nonce,
+                env.relayer_account.id(),
+                transfer_amount - transfer_message.fee.fee.0,
+                env.eth_factory_address.clone(),
+            );
+            env.relayer_account
+                .call(env.locker_contract.id(), "claim_fee")
+                .args_borsh(claim_fee_args)
+                .deposit(NearToken::from_yoctonear(1))
+                .max_gas()
+                .transact()
+                .await?
+                .into_result()?;
+        }
 
         let (user_balance_token, locker_balance_token, relayer_balance_token, _) =
             get_test_balances(&env).await?;
-
         assert_eq!(
             user_balance_token,
             U128(sender_balance_token - 2 * transfer_amount),
-            "User balance was not deducted for both transfers"
+            "User balance was not deducted for both resumed transfers"
         );
         assert_eq!(
             locker_balance_token,
-            U128(2 * (transfer_amount - base_msg.fee.0)),
-            "Locker balance was not increased for both transfers"
+            U128(2 * (transfer_amount - fee.0)),
+            "Locker balance was not increased for both resumed transfers"
         );
         assert_eq!(
             relayer_balance_token,
-            U128(2 * base_msg.fee.0),
-            "Relayer didn't receive transfer fee for both transfers."
+            U128(2 * fee.0),
+            "Relayer didn't receive transfer fee for both resumed transfers"
         );
         Ok(())
     }

--- a/near/omni-tests/src/init_transfer.rs
+++ b/near/omni-tests/src/init_transfer.rs
@@ -652,8 +652,8 @@ mod tests {
         let status_a = submit_ft_transfer_call(msg_a.clone()).await?;
         let status_b = submit_ft_transfer_call(msg_b.clone()).await?;
 
-        // Give the sandbox a few blocks to register both yielded promises before resuming.
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        // Fast-forward a few blocks so both yield/resume callbacks are processed.
+        env.worker.fast_forward(5);
 
         let required_balance_init_transfer: NearToken = env
             .locker_contract

--- a/near/omni-tests/src/init_transfer.rs
+++ b/near/omni-tests/src/init_transfer.rs
@@ -7,8 +7,8 @@ mod tests {
     };
     use near_workspaces::{result::ExecutionSuccess, types::NearToken, AccountId};
     use omni_types::{
-        near_events::OmniBridgeEvent, BridgeOnTransferMsg, ChainKind, Fee, InitTransferMsg,
-        OmniAddress, TransferId, TransferMessage, UpdateFee,
+        near_events::OmniBridgeEvent, BoundedString, BridgeOnTransferMsg, ChainKind, Fee,
+        InitTransferMsg, OmniAddress, TransferId, TransferMessage, UpdateFee,
     };
     use rstest::rstest;
 
@@ -302,6 +302,7 @@ mod tests {
             fee: U128(0),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
@@ -349,6 +350,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
@@ -394,6 +396,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
@@ -448,6 +451,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
         let update_fee_value = Fee {
             native_fee: U128(NearToken::from_near(2).as_yoctonear()),
@@ -507,6 +511,7 @@ mod tests {
             fee: U128(0),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
@@ -547,6 +552,56 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn test_init_transfer_with_external_id(
+        build_artifacts: &BuildArtifacts,
+    ) -> anyhow::Result<()> {
+        let sender_balance_token = 1_000_000;
+        let transfer_amount = 5000;
+        let base_msg = InitTransferMsg {
+            native_token_fee: U128(NearToken::from_near(1).as_yoctonear()),
+            fee: U128(1000),
+            recipient: eth_eoa_address(),
+            msg: None,
+            external_id: Some(BoundedString::new("external-id-1").unwrap()),
+        };
+
+        let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
+
+        // First transfer with an external_id — full flow must succeed end-to-end.
+        init_transfer_flow_on_near(&env, transfer_amount, base_msg.clone(), None, None, true)
+            .await?;
+
+        // Second transfer with an otherwise-identical message but a different external_id —
+        // this confirms external_id is threaded through and does not break the flow.
+        let second_msg = InitTransferMsg {
+            external_id: Some(BoundedString::new("external-id-2").unwrap()),
+            ..base_msg.clone()
+        };
+        init_transfer_flow_on_near(&env, transfer_amount, second_msg, None, None, true).await?;
+
+        let (user_balance_token, locker_balance_token, relayer_balance_token, _) =
+            get_test_balances(&env).await?;
+
+        assert_eq!(
+            user_balance_token,
+            U128(sender_balance_token - 2 * transfer_amount),
+            "User balance was not deducted for both transfers"
+        );
+        assert_eq!(
+            locker_balance_token,
+            U128(2 * (transfer_amount - base_msg.fee.0)),
+            "Locker balance was not increased for both transfers"
+        );
+        assert_eq!(
+            relayer_balance_token,
+            U128(2 * base_msg.fee.0),
+            "Relayer didn't receive transfer fee for both transfers."
+        );
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
     async fn test_untrusted_sender_cannot_sign_transfer(
         build_artifacts: &BuildArtifacts,
     ) -> anyhow::Result<()> {
@@ -557,6 +612,7 @@ mod tests {
             fee: U128(0),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
 
         let env = TestEnv::new(sender_balance_token, false, build_artifacts).await?;
@@ -632,6 +688,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
         let update_fee_value = Fee {
             native_fee: U128(NearToken::from_near(0).as_yoctonear()),
@@ -666,6 +723,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
         let update_fee_value = Fee {
             native_fee: U128(NearToken::from_near(1).as_yoctonear()),
@@ -700,6 +758,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
         let update_fee_value = Fee {
             native_fee: U128(NearToken::from_near(1).as_yoctonear()),
@@ -735,6 +794,7 @@ mod tests {
             fee: U128(1000),
             recipient: eth_eoa_address(),
             msg: None,
+            external_id: None,
         };
         let update_fee = UpdateFee::Proof(vec![]);
 

--- a/near/omni-tests/src/native_fee_role.rs
+++ b/near/omni-tests/src/native_fee_role.rs
@@ -207,6 +207,7 @@ mod tests {
                 fee: U128(token_fee),
                 recipient: eth_eoa_address(),
                 msg: None,
+                external_id: None,
             };
 
             let required_balance_init_transfer: NearToken = self

--- a/near/omni-types/src/bounded_string.rs
+++ b/near/omni-types/src/bounded_string.rs
@@ -1,0 +1,125 @@
+use std::fmt;
+use std::io;
+use std::str::FromStr;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
+
+use crate::errors::TypesError;
+
+/// UTF-8 string whose byte length is bounded by `MAX`.
+///
+/// The bound is enforced on construction ([`BoundedString::new`] / [`FromStr`]) and on
+/// both JSON and Borsh deserialization. Oversized inputs fail with
+/// [`TypesError::StringTooLong`], preventing untrusted callers from passing arbitrarily
+/// large strings that would inflate storage and gas costs or grow hashes without bound.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, BorshSerialize)]
+#[serde(transparent)]
+pub struct BoundedString<const MAX: usize>(String);
+
+impl<const MAX: usize> BoundedString<MAX> {
+    pub const MAX_LEN: usize = MAX;
+
+    pub fn new(s: impl Into<String>) -> Result<Self, TypesError> {
+        let s = s.into();
+        if s.len() > MAX {
+            return Err(TypesError::StringTooLong);
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> fmt::Display for BoundedString<MAX> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<const MAX: usize> AsRef<str> for BoundedString<MAX> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> From<BoundedString<MAX>> for String {
+    fn from(value: BoundedString<MAX>) -> Self {
+        value.0
+    }
+}
+
+impl<const MAX: usize> FromStr for BoundedString<MAX> {
+    type Err = TypesError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl<'de, const MAX: usize> Deserialize<'de> for BoundedString<MAX> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <String as Deserialize>::deserialize(deserializer)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<const MAX: usize> BorshDeserialize for BoundedString<MAX> {
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let s = String::deserialize_reader(reader)?;
+        Self::new(s).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Bs8 = BoundedString<8>;
+
+    #[test]
+    fn new_accepts_within_limit() {
+        assert_eq!(Bs8::new("hello").unwrap().as_str(), "hello");
+        // Exact limit is allowed.
+        assert_eq!(Bs8::new("12345678").unwrap().as_str(), "12345678");
+        // Empty is allowed.
+        assert_eq!(Bs8::new("").unwrap().as_str(), "");
+    }
+
+    #[test]
+    fn new_rejects_oversize() {
+        let err = Bs8::new("123456789").unwrap_err();
+        assert_eq!(err, TypesError::StringTooLong);
+    }
+
+    #[test]
+    fn json_roundtrips_and_enforces_limit() {
+        let bs = Bs8::new("hi").unwrap();
+        let json = near_sdk::serde_json::to_string(&bs).unwrap();
+        assert_eq!(json, "\"hi\"");
+        let parsed: Bs8 = near_sdk::serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, bs);
+
+        // Oversize rejected at deserialization.
+        let err = near_sdk::serde_json::from_str::<Bs8>("\"123456789\"").unwrap_err();
+        assert!(err.to_string().contains("ERR_STRING_TOO_LONG"));
+    }
+
+    #[test]
+    fn borsh_roundtrips_and_enforces_limit() {
+        let bs = Bs8::new("hi").unwrap();
+        let bytes = borsh::to_vec(&bs).unwrap();
+        let parsed: Bs8 = borsh::from_slice(&bytes).unwrap();
+        assert_eq!(parsed, bs);
+
+        // Manually craft a borsh-encoded oversized string and confirm it's rejected.
+        let oversized = String::from("123456789");
+        let bytes = borsh::to_vec(&oversized).unwrap();
+        assert!(borsh::from_slice::<Bs8>(&bytes).is_err());
+    }
+}

--- a/near/omni-types/src/errors.rs
+++ b/near/omni-types/src/errors.rs
@@ -129,6 +129,7 @@ pub enum ProverError {
 pub enum TypesError {
     InvalidHex,
     InvalidHexLength,
+    StringTooLong,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, AsRefStr, ErrorDisplay)]

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -12,6 +12,7 @@ use num_enum::IntoPrimitive;
 use schemars::JsonSchema;
 use sol_address::SolAddress;
 
+pub mod bounded_string;
 pub mod btc;
 pub mod errors;
 pub mod evm;
@@ -28,6 +29,7 @@ pub mod utils;
 #[cfg(test)]
 mod tests;
 
+pub use bounded_string::BoundedString;
 pub use errors::{
     BridgeError, OmniError, ProverError, StorageBalanceError, StorageError, TokenError, TypesError,
 };
@@ -444,12 +446,25 @@ pub enum BridgeOnTransferMsg {
     SwapMigratedToken,
 }
 
+/// Maximum byte length for `InitTransferMsg::msg` — caps the user-supplied hook payload
+/// forwarded to the destination chain.
+pub const MAX_INIT_TRANSFER_MSG_LEN: usize = 2048;
+/// Maximum byte length for `InitTransferMsg::external_id` — large enough for UUIDs or
+/// hex-encoded 32-byte hashes, small enough to bound storage-account-hash inputs.
+pub const MAX_EXTERNAL_ID_LEN: usize = 64;
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InitTransferMsg {
     pub recipient: OmniAddress,
     pub fee: U128,
     pub native_token_fee: U128,
-    pub msg: Option<String>,
+    /// Optional caller-supplied destination-chain hook payload. Length-capped to
+    /// [`MAX_INIT_TRANSFER_MSG_LEN`] bytes to prevent unbounded storage/gas inflation.
+    pub msg: Option<BoundedString<MAX_INIT_TRANSFER_MSG_LEN>>,
+    /// Optional caller-provided identifier mixed into the virtual storage account ID hash.
+    /// Lets otherwise-identical transfers derive distinct storage accounts so their
+    /// storage deposits do not collide. Length-capped to [`MAX_EXTERNAL_ID_LEN`] bytes.
+    pub external_id: Option<BoundedString<MAX_EXTERNAL_ID_LEN>>,
 }
 
 impl InitTransferMsg {
@@ -543,8 +558,8 @@ impl TransferMessage {
         self.recipient.get_chain()
     }
 
-    pub fn calculate_storage_account_id(&self) -> AccountId {
-        TransferMessageStorageAccount::from(self.clone()).id()
+    pub fn calculate_storage_account_id(&self, external_id: Option<String>) -> AccountId {
+        TransferMessageStorageAccount::from(self.clone()).id(external_id)
     }
 
     pub fn amount_without_fee(&self) -> Option<u128> {
@@ -566,8 +581,12 @@ pub struct TransferMessageStorageAccount {
 
 impl TransferMessageStorageAccount {
     #[allow(clippy::missing_panics_doc)]
-    pub fn id(&self) -> AccountId {
-        let hash = utils::sha256(&borsh::to_vec(self).unwrap());
+    pub fn id(&self, external_id: Option<String>) -> AccountId {
+        let mut bytes = borsh::to_vec(self).unwrap();
+        if let Some(external_id) = external_id {
+            bytes.extend_from_slice(external_id.as_bytes());
+        }
+        let hash = utils::sha256(&bytes);
         let implicit_account_id = hex::encode(hash);
         AccountId::try_from(implicit_account_id).unwrap()
     }


### PR DESCRIPTION
## Summary

- Add a new `external_id: Option<...>` field to `InitTransferMsg`. It's mixed into the virtual storage account hash so otherwise-identical transfers can derive distinct storage accounts and their storage deposits don't collide.
- Introduce `BoundedString<const MAX: usize>` in `omni-types` — a length-capped string wrapper that enforces its bound on construction, JSON deserialization, and Borsh deserialization. Oversized inputs fail with a new `TypesError::StringTooLong`.
- Apply `BoundedString` to `InitTransferMsg`:
  - `msg: Option<BoundedString<MAX_INIT_TRANSFER_MSG_LEN>>` (2048 B) — caps the caller-supplied destination-chain hook payload.
  - `external_id: Option<BoundedString<MAX_EXTERNAL_ID_LEN>>` (64 B) — caps the new identifier.
- Thread `external_id` through `TransferMessage::calculate_storage_account_id` and `TransferMessageStorageAccount::id`: when present, its bytes are appended to the borsh-encoded storage-account struct before hashing.

## Why

Two motivations:

1. **`external_id`**: without it, two identical outbound transfers from the same sender hash to the same virtual storage account — their pre-funded storage deposits collide. `external_id` is a caller-provided discriminator that breaks that collision.
2. **Bounded strings**: `msg` and `external_id` are user-controlled. Without a cap, callers could submit arbitrarily large payloads, inflating storage/gas costs and growing the storage-account-hash input without bound. Enforcing the limit at the type boundary rejects oversized input before any contract logic runs.

## Notes

- `BoundedString` bounds are enforced at every entry point: `BoundedString::new`, `FromStr`, `serde::Deserialize`, `BorshDeserialize`.
- `From<BoundedString<MAX>> for String` + `Default` keep downstream conversion ergonomic (`.map(String::from)`, `.unwrap_or_default()`).
- Chosen limits — 2048 B for `msg`, 64 B for `external_id` — are generous enough for real use (JSON hook payloads, UUIDs / hex-encoded 32-byte hashes) while still bounded.

## Test plan

- [x] New unit tests in `bounded_string.rs` cover: construction within/at/over limit, JSON roundtrip + oversize rejection, Borsh roundtrip + oversize rejection.
- [x] New integration test `test_init_transfer_with_external_id` runs two full init-transfer flows with different `external_id`s and asserts sender/locker/relayer balances reflect both transfers.
- [x] Updated every existing `InitTransferMsg` construction in `omni-tests` and `omni-bridge` tests with `external_id: None`.
- [x] `make clippy-near` clean (pedantic).