### PR TITLE
fix: Starknet nonce on reentrancy

### DIFF
--- a/starknet/Scarb.lock
+++ b/starknet/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "omni_bridge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/starknet/Scarb.toml
+++ b/starknet/Scarb.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni_bridge"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024_07"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html

--- a/starknet/src/omni_bridge.cairo
+++ b/starknet/src/omni_bridge.cairo
@@ -292,7 +292,8 @@ mod OmniBridge {
             assert(amount > 0, 'ERR_ZERO_AMOUNT');
             assert(fee < amount, 'ERR_INVALID_FEE');
 
-            self.current_origin_nonce.write(self.current_origin_nonce.read() + 1);
+            let origin_nonce = self.current_origin_nonce.read() + 1;
+            self.current_origin_nonce.write(origin_nonce);
 
             let caller = get_caller_address();
 
@@ -318,7 +319,7 @@ mod OmniBridge {
                         InitTransfer {
                             sender: caller,
                             token_address,
-                            origin_nonce: self.current_origin_nonce.read(),
+                            origin_nonce,
                             amount,
                             fee,
                             native_fee,


### PR DESCRIPTION
### Summary
Fixes H-03 from the Cairo Security Clan audit (reclassified as Low severity — no funds at risk, only log-stream desynchronization for a self-attacker using their own malicious token).

init_transfer re-read current_origin_nonce after external token calls, so a reentrant transfer_from callback could cause the outer call to emit an InitTransfer event with the post-reentrancy nonce value — producing two events sharing the same origin_nonce and a "skipped" nonce in the log stream.

Snapshot the nonce into a local before any external call and use the local both for the storage write and the event payload.

### Changes
[starknet/src/omni_bridge.cairo](vscode-webview://02tcmsvfacgr9apk4uagp69t6u5i9dd248j70uig4tp084e2c074/starknet/src/omni_bridge.cairo): compute origin_nonce once, reuse for storage and event emission.