### PR TITLE
feat(1155): add token id to the metadata

### DIFF
--- a/evm/src/omni-bridge/contracts/OmniBridge.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridge.sol
@@ -249,19 +249,15 @@ contract OmniBridge is
             }
         }
 
-        logMetadataExtension(
-            deterministicToken,
+        string memory name = string.concat(
             Strings.toHexString(tokenAddress),
-            "",
-            0
+            ":",
+            Strings.toString(tokenId)
         );
 
-        emit BridgeTypes.LogMetadata(
-            deterministicToken,
-            Strings.toHexString(tokenAddress),
-            "",
-            0
-        );
+        logMetadataExtension(deterministicToken, name, "", 0);
+
+        emit BridgeTypes.LogMetadata(deterministicToken, name, "", 0);
     }
 
     function logMetadataExtension(

--- a/evm/src/omni-bridge/contracts/OmniBridge.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridge.sol
@@ -251,7 +251,7 @@ contract OmniBridge is
 
         string memory name = string.concat(
             Strings.toHexString(tokenAddress),
-            ":",
+            "#",
             Strings.toString(tokenId)
         );
 

--- a/evm/tests/OmniBridge1155.test.ts
+++ b/evm/tests/OmniBridge1155.test.ts
@@ -134,10 +134,11 @@ describe("OmniBridge ERC1155", () => {
   it("logs metadata for ERC1155 tokens and sets mapping", async () => {
     const tokenAddress = await erc1155.getAddress()
     const deterministic = await bridge.deriveDeterministicAddress(tokenAddress, tokenId)
+    const expectedName = `${tokenAddress.toLowerCase()}#${tokenId}`
 
     await expect(bridge.logMetadata1155(tokenAddress, tokenId))
       .to.emit(bridge, "LogMetadata")
-      .withArgs(deterministic, tokenAddress.toLowerCase(), "", 0)
+      .withArgs(deterministic, expectedName, "", 0)
 
     const storedMapping = await bridge.multiTokens(deterministic)
     expect(storedMapping.tokenAddress).to.equal(tokenAddress)
@@ -146,7 +147,7 @@ describe("OmniBridge ERC1155", () => {
     // Calling again should reuse mapping without reverting
     await expect(bridge.logMetadata1155(tokenAddress, tokenId))
       .to.emit(bridge, "LogMetadata")
-      .withArgs(deterministic, tokenAddress.toLowerCase(), "", 0)
+      .withArgs(deterministic, expectedName, "", 0)
   })
 
   it("derives deterministic addresses consistently and rejects collisions", async () => {


### PR DESCRIPTION
This pull request updates the way token metadata is logged in the `OmniBridge` contract. The main change is to improve the metadata emitted for tokens by including both the token address and token ID in the log, making it easier to identify specific tokens.

**Metadata logging improvements:**

* The `name` variable now concatenates the token address and token ID (as a string) separated by a `#`, and this value is used in both the `logMetadataExtension` call and the `LogMetadata` event emission. This replaces the previous approach, which only included the token address.