### PR TITLE
fix: Solana build issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,12 +58,12 @@ solana-build: ENV = mainnet
 solana-build-dev solana-build:
 	cd solana && \
 	PROGRAM_ID=$$(solana address -k target/deploy/bridge_token_factory-keypair.json) && \
-	RUSTUP_TOOLCHAIN="nightly-2026-01-08" anchor build --verifiable --env "PROGRAM_ID=$$PROGRAM_ID" -- --no-default-features --features $(ENV)
+	RUSTUP_TOOLCHAIN="nightly-2026-01-08" anchor build --verifiable --program-name bridge_token_factory --env "PROGRAM_ID=$$PROGRAM_ID" -- --no-default-features --features $(ENV)
 
 solana-build-ci:
 	cd solana && \
 	export PROGRAM_ID=dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe && \
-	RUSTUP_TOOLCHAIN="nightly-2026-01-08" anchor build --verifiable --env "PROGRAM_ID=$$PROGRAM_ID" -- --no-default-features --features mainnet
+	RUSTUP_TOOLCHAIN="nightly-2026-01-08" anchor build --verifiable --program-name bridge_token_factory --env "PROGRAM_ID=$$PROGRAM_ID" -- --no-default-features --features mainnet
 
 solana-deploy-dev: ENV = devnet
 solana-deploy: ENV = mainnet

--- a/solana/CLAUDE.md
+++ b/solana/CLAUDE.md
@@ -4,8 +4,8 @@
 
 ```sh
 cd solana
-anchor build          # build bridge_token_factory.so + stub_program.so
-cargo test --package bridge_token_factory --test mollusk  # fast unit tests, no validator
+anchor build              # build bridge_token_factory.so + stub_program.so
+make -C .. solana-run-tests  # fast unit tests, no validator
 ```
 
 ## Key Architecture

--- a/solana/README.md
+++ b/solana/README.md
@@ -12,5 +12,5 @@ anchor build
 
 ```sh
 # Unit tests (no validator needed, fast)
-cargo test --package bridge_token_factory --test mollusk
+make solana-run-tests
 ```

--- a/solana/programs/bridge_token_factory/Cargo.toml
+++ b/solana/programs/bridge_token_factory/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 crate-type = ["cdylib", "lib"]
 name = "bridge_token_factory"
 
+[[test]]
+name = "mollusk"
+path = "tests/mollusk.rs"
+required-features = ["no-entrypoint"]
+
 [features]
 default = ["mainnet"]
 cpi = ["no-entrypoint"]


### PR DESCRIPTION
## Summary

`make solana-build-ci` (run by the `Update Contracts` release workflow) was failing with two
unrelated errors. This PR fixes both.

### 1. Duplicate `entrypoint` symbol during IDL extraction

`anchor build --verifiable` runs `cargo test __anchor_private_print_idl --features idl-build`
to extract the IDL. `cargo test` compiles **every** test target in the package, so the
`mollusk` integration test got built even though it wasn't selected to run. That binary linked
both `bridge_token_factory` (entrypoint emitted by `#[program]`) and the `stub_program`
dev-dep (entrypoint emitted by `entrypoint!`), producing:

rust-lld: error: duplicate symbol: entrypoint



Local `make solana-run-tests` worked because it passes `--features no-entrypoint`, which
suppresses bridge_token_factory's entrypoint and leaves only stub_program's.

**Fix:** gate the mollusk test on `no-entrypoint` via `required-features` so Cargo skips
compiling it during IDL extraction. Local tests still pass `--features no-entrypoint`, so
nothing changes for them.

### 2. `stub_program` doesn't have a `mainnet` feature

`anchor build` iterates over every workspace member under `programs/*` and applies the same
`-- --no-default-features --features mainnet` args to each. `stub_program` is a test fixture
(loaded as a `.so` by mollusk) and doesn't define `mainnet`/`devnet`, so the build aborted:

error: the package 'stub_program' does not contain this feature: mainnet



**Fix:** scope `solana-build`, `solana-build-dev`, and `solana-build-ci` to
`--program-name bridge_token_factory`. `stub_program` is never deployed and isn't listed in
`Anchor.toml`'s `[programs.localnet]`, so excluding it from the verifiable build is correct.
