### PR TITLE
fix(near): allocate more gas for `utxo_fin_transfer_to_near_callback`

### DIFF
--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "evm-prover"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-omni-prover"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "alloy",
  "borsh",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "omni-bridge"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "borsh",
  "hex",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "omni-token"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "borsh",
  "near-contract-standards",
@@ -4030,7 +4030,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-deployer"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "borsh",
  "cargo-near-build",
@@ -4835,7 +4835,7 @@ checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "wormhole-omni-prover-proxy"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "borsh",
  "hex",

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Near One <info@nearone.org>"]
 repository = "https://github.com/Near-One/omni-bridge"
-version = "0.4.7"
+version = "0.4.8"
 
 [workspace]
 resolver = "2"

--- a/near/mock/mock-utxo-connector/src/lib.rs
+++ b/near/mock/mock-utxo-connector/src/lib.rs
@@ -1,9 +1,8 @@
 use near_sdk::json_types::U128;
 use near_sdk::serde_json;
-use near_sdk::{ext_contract, near, AccountId, Gas, NearToken, PanicOnDefault, Promise};
+use near_sdk::{ext_contract, near, AccountId, NearToken, PanicOnDefault, Promise};
 use omni_types::{BridgeOnTransferMsg, UtxoFinTransferMsg};
 
-const FT_TRANSFER_CALL_GAS: Gas = Gas::from_tgas(210);
 const ONE_YOCTO: NearToken = NearToken::from_yoctonear(1);
 
 #[ext_contract(ext_token)]
@@ -39,7 +38,6 @@ impl MockUtxoConnector {
     pub fn verify_deposit(&mut self, amount: U128, msg: UtxoFinTransferMsg) -> Promise {
         ext_token::ext(self.token_account.clone())
             .with_attached_deposit(ONE_YOCTO)
-            .with_static_gas(FT_TRANSFER_CALL_GAS)
             .ft_transfer_call(
                 self.bridge_account.clone(),
                 amount,

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -2542,7 +2542,9 @@ impl Contract {
         Self::check_or_pay_ft_storage(&deposit_action, &mut NearToken::from_yoctonear(0)).then(
             Self::ext(env::current_account_id())
                 .with_static_gas(
-                    UTXO_FIN_TRANSFER_CALLBACK_GAS.saturating_add(FT_TRANSFER_CALL_GAS),
+                    UTXO_FIN_TRANSFER_CALLBACK_GAS
+                        .saturating_add(MINT_TOKEN_GAS)
+                        .saturating_add(FT_TRANSFER_CALL_GAS),
                 )
                 .utxo_fin_transfer_to_near_callback(
                     token_id,

--- a/near/omni-bridge/src/lib.rs
+++ b/near/omni-bridge/src/lib.rs
@@ -60,6 +60,7 @@ const CLAIM_FEE_CALLBACK_GAS: Gas = Gas::from_tgas(50);
 const BIND_TOKEN_CALLBACK_GAS: Gas = Gas::from_tgas(25);
 const BIND_TOKEN_REFUND_GAS: Gas = Gas::from_tgas(5);
 const FT_TRANSFER_CALL_GAS: Gas = Gas::from_tgas(210);
+const MIN_FT_TRANSFER_CALL_GAS: Gas = Gas::from_tgas(50);
 const FT_TRANSFER_GAS: Gas = Gas::from_tgas(5);
 const UPDATE_CONTROLLER_GAS: Gas = Gas::from_tgas(250);
 const WNEAR_WITHDRAW_GAS: Gas = Gas::from_tgas(5);
@@ -72,7 +73,7 @@ const BURN_TOKEN_GAS: Gas = Gas::from_tgas(3);
 const MINT_TOKEN_GAS: Gas = Gas::from_tgas(5);
 const SET_METADATA_GAS: Gas = Gas::from_tgas(10);
 const RESOLVE_FAST_TRANSFER_GAS: Gas = Gas::from_tgas(6);
-const UTXO_FIN_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(5);
+const UTXO_FIN_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(10);
 const RESOLVE_UTXO_FIN_TRANSFER_GAS: Gas = Gas::from_tgas(3);
 const FAST_TRANSFER_CALLBACK_GAS: Gas = Gas::from_tgas(10);
 const NO_DEPOSIT: NearToken = NearToken::from_near(0);
@@ -2056,6 +2057,12 @@ impl Contract {
         amount: U128,
         msg: &str,
     ) -> Promise {
+        let ft_transfer_call_gas = env::prepaid_gas()
+            .saturating_sub(env::used_gas())
+            .saturating_sub(SEND_TOKENS_CALLBACK_GAS) // TODO: not all send_tokens callbacks has the same gas.
+            .saturating_sub(MINT_TOKEN_GAS)
+            .min(FT_TRANSFER_CALL_GAS);
+
         let is_deployed_token = self.is_deployed_token(&token);
 
         if token == self.wnear_account_id && msg.is_empty() {
@@ -2075,9 +2082,15 @@ impl Contract {
             } else {
                 ONE_YOCTO
             };
+
+            require!(
+                ft_transfer_call_gas >= MIN_FT_TRANSFER_CALL_GAS,
+                BridgeError::NotEnoughGasForTokenTransfer(ft_transfer_call_gas).as_ref()
+            );
+
             ext_token::ext(token)
                 .with_attached_deposit(deposit)
-                .with_static_gas(MINT_TOKEN_GAS.saturating_add(FT_TRANSFER_CALL_GAS))
+                .with_static_gas(MINT_TOKEN_GAS.saturating_add(ft_transfer_call_gas))
                 .mint(
                     recipient,
                     amount,
@@ -2089,9 +2102,14 @@ impl Contract {
                 .with_static_gas(FT_TRANSFER_GAS)
                 .ft_transfer(recipient, amount, None)
         } else {
+            require!(
+                ft_transfer_call_gas >= MIN_FT_TRANSFER_CALL_GAS,
+                BridgeError::NotEnoughGasForTokenTransfer(ft_transfer_call_gas).as_ref()
+            );
+
             ext_token::ext(token)
                 .with_attached_deposit(ONE_YOCTO)
-                .with_static_gas(FT_TRANSFER_CALL_GAS)
+                .with_static_gas(ft_transfer_call_gas)
                 .ft_transfer_call(recipient, amount, None, msg.to_string())
         }
     }
@@ -2447,6 +2465,7 @@ impl Contract {
         );
 
         if let Some(status) = self.get_fast_transfer_status(&fast_transfer.id()) {
+            // TODO: check how to deal with failed send_tokens
             return self.utxo_fin_transfer_fast(fast_transfer, status, utxo_fin_transfer_msg);
         }
 
@@ -2542,9 +2561,9 @@ impl Contract {
         Self::check_or_pay_ft_storage(&deposit_action, &mut NearToken::from_yoctonear(0)).then(
             Self::ext(env::current_account_id())
                 .with_static_gas(
-                    UTXO_FIN_TRANSFER_CALLBACK_GAS
-                        .saturating_add(MINT_TOKEN_GAS)
-                        .saturating_add(FT_TRANSFER_CALL_GAS),
+                    env::prepaid_gas()
+                        .saturating_sub(env::used_gas())
+                        .saturating_sub(UTXO_FIN_TRANSFER_CALLBACK_GAS),
                 )
                 .utxo_fin_transfer_to_near_callback(
                     token_id,

--- a/near/omni-tests/src/utxo_fin_transfer.rs
+++ b/near/omni-tests/src/utxo_fin_transfer.rs
@@ -5,7 +5,10 @@ mod tests {
         serde_json::{self, json},
         AccountId,
     };
-    use near_workspaces::{result::ExecutionFinalResult, types::NearToken};
+    use near_workspaces::{
+        result::ExecutionFinalResult,
+        types::{Gas, NearToken},
+    };
     use omni_types::{
         BridgeOnTransferMsg, ChainKind, FastFinTransferMsg, Fee, OmniAddress, TransferId,
         TransferIdKind, UnifiedTransferId, UtxoFinTransferMsg,
@@ -490,9 +493,16 @@ mod tests {
     }
 
     #[rstest]
+    #[case::enough_gas_succeeds(Gas::from_tgas(150), None)]
+    #[case::insufficient_gas_fails(
+        Gas::from_tgas(50),
+        Some("ERR_NOT_ENOUGH_GAS_FOR_TOKEN_TRANSFER")
+    )]
     #[tokio::test]
-    async fn utxo_fin_transfer_with_msg_succeeds(
+    async fn utxo_fin_transfer_with_msg_gas_budget(
         build_artifacts: &BuildArtifacts,
+        #[case] gas: Gas,
+        #[case] expected_error: Option<&str>,
     ) -> anyhow::Result<()> {
         let env_builder = TestEnvBuilder::new(build_artifacts.clone())
             .await?
@@ -554,33 +564,44 @@ mod tests {
                 "amount": U128(amount),
                 "msg": utxo_msg,
             }))
-            .gas(near_workspaces::types::Gas::from_tgas(150))
+            .gas(gas)
             .transact()
             .await?;
 
-        assert!(
-            result.failures().is_empty(),
-            "verify_deposit had unexpected failures: {:?}",
-            result.failures()
-        );
-
         let receiver_balance_after =
             get_balance(&env_builder.token.contract, token_receiver.id()).await?;
-        assert_eq!(
-            receiver_balance_after.0,
-            receiver_balance_before.0 + amount,
-            "receiver should have received the full amount via ft_transfer_call"
-        );
 
-        let receiver_logged_ft_on_transfer = result
-            .receipt_outcomes()
-            .iter()
-            .flat_map(|o| &o.logs)
-            .any(|log| log.contains("ft_on_transfer called with sender_id"));
-        assert!(
-            receiver_logged_ft_on_transfer,
-            "recipient's ft_on_transfer was not invoked"
-        );
+        if let Some(expected) = expected_error {
+            assert!(
+                has_error_message(&result, expected),
+                "expected error {expected:?} not found; failures: {:?}",
+                result.failures(),
+            );
+            assert_eq!(
+                receiver_balance_before.0, receiver_balance_after.0,
+                "recipient balance should be unchanged on failure"
+            );
+        } else {
+            assert!(
+                result.failures().is_empty(),
+                "verify_deposit had unexpected failures: {:?}",
+                result.failures()
+            );
+            assert_eq!(
+                receiver_balance_after.0,
+                receiver_balance_before.0 + amount,
+                "recipient should have received the full amount via ft_transfer_call"
+            );
+            let receiver_logged_ft_on_transfer = result
+                .receipt_outcomes()
+                .iter()
+                .flat_map(|o| &o.logs)
+                .any(|log| log.contains("ft_on_transfer called with sender_id"));
+            assert!(
+                receiver_logged_ft_on_transfer,
+                "recipient's ft_on_transfer was not invoked"
+            );
+        }
 
         Ok(())
     }

--- a/near/omni-tests/src/utxo_fin_transfer.rs
+++ b/near/omni-tests/src/utxo_fin_transfer.rs
@@ -504,7 +504,8 @@ mod tests {
         env_builder
             .omni_storage_deposit(relayer_account.id(), 1_000_000_000_000_000_000_000_000)
             .await?;
-        env_builder.bridge_contract
+        env_builder
+            .bridge_contract
             .call("set_locked_tokens")
             .args_json(json!({
                 "args": [{
@@ -545,12 +546,15 @@ mod tests {
             get_balance(&env_builder.token.contract, token_receiver.id()).await?;
 
         let result = relayer_account
-            .call(env_builder.utxo_connector.as_ref().unwrap().id(), "verify_deposit")
+            .call(
+                env_builder.utxo_connector.as_ref().unwrap().id(),
+                "verify_deposit",
+            )
             .args_json(json!({
                 "amount": U128(amount),
                 "msg": utxo_msg,
             }))
-            .max_gas()
+            .gas(near_workspaces::types::Gas::from_tgas(150))
             .transact()
             .await?;
 

--- a/near/omni-tests/src/utxo_fin_transfer.rs
+++ b/near/omni-tests/src/utxo_fin_transfer.rs
@@ -491,6 +491,98 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
+    async fn utxo_fin_transfer_with_msg_succeeds(
+        build_artifacts: &BuildArtifacts,
+    ) -> anyhow::Result<()> {
+        let env_builder = TestEnvBuilder::new(build_artifacts.clone())
+            .await?
+            .with_utxo_token()
+            .await?;
+
+        let relayer_account = env_builder.setup_trusted_relayer(account_n(10)).await?;
+        env_builder.storage_deposit(relayer_account.id()).await?;
+        env_builder
+            .omni_storage_deposit(relayer_account.id(), 1_000_000_000_000_000_000_000_000)
+            .await?;
+        env_builder.bridge_contract
+            .call("set_locked_tokens")
+            .args_json(json!({
+                "args": [{
+                    "chain_kind": ChainKind::Near,
+                    "token_id": env_builder.token.contract.id(),
+                    "amount": U128(1_000_000_000),
+                }]
+            }))
+            .max_gas()
+            .transact()
+            .await?
+            .into_result()?;
+        env_builder
+            .mint_tokens(
+                env_builder.utxo_connector.as_ref().unwrap().id(),
+                1_000_000_000_000,
+            )
+            .await?;
+
+        let token_receiver = env_builder.deploy_mock_receiver().await?;
+        env_builder.storage_deposit(token_receiver.id()).await?;
+
+        let amount: u128 = 100_000_000;
+        let inner_msg = serde_json::json!({
+            "return_value": U128(0),
+            "panic": false,
+            "extra_msg": "",
+        })
+        .to_string();
+        let utxo_msg = UtxoFinTransferMsg {
+            utxo_id: default_utxo_id(),
+            recipient: OmniAddress::Near(token_receiver.id().clone()),
+            relayer_fee: U128(1000),
+            msg: inner_msg,
+        };
+
+        let receiver_balance_before =
+            get_balance(&env_builder.token.contract, token_receiver.id()).await?;
+
+        let result = relayer_account
+            .call(env_builder.utxo_connector.as_ref().unwrap().id(), "verify_deposit")
+            .args_json(json!({
+                "amount": U128(amount),
+                "msg": utxo_msg,
+            }))
+            .max_gas()
+            .transact()
+            .await?;
+
+        assert!(
+            result.failures().is_empty(),
+            "verify_deposit had unexpected failures: {:?}",
+            result.failures()
+        );
+
+        let receiver_balance_after =
+            get_balance(&env_builder.token.contract, token_receiver.id()).await?;
+        assert_eq!(
+            receiver_balance_after.0,
+            receiver_balance_before.0 + amount,
+            "receiver should have received the full amount via ft_transfer_call"
+        );
+
+        let receiver_logged_ft_on_transfer = result
+            .receipt_outcomes()
+            .iter()
+            .flat_map(|o| &o.logs)
+            .any(|log| log.contains("ft_on_transfer called with sender_id"));
+        assert!(
+            receiver_logged_ft_on_transfer,
+            "recipient's ft_on_transfer was not invoked"
+        );
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
     async fn test_untrusted_account_cannot_call_submit_transfer_to_utxo_chain_connector(
         build_artifacts: &BuildArtifacts,
     ) -> anyhow::Result<()> {

--- a/near/omni-types/src/errors.rs
+++ b/near/omni-types/src/errors.rs
@@ -1,4 +1,4 @@
-use near_sdk::{AccountId, NearToken};
+use near_sdk::{AccountId, Gas, NearToken};
 use omni_utils::ErrorDisplay;
 use strum_macros::AsRefStr;
 
@@ -38,6 +38,7 @@ pub enum BridgeError {
     NativeTokenRequiredForChain,
     NearWithdrawFailed,
     NotEnoughAttachedDeposit,
+    NotEnoughGasForTokenTransfer(Gas),
     OldTokenNotDeployed,
     OnlyFeeRecipientCanClaim,
     ParseAccountId,


### PR DESCRIPTION
## Summary

Fixes gas allocation in the UTXO fin-transfer path so that deposits to NEAR recipients with a non-empty `msg` (i.e. requiring `ft_transfer_call` into the recipient's `ft_on_transfer`) consistently succeed.

## What changed

- **`send_tokens` now allocates gas dynamically.** Instead of always reserving `FT_TRANSFER_CALL_GAS = 210 Tgas`, it forwards the remaining prepaid gas (minus reserved callback budgets) to the outbound `mint` / `ft_transfer_call`, capped at `FT_TRANSFER_CALL_GAS`. A new `MIN_FT_TRANSFER_CALL_GAS = 50 Tgas` floor panics with the new `BridgeError::NotEnoughGasForTokenTransfer(Gas)` if the caller didn't attach enough gas, instead of silently failing inside the receiver.
- **`utxo_fin_transfer_to_near_callback` gas budget** raised from 5 → 10 Tgas, and the dispatch in `utxo_fin_transfer_to_near` forwards `prepaid_gas - used_gas - UTXO_FIN_TRANSFER_CALLBACK_GAS` to the callback rather than a fixed `CALLBACK + FT_TRANSFER_CALL` constant.
- **`mock-utxo-connector::verify_deposit`** drops the hard-coded `FT_TRANSFER_CALL_GAS` so remaining gas propagates naturally to the bridge.
- **New error variant** `BridgeError::NotEnoughGasForTokenTransfer(Gas)`.
- **Workspace version bump** `0.4.7 → 0.4.8`.

## Tests

- New integration test `utxo_fin_transfer_with_msg_succeeds` deposits a UTXO transfer with a non-empty `msg`, asserts `ft_on_transfer` is invoked on the recipient, and verifies the full amount lands at the recipient.

