### PR TITLE
fix: fogo ci relesae

### DIFF
--- a/.github/workflows/update-contracts.yaml
+++ b/.github/workflows/update-contracts.yaml
@@ -43,18 +43,7 @@ jobs:
       # FOGO is built first: solana-build-ci-fogo renames its outputs to `_fogo`,
       # leaving the canonical `bridge_token_factory.{so,json}` paths free for the
       # subsequent Solana build to occupy.
-      #
-      # Wormhole-side FOGO addresses come from repo GitHub Actions variables when
-      # set; otherwise the Makefile defaults (FOGO mainnet) are used. To target
-      # FOGO testnet from CI, set FOGO_BRIDGE_ADDRESS=BhnQyKoQQgpuRTRo6D8Emz93PvXCYfVgHhnrR4T3qhw4
-      # and the matching shim/CHAIN_ID variables.
       - name: Build FOGO contract
-        env:
-          FOGO_PROGRAM_ID: ${{ vars.FOGO_PROGRAM_ID }}
-          FOGO_WORMHOLE_CHAIN_ID: ${{ vars.FOGO_WORMHOLE_CHAIN_ID }}
-          FOGO_BRIDGE_ADDRESS: ${{ vars.FOGO_BRIDGE_ADDRESS }}
-          FOGO_POST_MESSAGE_SHIM_PROGRAM_ID: ${{ vars.FOGO_POST_MESSAGE_SHIM_PROGRAM_ID }}
-          FOGO_VERIFY_VAA_SHIM_PROGRAM_ID: ${{ vars.FOGO_VERIFY_VAA_SHIM_PROGRAM_ID }}
         run: |
           make solana-build-ci-fogo
         timeout-minutes: 60

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ FOGO_POST_MESSAGE_SHIM_PROGRAM_ID ?= EtZMZM22ViKMo4r5y4Anovs3wKQ2owUmDpjygnMMcdE
 FOGO_VERIFY_VAA_SHIM_PROGRAM_ID   ?= EFaNWErqAtVWufdNb7yofSHHfWFos843DFpu4JBw24at
 
 # Provided by the operator/CI for FOGO builds and deploys.
-FOGO_PROGRAM_ID ?=
+FOGO_PROGRAM_ID ?= dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe
 FOGO_RPC_URL ?=
 # Path (relative to solana/) of the keypair whose address is the SVM program ID
 # (used for Solana and FOGO builds/deploys). For FOGO it must resolve to the same


### PR DESCRIPTION
This pull request updates the default configuration for building the FOGO contract, simplifying the CI workflow and setting a default value for the FOGO program ID. The main changes focus on removing the need for environment variable overrides in the GitHub Actions workflow and specifying a default program ID in the `Makefile`.

Configuration simplification:

* Removed explicit environment variable overrides (`FOGO_PROGRAM_ID`, `FOGO_WORMHOLE_CHAIN_ID`, `FOGO_BRIDGE_ADDRESS`, `FOGO_POST_MESSAGE_SHIM_PROGRAM_ID`, `FOGO_VERIFY_VAA_SHIM_PROGRAM_ID`) from the FOGO contract build step in `.github/workflows/update-contracts.yaml`, relying instead on defaults set in the `Makefile`.

Default value update:

* Set a default value for `FOGO_PROGRAM_ID` in the `Makefile`, so it no longer defaults to empty and instead uses `dahPEoZGXfyV58JqqH85okdHmpN8U2q8owgPUXSCPxe`.