### PR TITLE
feat(solana): add admin setter for `derived_near_bridge_address`

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_token_factory"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana/programs/bridge_token_factory/Cargo.toml
+++ b/solana/programs/bridge_token_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge_token_factory"
-version = "0.2.7"
+version = "0.2.8"
 description = "Created with Anchor"
 edition = "2021"
 

--- a/solana/programs/bridge_token_factory/src/instructions/admin/change_config.rs
+++ b/solana/programs/bridge_token_factory/src/instructions/admin/change_config.rs
@@ -42,4 +42,13 @@ impl ChangeConfig<'_> {
 
         Ok(())
     }
+
+    pub fn set_derived_near_bridge_address(
+        &mut self,
+        derived_near_bridge_address: [u8; 64],
+    ) -> Result<()> {
+        self.config.derived_near_bridge_address = derived_near_bridge_address;
+
+        Ok(())
+    }
 }

--- a/solana/programs/bridge_token_factory/src/lib.rs
+++ b/solana/programs/bridge_token_factory/src/lib.rs
@@ -188,6 +188,18 @@ pub mod bridge_token_factory {
         Ok(())
     }
 
+    pub fn set_derived_near_bridge_address(
+        ctx: Context<ChangeConfig>,
+        derived_near_bridge_address: [u8; 64],
+    ) -> Result<()> {
+        msg!("Setting derived NEAR bridge address");
+
+        ctx.accounts
+            .set_derived_near_bridge_address(derived_near_bridge_address)?;
+
+        Ok(())
+    }
+
     pub fn update_metadata(
         ctx: Context<UpdateMetadata>,
         name: Option<String>,


### PR DESCRIPTION
This pull request introduces a new function to the `bridge_token_factory` Solana program, allowing the configuration of a derived NEAR bridge address. It also bumps the crate version to reflect this new capability. The main changes are grouped below:

**New functionality:**

* Added a new instruction handler `set_derived_near_bridge_address` to the `bridge_token_factory` program, enabling the setting of a derived NEAR bridge address in the configuration.
* Implemented a corresponding method in the `ChangeConfig` struct to update the `derived_near_bridge_address` field within the program's configuration.

**Versioning:**

* Bumped the crate version from `0.2.7` to `0.2.8` in `Cargo.toml` to reflect the addition of new functionality.