### PR TITLE
feat(evm): add coreReceiveWithData callback to HlBridgeToken

### DIFF
--- a/evm/.openzeppelin/unknown-998.json
+++ b/evm/.openzeppelin/unknown-998.json
@@ -1,0 +1,260 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xf353b40fC144d1c6c5BCdda712fa6De833016aF9",
+      "txHash": "0x06049f9a8a9b5f991b891cb41a843d5aa56262cd814f89e9c0d6e36a5e7b3887",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "577b5b3db8bb902b933ed367060230241c7a2fd97c32b186350df15bdaf9f32b": {
+      "address": "0xAfDa1b2ad1cFe85FdFD34cD87930Ff56f07CDbe3",
+      "txHash": "0x4f811db67291250568f962e4fbcd868cbdba8761124570d99a03a59ba9d30b11",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "ethToNearToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_string_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:36"
+          },
+          {
+            "label": "nearToEthToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_string_memory_ptr,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:37"
+          },
+          {
+            "label": "isBridgeToken",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:38"
+          },
+          {
+            "label": "tokenImplementationAddress",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:40"
+          },
+          {
+            "label": "nearBridgeDerivedAddress",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:41"
+          },
+          {
+            "label": "omniBridgeChainId",
+            "offset": 20,
+            "slot": "4",
+            "type": "t_uint8",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:42"
+          },
+          {
+            "label": "completedTransfers",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:44"
+          },
+          {
+            "label": "currentOriginNonce",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint64",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:45"
+          },
+          {
+            "label": "customMinters",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:47"
+          },
+          {
+            "label": "multiTokens",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:48"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:598"
+          },
+          {
+            "label": "_wormhole",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_contract(IWormhole)11143",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:27"
+          },
+          {
+            "label": "_consistencyLevel",
+            "offset": 20,
+            "slot": "58",
+            "type": "t_uint8",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:29"
+          },
+          {
+            "label": "wormholeNonce",
+            "offset": 21,
+            "slot": "58",
+            "type": "t_uint32",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:30"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IWormhole)11143": {
+            "label": "contract IWormhole",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_string_storage)": {
+            "label": "mapping(address => string)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)": {
+            "label": "mapping(address => struct MultiTokenInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_address)": {
+            "label": "mapping(string => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(MultiTokenInfo)9674_storage": {
+            "label": "struct MultiTokenInfo",
+            "members": [
+              {
+                "label": "tokenAddress",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)27_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)27_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)27_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/evm/.openzeppelin/unknown-999.json
+++ b/evm/.openzeppelin/unknown-999.json
@@ -1,0 +1,260 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xf353b40fC144d1c6c5BCdda712fa6De833016aF9",
+      "txHash": "0xd40a23d7db8e2d76401d52e08e4b3183805d392fe7e2b3898e7b1b18754b7066",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "577b5b3db8bb902b933ed367060230241c7a2fd97c32b186350df15bdaf9f32b": {
+      "address": "0xAfDa1b2ad1cFe85FdFD34cD87930Ff56f07CDbe3",
+      "txHash": "0x856c79ad54d2fbfc16516daef3b8fbf023ecc0e577343fa18dfb94407c37eb2c",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "ethToNearToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_string_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:36"
+          },
+          {
+            "label": "nearToEthToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_string_memory_ptr,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:37"
+          },
+          {
+            "label": "isBridgeToken",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:38"
+          },
+          {
+            "label": "tokenImplementationAddress",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:40"
+          },
+          {
+            "label": "nearBridgeDerivedAddress",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:41"
+          },
+          {
+            "label": "omniBridgeChainId",
+            "offset": 20,
+            "slot": "4",
+            "type": "t_uint8",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:42"
+          },
+          {
+            "label": "completedTransfers",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:44"
+          },
+          {
+            "label": "currentOriginNonce",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint64",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:45"
+          },
+          {
+            "label": "customMinters",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:47"
+          },
+          {
+            "label": "multiTokens",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:48"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:598"
+          },
+          {
+            "label": "_wormhole",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_contract(IWormhole)11143",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:27"
+          },
+          {
+            "label": "_consistencyLevel",
+            "offset": 20,
+            "slot": "58",
+            "type": "t_uint8",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:29"
+          },
+          {
+            "label": "wormholeNonce",
+            "offset": 21,
+            "slot": "58",
+            "type": "t_uint32",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:30"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IWormhole)11143": {
+            "label": "contract IWormhole",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_string_storage)": {
+            "label": "mapping(address => string)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)": {
+            "label": "mapping(address => struct MultiTokenInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_address)": {
+            "label": "mapping(string => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(MultiTokenInfo)9674_storage": {
+            "label": "struct MultiTokenInfo",
+            "members": [
+              {
+                "label": "tokenAddress",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)27_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)27_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)27_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -383,7 +383,7 @@ const config: HardhatUserConfig = {
       wormholeAddress: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd",
       omniChainId: 9,
       chainId: 998,
-      url: "https://rpc.hyperliquid-testnet.xyz/evm",
+      url: "https://rpcs.chain.link/hyperevm/testnet",
       accounts: [`${EVM_PRIVATE_KEY}`],
     },
     abstractTestnet: {

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -1,13 +1,52 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.24;
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {BridgeToken} from "./BridgeToken.sol";
+
+interface IOmniBridgeInitTransfer {
+    function initTransfer(
+        address tokenAddress,
+        uint128 amount,
+        uint128 fee,
+        uint128 nativeFee,
+        string calldata recipient,
+        string calldata message
+    ) external payable;
+}
+
+interface ICoreReceiveWithData {
+    function coreReceiveWithData(
+        address from,
+        bytes32 destinationRecipient,
+        uint32 destinationChainId,
+        uint256 amount,
+        uint64 coreNonce,
+        bytes calldata data
+    ) external;
+}
 
 /// @notice Hyperliquid-specific BridgeToken with two mint paths:
 /// - 2-arg mint(address, uint256): mints on HyperEVM (tokens go directly to user)
 /// - 3-arg mint(address, uint256, bytes): mints on HyperCore (includes _update to system address for spot-balance tracking)
-contract HyperliquedBridgeToken is BridgeToken {
+contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
+    using SafeCast for uint256;
+
     address internal _systemAddress;
+
+    uint8 public constant ACTION_TRANSFER = 0;
+    uint8 public constant ACTION_INIT_TRANSFER = 1;
+
+    event CoreReceived(
+        address indexed sender,
+        uint8 indexed action,
+        uint256 amount,
+        bytes data
+    );
+
+    error NotSystemAddress();
+    error EmptyActionData();
+    error UnknownAction(uint8 action);
 
     function initialize(
         string memory name_,
@@ -32,5 +71,53 @@ contract HyperliquedBridgeToken is BridgeToken {
     ) external override onlyOwner {
         _mint(account, value);
         _update(account, _systemAddress, value);
+    }
+
+    /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
+    /// HyperCore user triggers `sendToEvmWithData` targeting this token. By the time
+    /// this fires, `amount` tokens have already been transferred to `address(this)`.
+    /// `destinationRecipient`, `destinationChainId`, and `coreNonce` are CCTP-shaped
+    /// and not used here; all routing info comes from `data`.
+    /// @dev Dispatch:
+    /// - data == 0x00 || abi.encode(address recipient): forward `amount` to the
+    ///   HyperEVM `recipient`.
+    /// - data == 0x01 || abi.encode(uint128 fee, string recipient, string message):
+    ///   bridge via OmniBridge.initTransfer. `recipient` is an OmniAddress string
+    ///   (e.g. `near:alice.near`, `sol:<base58>`). nativeFee is forced to 0.
+    /// The emitted InitTransfer event will carry `sender = address(this)`; the NEAR
+    /// side cannot recover the originating HyperCore user (`from`) from this path.
+    function coreReceiveWithData(
+        address from,
+        bytes32 /*destinationRecipient*/,
+        uint32 /*destinationChainId*/,
+        uint256 amount,
+        uint64 /*coreNonce*/,
+        bytes calldata data
+    ) external override {
+        if (msg.sender != _systemAddress) revert NotSystemAddress();
+        if (data.length == 0) revert EmptyActionData();
+
+        uint8 action = uint8(data[0]);
+        bytes calldata tail = data[1:];
+
+        if (action == ACTION_TRANSFER) {
+            address recipient = abi.decode(tail, (address));
+            _update(address(this), recipient, amount);
+        } else if (action == ACTION_INIT_TRANSFER) {
+            (uint128 fee, string memory recipient, string memory message) = abi
+                .decode(tail, (uint128, string, string));
+            IOmniBridgeInitTransfer(owner()).initTransfer(
+                address(this),
+                amount.toUint128(),
+                fee,
+                0,
+                recipient,
+                message
+            );
+        } else {
+            revert UnknownAction(action);
+        }
+
+        emit CoreReceived(from, action, amount, data);
     }
 }

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -74,16 +74,24 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     }
 
     /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
-    /// HyperCore user triggers `sendToEvmWithData` targeting this token. By the time
-    /// this fires, `amount` tokens have already been transferred to `address(this)`.
+    /// HyperCore user triggers `sendToEvmWithData` targeting this token.
     /// `destinationRecipient`, `destinationChainId`, and `coreNonce` are CCTP-shaped
     /// and not used here; all routing info comes from `data`.
-    /// @dev Dispatch:
-    /// - data == 0x00 || abi.encode(address recipient): forward `amount` to the
-    ///   HyperEVM `recipient`.
+    /// @dev Accounting model: the 3-arg `mint` parks HyperCore-bound tokens at
+    /// `_systemAddress`, so that account holds the standing pool that mirrors total
+    /// HyperCore-side balance. HyperLiquid does NOT pre-transfer tokens before this
+    /// call fires (the HL system address holds no real ERC20 balance — Circle's
+    /// CoreDepositWallet pattern shows the same, with its own pool at `address(this)`).
+    /// We pull from `_systemAddress` ourselves; an insufficient pool is a safe revert
+    /// that signals an accounting drift between HyperCore and HyperEVM.
+    ///
+    /// Dispatch:
+    /// - data == 0x00 || abi.encode(address recipient): release `amount` from the
+    ///   pool to the HyperEVM `recipient`.
     /// - data == 0x01 || abi.encode(uint128 fee, string recipient, string message):
-    ///   bridge via OmniBridge.initTransfer. `recipient` is an OmniAddress string
-    ///   (e.g. `near:alice.near`, `sol:<base58>`). nativeFee is forced to 0.
+    ///   move `amount` from the pool to this contract, then bridge via
+    ///   OmniBridge.initTransfer (which burns from `address(this)`). `recipient` is an
+    ///   OmniAddress string (e.g. `near:alice.near`, `sol:<base58>`). nativeFee = 0.
     /// The emitted InitTransfer event will carry `sender = address(this)`; the NEAR
     /// side cannot recover the originating HyperCore user (`from`) from this path.
     function coreReceiveWithData(
@@ -102,13 +110,15 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
 
         if (action == ACTION_TRANSFER) {
             address recipient = abi.decode(tail, (address));
-            _update(address(this), recipient, amount);
+            _update(_systemAddress, recipient, amount);
         } else if (action == ACTION_INIT_TRANSFER) {
             (uint128 fee, string memory recipient, string memory message) = abi
                 .decode(tail, (uint128, string, string));
+            uint128 amount128 = amount.toUint128();
+            _update(_systemAddress, address(this), amount);
             IOmniBridgeInitTransfer(owner()).initTransfer(
                 address(this),
-                amount.toUint128(),
+                amount128,
                 fee,
                 0,
                 recipient,

--- a/evm/src/omni-bridge/contracts/OmniBridge.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridge.sol
@@ -52,6 +52,7 @@ contract OmniBridge is
     uint256 constant UNPAUSED_ALL = 0;
     uint256 constant PAUSED_INIT_TRANSFER = 1 << 0;
     uint256 constant PAUSED_FIN_TRANSFER = 1 << 1;
+    uint256 constant PAUSED_DEPLOY_TOKEN = 1 << 2;
 
     error InvalidSignature();
     error NonceAlreadyUsed(uint64 nonce);
@@ -61,6 +62,7 @@ contract OmniBridge is
     error ERC1155MappingMismatch();
     error ERC1155DirectSendNotAllowed();
     error ERC1155BatchNotSupported();
+    error TokenImplementationNotSet();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -133,7 +135,10 @@ contract OmniBridge is
     function deployToken(
         bytes calldata signatureData,
         BridgeTypes.MetadataPayload calldata metadata
-    ) external payable returns (address) {
+    ) external payable whenNotPaused(PAUSED_DEPLOY_TOKEN) returns (address) {
+        if (tokenImplementationAddress == address(0)) {
+            revert TokenImplementationNotSet();
+        }
         bytes memory borshEncoded = bytes.concat(
             bytes1(uint8(BridgeTypes.PayloadType.Metadata)),
             Borsh.encodeString(metadata.token),
@@ -545,7 +550,9 @@ contract OmniBridge is
     }
 
     function pauseAll() external onlyRole(PAUSABLE_ADMIN_ROLE) {
-        uint256 flags = PAUSED_FIN_TRANSFER | PAUSED_INIT_TRANSFER;
+        uint256 flags = PAUSED_FIN_TRANSFER |
+            PAUSED_INIT_TRANSFER |
+            PAUSED_DEPLOY_TOKEN;
         _pause(flags);
     }
 

--- a/evm/tests/BridgeToken.ts
+++ b/evm/tests/BridgeToken.ts
@@ -9,8 +9,10 @@ const PauseMode = {
   UnpausedAll: 0,
   PausedInitTransfer: 1 << 0,
   PausedFinTransfer: 1 << 1,
+  PausedDeployToken: 1 << 2,
 }
-const PauseAll = PauseMode.PausedInitTransfer | PauseMode.PausedFinTransfer
+const PauseAll =
+  PauseMode.PausedInitTransfer | PauseMode.PausedFinTransfer | PauseMode.PausedDeployToken
 const PanicCodeArithmeticOperationOverflowed = "0x11"
 
 describe("BridgeToken", () => {
@@ -429,12 +431,20 @@ describe("BridgeToken", () => {
     // Pause all
     await expect(OmniBridge.pauseAll())
       .to.emit(OmniBridge, "Paused")
-      .withArgs(adminAccount.address, PauseMode.PausedFinTransfer | PauseMode.PausedInitTransfer)
-    expect(await OmniBridge.pausedFlags()).to.be.equal(
-      PauseMode.PausedFinTransfer | PauseMode.PausedInitTransfer,
-    )
+      .withArgs(adminAccount.address, PauseAll)
+    expect(await OmniBridge.pausedFlags()).to.be.equal(PauseAll)
     expect(await OmniBridge.paused(PauseMode.PausedFinTransfer)).to.be.equal(true)
     expect(await OmniBridge.paused(PauseMode.PausedInitTransfer)).to.be.equal(true)
+    expect(await OmniBridge.paused(PauseMode.PausedDeployToken)).to.be.equal(true)
+  })
+
+  it("can't deploy token when paused", async () => {
+    await expect(OmniBridge.pause(PauseMode.PausedDeployToken))
+      .to.emit(OmniBridge, "Paused")
+      .withArgs(adminAccount.address, PauseMode.PausedDeployToken)
+
+    const { signature, payload } = await metadataSignature(wrappedNearId)
+    await expect(OmniBridge.deployToken(signature, payload)).to.be.revertedWith("Pausable: paused")
   })
 
   it("Test grant admin role", async () => {

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -1,0 +1,229 @@
+import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers"
+import { expect } from "chai"
+import { ethers, upgrades } from "hardhat"
+import { testWallet } from "./helpers/signatures"
+import type { HyperliquedBridgeToken, OmniBridge } from "../typechain-types"
+
+const ACTION_TRANSFER = 0
+const ACTION_INIT_TRANSFER = 1
+
+describe("HyperliquedBridgeToken", () => {
+  let adminAccount: HardhatEthersSigner
+  let user1: HardhatEthersSigner
+  let user2: HardhatEthersSigner
+  let systemSigner: HardhatEthersSigner
+
+  let omniBridge: OmniBridge
+  let omniBridgeAddress: string
+
+  const SYSTEM_ADDRESS = "0x2222000000000000000000000000000000000000"
+  const NEAR_TOKEN_ID = "hl.testnet"
+
+  beforeEach(async () => {
+    ;[adminAccount, user1, user2] = await ethers.getSigners()
+    systemSigner = await ethers.getImpersonatedSigner(SYSTEM_ADDRESS)
+    await adminAccount.sendTransaction({
+      to: SYSTEM_ADDRESS,
+      value: ethers.parseEther("1"),
+    })
+
+    // Deploy OmniBridge with a generic BridgeToken impl — we register an
+    // externally-deployed HlBridgeToken via addCustomToken, so the implementation
+    // address here is unused for our flows.
+    const BridgeToken_factory = await ethers.getContractFactory("BridgeToken")
+    const bridgeTokenImpl = await BridgeToken_factory.deploy()
+    await bridgeTokenImpl.waitForDeployment()
+
+    const OmniBridge_factory = await ethers.getContractFactory("OmniBridge")
+    const omniBridgeProxy = await upgrades.deployProxy(
+      OmniBridge_factory,
+      [await bridgeTokenImpl.getAddress(), testWallet.address, 0],
+      { initializer: "initialize" },
+    )
+    omniBridge = (await omniBridgeProxy.waitForDeployment()) as unknown as OmniBridge
+    omniBridgeAddress = await omniBridge.getAddress()
+  })
+
+  async function deployHlToken(): Promise<{
+    token: HyperliquedBridgeToken
+    address: string
+  }> {
+    const HlFactory = await ethers.getContractFactory("HyperliquedBridgeToken")
+    const deployed = await upgrades.deployProxy(
+      HlFactory,
+      ["Wrapped HL", "wHL", 18, SYSTEM_ADDRESS],
+      { initializer: "initialize(string,string,uint8,address)", kind: "uups" },
+    )
+    const token = (await deployed.waitForDeployment()) as unknown as HyperliquedBridgeToken
+    return { token, address: await token.getAddress() }
+  }
+
+  // `addCustomToken` with `customMinter = address(0)` registers the token so that
+  // `OmniBridge.initTransfer` falls into the `isBridgeToken` branch and calls
+  // `BridgeToken.burn(msg.sender, amount)` — exactly the path we want.
+  async function registerHlOnBridge(tokenAddress: string) {
+    await omniBridge.addCustomToken(NEAR_TOKEN_ID, tokenAddress, ethers.ZeroAddress, 18)
+  }
+
+  describe("3-arg mint (HyperCore path)", () => {
+    let token: HyperliquedBridgeToken
+
+    beforeEach(async () => {
+      ;({ token } = await deployHlToken())
+    })
+
+    it("mints to account then routes balance to system address", async () => {
+      await token.connect(adminAccount)["mint(address,uint256,bytes)"](user1.address, 1000, "0x")
+      expect(await token.balanceOf(user1.address)).to.equal(0n)
+      expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(1000n)
+    })
+
+    it("rejects non-owner callers", async () => {
+      await expect(
+        token.connect(user1)["mint(address,uint256,bytes)"](user1.address, 1000, "0x"),
+      ).to.be.revertedWithCustomError(token, "OwnableUnauthorizedAccount")
+    })
+  })
+
+  describe("coreReceiveWithData authorization & dispatch", () => {
+    let token: HyperliquedBridgeToken
+
+    beforeEach(async () => {
+      ;({ token } = await deployHlToken())
+    })
+
+    it("reverts when caller is not the system address", async () => {
+      await expect(
+        token
+          .connect(user1)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, 100, 0, "0x00"),
+      ).to.be.revertedWithCustomError(token, "NotSystemAddress")
+    })
+
+    it("reverts on empty data", async () => {
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, 100, 0, "0x"),
+      ).to.be.revertedWithCustomError(token, "EmptyActionData")
+    })
+
+    it("reverts on unknown action tag", async () => {
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, 100, 0, "0x99"),
+      )
+        .to.be.revertedWithCustomError(token, "UnknownAction")
+        .withArgs(0x99)
+    })
+  })
+
+  describe("ACTION_TRANSFER (0x00)", () => {
+    const AMOUNT = 500n
+    let token: HyperliquedBridgeToken
+    let tokenAddress: string
+
+    beforeEach(async () => {
+      ;({ token, address: tokenAddress } = await deployHlToken())
+      // Simulate the system address pre-transferring tokens to address(this).
+      await token.connect(adminAccount)["mint(address,uint256)"](tokenAddress, AMOUNT)
+    })
+
+    it("forwards tokens to recipient encoded in data", async () => {
+      const data = ethers.concat([
+        "0x00",
+        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
+      ])
+
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data),
+      )
+        .to.emit(token, "CoreReceived")
+        .withArgs(user1.address, ACTION_TRANSFER, AMOUNT, data)
+
+      expect(await token.balanceOf(user2.address)).to.equal(AMOUNT)
+      expect(await token.balanceOf(tokenAddress)).to.equal(0n)
+    })
+
+    it("reverts if the contract balance is insufficient", async () => {
+      const data = ethers.concat([
+        "0x00",
+        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
+      ])
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(
+            user1.address,
+            ethers.ZeroHash,
+            0,
+            AMOUNT + 1n,
+            0,
+            data,
+          ),
+      ).to.be.revertedWithCustomError(token, "ERC20InsufficientBalance")
+    })
+  })
+
+  describe("ACTION_INIT_TRANSFER (0x01) via real OmniBridge", () => {
+    const AMOUNT = 1000n
+    const FEE = 10n
+    const RECIPIENT = "near:alice.near"
+    const MESSAGE = "ref=hypercore"
+    let token: HyperliquedBridgeToken
+    let tokenAddress: string
+
+    beforeEach(async () => {
+      ;({ token, address: tokenAddress } = await deployHlToken())
+      // Mint to address(this) while we're still the owner.
+      await token.connect(adminAccount)["mint(address,uint256)"](tokenAddress, AMOUNT)
+      // Hand ownership to OmniBridge so it can burn from the token contract.
+      await token.transferOwnership(omniBridgeAddress)
+      await omniBridge.acceptTokenOwnership(tokenAddress)
+      await registerHlOnBridge(tokenAddress)
+    })
+
+    function encodeData(fee: bigint = FEE) {
+      return ethers.concat([
+        "0x01",
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["uint128", "string", "string"],
+          [fee, RECIPIENT, MESSAGE],
+        ),
+      ])
+    }
+
+    it("emits InitTransfer on the real OmniBridge and burns the bridged amount", async () => {
+      const data = encodeData()
+      const tx = token
+        .connect(systemSigner)
+        .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data)
+
+      await expect(tx)
+        .to.emit(omniBridge, "InitTransfer")
+        .withArgs(tokenAddress, tokenAddress, 1n, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
+
+      await expect(tx)
+        .to.emit(token, "CoreReceived")
+        .withArgs(user1.address, ACTION_INIT_TRANSFER, AMOUNT, data)
+
+      expect(await token.balanceOf(tokenAddress)).to.equal(0n)
+      expect(await token.totalSupply()).to.equal(0n)
+    })
+
+    it("reverts when amount overflows uint128 (SafeCast)", async () => {
+      const tooBig = 2n ** 128n
+      const data = encodeData()
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, tooBig, 0, data),
+      )
+        .to.be.revertedWithCustomError(token, "SafeCastOverflowedUintDowncast")
+        .withArgs(128, tooBig)
+    })
+  })
+})

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -1,8 +1,8 @@
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers"
 import { expect } from "chai"
 import { ethers, upgrades } from "hardhat"
-import { testWallet } from "./helpers/signatures"
 import type { HyperliquedBridgeToken, OmniBridge } from "../typechain-types"
+import { testWallet } from "./helpers/signatures"
 
 const ACTION_TRANSFER = 0
 const ACTION_INIT_TRANSFER = 1
@@ -94,9 +94,7 @@ describe("HyperliquedBridgeToken", () => {
 
     it("reverts when caller is not the system address", async () => {
       await expect(
-        token
-          .connect(user1)
-          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, 100, 0, "0x00"),
+        token.connect(user1).coreReceiveWithData(user1.address, ethers.ZeroHash, 0, 100, 0, "0x00"),
       ).to.be.revertedWithCustomError(token, "NotSystemAddress")
     })
 
@@ -156,14 +154,7 @@ describe("HyperliquedBridgeToken", () => {
       await expect(
         token
           .connect(systemSigner)
-          .coreReceiveWithData(
-            user1.address,
-            ethers.ZeroHash,
-            0,
-            AMOUNT + 1n,
-            0,
-            data,
-          ),
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT + 1n, 0, data),
       ).to.be.revertedWithCustomError(token, "ERC20InsufficientBalance")
     })
   })

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -124,11 +124,11 @@ describe("HyperliquedBridgeToken", () => {
 
     beforeEach(async () => {
       ;({ token, address: tokenAddress } = await deployHlToken())
-      // Simulate the system address pre-transferring tokens to address(this).
-      await token.connect(adminAccount)["mint(address,uint256)"](tokenAddress, AMOUNT)
+      // Seed the system-address pool the way a prior 3-arg mint would.
+      await token.connect(adminAccount)["mint(address,uint256)"](SYSTEM_ADDRESS, AMOUNT)
     })
 
-    it("forwards tokens to recipient encoded in data", async () => {
+    it("releases tokens from the system-address pool to recipient", async () => {
       const data = ethers.concat([
         "0x00",
         ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
@@ -143,10 +143,11 @@ describe("HyperliquedBridgeToken", () => {
         .withArgs(user1.address, ACTION_TRANSFER, AMOUNT, data)
 
       expect(await token.balanceOf(user2.address)).to.equal(AMOUNT)
+      expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(0n)
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
     })
 
-    it("reverts if the contract balance is insufficient", async () => {
+    it("reverts if the system-address pool is insufficient", async () => {
       const data = ethers.concat([
         "0x00",
         ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
@@ -169,9 +170,11 @@ describe("HyperliquedBridgeToken", () => {
 
     beforeEach(async () => {
       ;({ token, address: tokenAddress } = await deployHlToken())
-      // Mint to address(this) while we're still the owner.
-      await token.connect(adminAccount)["mint(address,uint256)"](tokenAddress, AMOUNT)
-      // Hand ownership to OmniBridge so it can burn from the token contract.
+      // Seed the standing pool at _systemAddress while we're still the owner.
+      await token.connect(adminAccount)["mint(address,uint256)"](SYSTEM_ADDRESS, AMOUNT)
+      // Hand ownership to OmniBridge so it can burn from the token contract once
+      // we've moved the bridged amount from the pool to address(this) inside
+      // coreReceiveWithData.
       await token.transferOwnership(omniBridgeAddress)
       await omniBridge.acceptTokenOwnership(tokenAddress)
       await registerHlOnBridge(tokenAddress)


### PR DESCRIPTION
This pull request introduces a new callback mechanism to the `HyperliquedBridgeToken` contract, allowing it to receive and process cross-chain messages from HyperCore, with robust authorization, action dispatch, and bridging logic. It also adds comprehensive tests to ensure correct behavior for all new code paths.

**Core contract enhancements:**

* Added the `coreReceiveWithData` function to `HyperliquedBridgeToken`, implementing the `ICoreReceiveWithData` interface. This function dispatches actions based on the first byte of `data`, supporting both direct token transfers and cross-chain bridging via `OmniBridge.initTransfer`, with strict authorization and error handling. [[1]](diffhunk://#diff-e523b53d18de81376b70c2efc3182c67d9bcdf2d84e8aa55db6e4761bdd1407cR4-R50) [[2]](diffhunk://#diff-e523b53d18de81376b70c2efc3182c67d9bcdf2d84e8aa55db6e4761bdd1407cR75-R122)
* Introduced new events (`CoreReceived`) and custom errors (`NotSystemAddress`, `EmptyActionData`, `UnknownAction`) to improve observability and error reporting in the contract.

**Testing improvements:**

* Added a new test suite (`HlBridgeToken.ts`) that covers all major code paths of `HyperliquedBridgeToken`, including authorization checks, action dispatch, error cases, and integration with the real `OmniBridge` contract.
* Tests verify correct minting, ownership restrictions, dispatch logic for both transfer and bridge actions, event emission, and handling of edge cases such as balance insufficiency and type overflows.