### PR TITLE
feat(hyperliquid): add HIP-1 deploy and HC↔EVM linking scripts

### DIFF
--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -151,6 +151,77 @@ task("deploy-token-impl", "Deploys the BridgeToken implementation").setAction(as
   )
 })
 
+task("deploy-hl-token-impl", "Deploys the HlBridgeToken (HyperliquedBridgeToken) implementation").setAction(
+  async (_, hre) => {
+    const { ethers } = hre
+    const HlBridgeTokenContractFactory = await ethers.getContractFactory("HyperliquedBridgeToken")
+    const HlBridgeTokenContract = await HlBridgeTokenContractFactory.deploy()
+    await HlBridgeTokenContract.waitForDeployment()
+    console.log(
+      JSON.stringify({
+        tokenImplAddress: await HlBridgeTokenContract.getAddress(),
+      }),
+    )
+  },
+)
+
+task(
+  "deploy-hl-bridge-token-proxy",
+  "Deploy an ERC1967Proxy over HyperliquedBridgeToken (5-arg initialize: name, symbol, decimals, systemAddress, hyperCoreDeployer)",
+)
+  .addParam("impl", "HyperliquedBridgeToken implementation address")
+  .addParam("name", "Token name (e.g. 'NEAR')")
+  .addParam("symbol", "Token symbol (e.g. 'NEAR')")
+  .addParam("decimals", "Token decimals (e.g. '18')")
+  .addParam("systemAddress", "HyperCore system address for this token (e.g. 0x20...0201)")
+  .addParam("hyperCoreDeployer", "Address of the HyperCore deployer (to be stored at keccak256('HyperCore deployer'))")
+  .setAction(async (taskArgs, hre) => {
+    const { ethers } = hre
+    const impl = ethers.getAddress(taskArgs.impl)
+    const systemAddress = ethers.getAddress(taskArgs.systemAddress)
+    const hyperCoreDeployer = ethers.getAddress(taskArgs.hyperCoreDeployer)
+
+    const HlBridgeToken = await ethers.getContractFactory("HyperliquedBridgeToken")
+    // `initialize` is overloaded (inherited 3-arg from BridgeToken + 5-arg from HyperliquedBridgeToken),
+    // so we must pass the full canonical signature to disambiguate.
+    const initData = HlBridgeToken.interface.encodeFunctionData(
+      "initialize(string,string,uint8,address,address)",
+      [
+        taskArgs.name,
+        taskArgs.symbol,
+        Number.parseInt(taskArgs.decimals, 10),
+        systemAddress,
+        hyperCoreDeployer,
+      ],
+    )
+
+    const Proxy = await ethers.getContractFactory("ERC1967Proxy")
+    const proxy = await Proxy.deploy(impl, initData)
+    await proxy.waitForDeployment()
+    const proxyAddress = await proxy.getAddress()
+
+    const EIP1967_IMPL_SLOT =
+      "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+    const implSlot = await ethers.provider.getStorage(proxyAddress, EIP1967_IMPL_SLOT)
+    const implementation = ethers.getAddress("0x" + implSlot.slice(-40))
+
+    console.log(
+      JSON.stringify(
+        {
+          proxyAddress,
+          implementation,
+          name: taskArgs.name,
+          symbol: taskArgs.symbol,
+          decimals: Number.parseInt(taskArgs.decimals, 10),
+          systemAddress,
+          hyperCoreDeployer,
+        },
+        null,
+        2,
+      ),
+    )
+  })
+
 task("upgrade-bridge-token", "Upgrades a BridgeToken to a new implementation")
   .addParam("factory", "The address of the OmniBridge contract")
   .addParam("nearTokenAccount", "The NEAR token ID")
@@ -251,6 +322,90 @@ task("deploy-bytecode", "Deploys a contract with a given bytecode")
         contractAddress: await contract.getAddress(),
       }),
     )
+  })
+
+task(
+  "inspect-token",
+  "Inspect a token contract: detect proxy, read implementation, ERC-20 metadata, owner, and HL-specific fields",
+)
+  .addParam("token", "Contract address to inspect")
+  .setAction(async (taskArgs, hre) => {
+    const { ethers } = hre
+    const provider = ethers.provider
+    const addr = ethers.getAddress(taskArgs.token)
+
+    const result: Record<string, unknown> = { address: addr }
+
+    // 0. Is there code at all?
+    const code = await provider.getCode(addr)
+    result.isContract = code !== "0x"
+    result.codeSize = (code.length - 2) / 2 // bytes
+    if (!result.isContract) {
+      console.log(JSON.stringify(result, null, 2))
+      return
+    }
+
+    // 1. EIP-1967 proxy detection: implementation slot, admin slot, beacon slot
+    const EIP1967_IMPL_SLOT =
+      "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+    const EIP1967_ADMIN_SLOT =
+      "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
+    const EIP1967_BEACON_SLOT =
+      "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50"
+    const implSlot = await provider.getStorage(addr, EIP1967_IMPL_SLOT)
+    const adminSlot = await provider.getStorage(addr, EIP1967_ADMIN_SLOT)
+    const beaconSlot = await provider.getStorage(addr, EIP1967_BEACON_SLOT)
+    const implementation = ethers.getAddress("0x" + implSlot.slice(-40))
+    const admin = ethers.getAddress("0x" + adminSlot.slice(-40))
+    const beacon = ethers.getAddress("0x" + beaconSlot.slice(-40))
+    result.isProxy = implementation !== ethers.ZeroAddress
+    result.implementation = implementation
+    result.proxyAdmin = admin === ethers.ZeroAddress ? null : admin
+    result.beacon = beacon === ethers.ZeroAddress ? null : beacon
+
+    // 2. ERC-20 + Ownable2Step + UUPS reads, each wrapped in try/catch
+    const iface = new ethers.Interface([
+      "function name() view returns (string)",
+      "function symbol() view returns (string)",
+      "function decimals() view returns (uint8)",
+      "function totalSupply() view returns (uint256)",
+      "function owner() view returns (address)",
+      "function pendingOwner() view returns (address)",
+      "function UPGRADE_INTERFACE_VERSION() view returns (string)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function systemAddress() view returns (address)",
+    ])
+    const c = new ethers.Contract(addr, iface, provider)
+
+    const calls: Array<[string, () => Promise<unknown>]> = [
+      ["name", () => c.name()],
+      ["symbol", () => c.symbol()],
+      ["decimals", () => c.decimals()],
+      ["totalSupply", () => c.totalSupply()],
+      ["owner", () => c.owner()],
+      ["pendingOwner", () => c.pendingOwner()],
+      ["UPGRADE_INTERFACE_VERSION", () => c.UPGRADE_INTERFACE_VERSION()],
+      ["proxiableUUID", () => c.proxiableUUID()],
+      ["systemAddress", () => c.systemAddress()],
+    ]
+    for (const [key, fn] of calls) {
+      try {
+        const v = await fn()
+        result[key] = typeof v === "bigint" ? v.toString() : v
+      } catch {
+        result[key] = null
+      }
+    }
+
+    // 3. HyperCore-deployer slot (keccak256("HyperCore deployer"))
+    const HYPER_CORE_DEPLOYER_SLOT = ethers.keccak256(
+      ethers.toUtf8Bytes("HyperCore deployer"),
+    )
+    const hcSlot = await provider.getStorage(addr, HYPER_CORE_DEPLOYER_SLOT)
+    const hcDeployer = ethers.getAddress("0x" + hcSlot.slice(-40))
+    result.hyperCoreDeployer = hcDeployer === ethers.ZeroAddress ? null : hcDeployer
+
+    console.log(JSON.stringify(result, null, 2))
   })
 
 const config: HardhatUserConfig = {

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -325,6 +325,62 @@ task("deploy-bytecode", "Deploys a contract with a given bytecode")
   })
 
 task(
+  "set-hyper-core-deployer",
+  "Set the HyperCore deployer address stored at slot keccak256('HyperCore deployer') (onlyOwner)",
+)
+  .addParam("token", "Token proxy address (HlBridgeToken / HyperliquedBridgeToken)")
+  .addParam("deployer", "HyperCore deployer address to write into the namespaced slot")
+  .setAction(async (taskArgs, hre) => {
+    const { ethers } = hre
+    const [signer] = await ethers.getSigners()
+    const proxy = ethers.getAddress(taskArgs.token)
+    const deployer = ethers.getAddress(taskArgs.deployer)
+
+    const HYPER_CORE_DEPLOYER_SLOT = ethers.keccak256(ethers.toUtf8Bytes("HyperCore deployer"))
+
+    // Read the current value via direct storage slot (works even if the contract
+    // doesn't expose a getter — slot is canonical).
+    const beforeRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
+    const before = ethers.getAddress("0x" + beforeRaw.slice(-40))
+
+    const iface = new ethers.Interface([
+      "function setHyperCoreDeployer(address) external",
+      "function owner() external view returns (address)",
+    ])
+    const token = new ethers.Contract(proxy, iface, signer)
+
+    const owner: string = await token.owner()
+    const signerAddress = await signer.getAddress()
+    if (signerAddress.toLowerCase() !== owner.toLowerCase()) {
+      console.warn(
+        `WARNING: signer (${signerAddress}) is not the owner (${owner}) — tx will revert`,
+      )
+    }
+
+    const tx = await token.setHyperCoreDeployer(deployer)
+    const receipt = await tx.wait()
+
+    const afterRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
+    const after = ethers.getAddress("0x" + afterRaw.slice(-40))
+
+    console.log(
+      JSON.stringify(
+        {
+          proxy,
+          signer: signerAddress,
+          owner,
+          slot: HYPER_CORE_DEPLOYER_SLOT,
+          hyperCoreDeployerBefore: before,
+          hyperCoreDeployerAfter: after,
+          txHash: receipt.hash,
+        },
+        null,
+        2,
+      ),
+    )
+  })
+
+task(
   "inspect-token",
   "Inspect a token contract: detect proxy, read implementation, ERC-20 metadata, owner, and HL-specific fields",
 )

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -384,6 +384,61 @@ task(
   })
 
 task(
+  "transfer-token-ownership",
+  "Step 1 of Ownable2Step: current owner initiates ownership transfer (sets pendingOwner = newOwner). The new owner must then call acceptOwnership themselves.",
+)
+  .addParam("token", "Proxy address of the token")
+  .addParam("newOwner", "Address that will become the new owner after they call acceptOwnership")
+  .setAction(async (taskArgs, hre) => {
+    const { ethers } = hre
+    const [signer] = await ethers.getSigners()
+    const proxy = ethers.getAddress(taskArgs.token)
+    const newOwner = ethers.getAddress(taskArgs.newOwner)
+
+    const token = new ethers.Contract(
+      proxy,
+      [
+        "function transferOwnership(address) external",
+        "function owner() external view returns (address)",
+        "function pendingOwner() external view returns (address)",
+      ],
+      signer,
+    )
+
+    const ownerBefore: string = await token.owner()
+    const pendingBefore: string = await token.pendingOwner()
+    const signerAddress = await signer.getAddress()
+
+    if (signerAddress.toLowerCase() !== ownerBefore.toLowerCase()) {
+      console.warn(
+        `WARNING: signer (${signerAddress}) is not the current owner (${ownerBefore}) — tx will revert`,
+      )
+    }
+
+    const tx = await token.transferOwnership(newOwner)
+    const receipt = await tx.wait()
+    const ownerAfter: string = await token.owner()
+    const pendingAfter: string = await token.pendingOwner()
+
+    console.log(
+      JSON.stringify(
+        {
+          proxy,
+          signer: signerAddress,
+          ownerBefore,
+          pendingOwnerBefore: pendingBefore,
+          ownerAfter,
+          pendingOwnerAfter: pendingAfter,
+          txHash: receipt.hash,
+          nextStep: `New owner (${newOwner}) must call acceptOwnership() on ${proxy} to complete the transfer.`,
+        },
+        null,
+        2,
+      ),
+    )
+  })
+
+task(
   "inspect-token",
   "Inspect a token contract: detect proxy, read implementation, ERC-20 metadata, owner, and HL-specific fields",
 )

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -328,62 +328,6 @@ task("deploy-bytecode", "Deploys a contract with a given bytecode")
   })
 
 task(
-  "set-hyper-core-deployer",
-  "Set the HyperCore deployer address stored at slot keccak256('HyperCore deployer') (onlyOwner)",
-)
-  .addParam("token", "Token proxy address (HlBridgeToken / HyperliquedBridgeToken)")
-  .addParam("deployer", "HyperCore deployer address to write into the namespaced slot")
-  .setAction(async (taskArgs, hre) => {
-    const { ethers } = hre
-    const [signer] = await ethers.getSigners()
-    const proxy = ethers.getAddress(taskArgs.token)
-    const deployer = ethers.getAddress(taskArgs.deployer)
-
-    const HYPER_CORE_DEPLOYER_SLOT = ethers.keccak256(ethers.toUtf8Bytes("HyperCore deployer"))
-
-    // Read the current value via direct storage slot (works even if the contract
-    // doesn't expose a getter — slot is canonical).
-    const beforeRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
-    const before = ethers.getAddress(`0x${beforeRaw.slice(-40)}`)
-
-    const iface = new ethers.Interface([
-      "function setHyperCoreDeployer(address) external",
-      "function owner() external view returns (address)",
-    ])
-    const token = new ethers.Contract(proxy, iface, signer)
-
-    const owner: string = await token.owner()
-    const signerAddress = await signer.getAddress()
-    if (signerAddress.toLowerCase() !== owner.toLowerCase()) {
-      console.warn(
-        `WARNING: signer (${signerAddress}) is not the owner (${owner}) — tx will revert`,
-      )
-    }
-
-    const tx = await token.setHyperCoreDeployer(deployer)
-    const receipt = await tx.wait()
-
-    const afterRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
-    const after = ethers.getAddress(`0x${afterRaw.slice(-40)}`)
-
-    console.log(
-      JSON.stringify(
-        {
-          proxy,
-          signer: signerAddress,
-          owner,
-          slot: HYPER_CORE_DEPLOYER_SLOT,
-          hyperCoreDeployerBefore: before,
-          hyperCoreDeployerAfter: after,
-          txHash: receipt.hash,
-        },
-        null,
-        2,
-      ),
-    )
-  })
-
-task(
   "transfer-token-ownership",
   "Step 1 of Ownable2Step: current owner initiates ownership transfer (sets pendingOwner = newOwner). The new owner must then call acceptOwnership themselves.",
 )

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -151,19 +151,20 @@ task("deploy-token-impl", "Deploys the BridgeToken implementation").setAction(as
   )
 })
 
-task("deploy-hl-token-impl", "Deploys the HlBridgeToken (HyperliquedBridgeToken) implementation").setAction(
-  async (_, hre) => {
-    const { ethers } = hre
-    const HlBridgeTokenContractFactory = await ethers.getContractFactory("HyperliquedBridgeToken")
-    const HlBridgeTokenContract = await HlBridgeTokenContractFactory.deploy()
-    await HlBridgeTokenContract.waitForDeployment()
-    console.log(
-      JSON.stringify({
-        tokenImplAddress: await HlBridgeTokenContract.getAddress(),
-      }),
-    )
-  },
-)
+task(
+  "deploy-hl-token-impl",
+  "Deploys the HlBridgeToken (HyperliquedBridgeToken) implementation",
+).setAction(async (_, hre) => {
+  const { ethers } = hre
+  const HlBridgeTokenContractFactory = await ethers.getContractFactory("HyperliquedBridgeToken")
+  const HlBridgeTokenContract = await HlBridgeTokenContractFactory.deploy()
+  await HlBridgeTokenContract.waitForDeployment()
+  console.log(
+    JSON.stringify({
+      tokenImplAddress: await HlBridgeTokenContract.getAddress(),
+    }),
+  )
+})
 
 task(
   "deploy-hl-bridge-token-proxy",
@@ -174,7 +175,10 @@ task(
   .addParam("symbol", "Token symbol (e.g. 'NEAR')")
   .addParam("decimals", "Token decimals (e.g. '18')")
   .addParam("systemAddress", "HyperCore system address for this token (e.g. 0x20...0201)")
-  .addParam("hyperCoreDeployer", "Address of the HyperCore deployer (to be stored at keccak256('HyperCore deployer'))")
+  .addParam(
+    "hyperCoreDeployer",
+    "Address of the HyperCore deployer (to be stored at keccak256('HyperCore deployer'))",
+  )
   .setAction(async (taskArgs, hre) => {
     const { ethers } = hre
     const impl = ethers.getAddress(taskArgs.impl)
@@ -195,15 +199,14 @@ task(
       ],
     )
 
-    const Proxy = await ethers.getContractFactory("ERC1967Proxy")
-    const proxy = await Proxy.deploy(impl, initData)
+    const ProxyFactory = await ethers.getContractFactory("ERC1967Proxy")
+    const proxy = await ProxyFactory.deploy(impl, initData)
     await proxy.waitForDeployment()
     const proxyAddress = await proxy.getAddress()
 
-    const EIP1967_IMPL_SLOT =
-      "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+    const EIP1967_IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
     const implSlot = await ethers.provider.getStorage(proxyAddress, EIP1967_IMPL_SLOT)
-    const implementation = ethers.getAddress("0x" + implSlot.slice(-40))
+    const implementation = ethers.getAddress(`0x${implSlot.slice(-40)}`)
 
     console.log(
       JSON.stringify(
@@ -341,7 +344,7 @@ task(
     // Read the current value via direct storage slot (works even if the contract
     // doesn't expose a getter — slot is canonical).
     const beforeRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
-    const before = ethers.getAddress("0x" + beforeRaw.slice(-40))
+    const before = ethers.getAddress(`0x${beforeRaw.slice(-40)}`)
 
     const iface = new ethers.Interface([
       "function setHyperCoreDeployer(address) external",
@@ -361,7 +364,7 @@ task(
     const receipt = await tx.wait()
 
     const afterRaw = await ethers.provider.getStorage(proxy, HYPER_CORE_DEPLOYER_SLOT)
-    const after = ethers.getAddress("0x" + afterRaw.slice(-40))
+    const after = ethers.getAddress(`0x${afterRaw.slice(-40)}`)
 
     console.log(
       JSON.stringify(
@@ -402,18 +405,15 @@ task(
     }
 
     // 1. EIP-1967 proxy detection: implementation slot, admin slot, beacon slot
-    const EIP1967_IMPL_SLOT =
-      "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
-    const EIP1967_ADMIN_SLOT =
-      "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
-    const EIP1967_BEACON_SLOT =
-      "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50"
+    const EIP1967_IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+    const EIP1967_ADMIN_SLOT = "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
+    const EIP1967_BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50"
     const implSlot = await provider.getStorage(addr, EIP1967_IMPL_SLOT)
     const adminSlot = await provider.getStorage(addr, EIP1967_ADMIN_SLOT)
     const beaconSlot = await provider.getStorage(addr, EIP1967_BEACON_SLOT)
-    const implementation = ethers.getAddress("0x" + implSlot.slice(-40))
-    const admin = ethers.getAddress("0x" + adminSlot.slice(-40))
-    const beacon = ethers.getAddress("0x" + beaconSlot.slice(-40))
+    const implementation = ethers.getAddress(`0x${implSlot.slice(-40)}`)
+    const admin = ethers.getAddress(`0x${adminSlot.slice(-40)}`)
+    const beacon = ethers.getAddress(`0x${beaconSlot.slice(-40)}`)
     result.isProxy = implementation !== ethers.ZeroAddress
     result.implementation = implementation
     result.proxyAdmin = admin === ethers.ZeroAddress ? null : admin
@@ -454,11 +454,9 @@ task(
     }
 
     // 3. HyperCore-deployer slot (keccak256("HyperCore deployer"))
-    const HYPER_CORE_DEPLOYER_SLOT = ethers.keccak256(
-      ethers.toUtf8Bytes("HyperCore deployer"),
-    )
+    const HYPER_CORE_DEPLOYER_SLOT = ethers.keccak256(ethers.toUtf8Bytes("HyperCore deployer"))
     const hcSlot = await provider.getStorage(addr, HYPER_CORE_DEPLOYER_SLOT)
-    const hcDeployer = ethers.getAddress("0x" + hcSlot.slice(-40))
+    const hcDeployer = ethers.getAddress(`0x${hcSlot.slice(-40)}`)
     result.hyperCoreDeployer = hcDeployer === ethers.ZeroAddress ? null : hcDeployer
 
     console.log(JSON.stringify(result, null, 2))

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -86,7 +86,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     /// Used by Hyperliquid's `finalizeEvmContract` action to authorize the linking of this
     /// EVM contract to the HC token — HL reads this slot and the signer of `finalizeEvmContract`
     /// must match its value.
-    function setHyperCoreDeployer(address hyperCoreDeployer_) external onlyOwner {
+    function setHyperCoreDeployer(
+        address hyperCoreDeployer_
+    ) external onlyOwner {
         bytes32 slot = HYPER_CORE_DEPLOYER_SLOT;
         assembly {
             sstore(slot, hyperCoreDeployer_)

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -8,12 +8,15 @@ import {BridgeToken} from "./BridgeToken.sol";
 /// - 3-arg mint(address, uint256, bytes): mints on HyperCore (includes _update to system address for spot-balance tracking)
 contract HyperliquedBridgeToken is BridgeToken {
     address internal _systemAddress;
+    bytes32 constant HYPER_CORE_DEPLOYER_SLOT = keccak256("HyperCore deployer");
+    event HyperCoreDeployerSet(address indexed deployer);
 
     function initialize(
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
-        address systemAddress_
+        address systemAddress_,
+        address hyperCoreDeployer_
     ) external initializer {
         __ERC20_init(name_, symbol_);
         __UUPSUpgradeable_init();
@@ -23,6 +26,12 @@ contract HyperliquedBridgeToken is BridgeToken {
         _symbol = symbol_;
         _decimals = decimals_;
         _systemAddress = systemAddress_;
+
+        bytes32 hyperCoreDeployerSlot = HYPER_CORE_DEPLOYER_SLOT;
+        assembly {
+            sstore(hyperCoreDeployerSlot, hyperCoreDeployer_)
+        }
+        emit HyperCoreDeployerSet(hyperCoreDeployer_);
     }
 
     function mint(
@@ -32,5 +41,17 @@ contract HyperliquedBridgeToken is BridgeToken {
     ) external override onlyOwner {
         _mint(account, value);
         _update(account, _systemAddress, value);
+    }
+
+    /// @notice Sets the HyperCore deployer address stored at slot keccak256("HyperCore deployer").
+    /// Used by Hyperliquid's `finalizeEvmContract` action to authorize the linking of this
+    /// EVM contract to the HC token — HL reads this slot and the signer of `finalizeEvmContract`
+    /// must match its value.
+    function setHyperCoreDeployer(address hyperCoreDeployer_) external onlyOwner {
+        bytes32 slot = HYPER_CORE_DEPLOYER_SLOT;
+        assembly {
+            sstore(slot, hyperCoreDeployer_)
+        }
+        emit HyperCoreDeployerSet(hyperCoreDeployer_);
     }
 }

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -82,20 +82,6 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         _update(account, _systemAddress, value);
     }
 
-    /// @notice Sets the HyperCore deployer address stored at slot keccak256("HyperCore deployer").
-    /// Used by Hyperliquid's `finalizeEvmContract` action to authorize the linking of this
-    /// EVM contract to the HC token — HL reads this slot and the signer of `finalizeEvmContract`
-    /// must match its value.
-    function setHyperCoreDeployer(
-        address hyperCoreDeployer_
-    ) external onlyOwner {
-        bytes32 slot = HYPER_CORE_DEPLOYER_SLOT;
-        assembly {
-            sstore(slot, hyperCoreDeployer_)
-        }
-        emit HyperCoreDeployerSet(hyperCoreDeployer_);
-    }
-
     /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
     /// HyperCore user triggers `sendToEvmWithData` targeting this token.
     /// `destinationRecipient`, `destinationChainId`, and `coreNonce` are CCTP-shaped

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -51,8 +51,8 @@ describe("HyperliquedBridgeToken", () => {
     const HlFactory = await ethers.getContractFactory("HyperliquedBridgeToken")
     const deployed = await upgrades.deployProxy(
       HlFactory,
-      ["Wrapped HL", "wHL", 18, SYSTEM_ADDRESS],
-      { initializer: "initialize(string,string,uint8,address)", kind: "uups" },
+      ["Wrapped HL", "wHL", 18, SYSTEM_ADDRESS, adminAccount.address],
+      { initializer: "initialize(string,string,uint8,address,address)", kind: "uups" },
     )
     const token = (await deployed.waitForDeployment()) as unknown as HyperliquedBridgeToken
     return { token, address: await token.getAddress() }

--- a/evm/utils/hyperliquid/.env.example
+++ b/evm/utils/hyperliquid/.env.example
@@ -1,3 +1,6 @@
+# Which Hyperliquid network to target: "testnet" or "mainnet".
+HL_NETWORK=testnet
+
 # Hyperliquid HyperCore deployer key.
 # Hex string, with or without 0x prefix (eth_account handles both).
 HL_SECRET_KEY=

--- a/evm/utils/hyperliquid/.env.example
+++ b/evm/utils/hyperliquid/.env.example
@@ -1,6 +1,3 @@
-# Which Hyperliquid network to target: "testnet" or "mainnet".
-HL_NETWORK=testnet
-
 # Hyperliquid HyperCore deployer key.
 # Hex string, with or without 0x prefix (eth_account handles both).
 HL_SECRET_KEY=

--- a/evm/utils/hyperliquid/.env.example
+++ b/evm/utils/hyperliquid/.env.example
@@ -1,0 +1,8 @@
+# Hyperliquid HyperCore deployer key.
+# Hex string, with or without 0x prefix (eth_account handles both).
+HL_SECRET_KEY=
+
+# Optional. The address of the main account if HL_SECRET_KEY belongs to an API
+# (agent) wallet. Leave empty if the secret key is the main account's own key —
+# the address will be derived from it.
+HL_ACCOUNT_ADDRESS=

--- a/evm/utils/hyperliquid/.env.example
+++ b/evm/utils/hyperliquid/.env.example
@@ -6,3 +6,9 @@ HL_SECRET_KEY=
 # (agent) wallet. Leave empty if the secret key is the main account's own key —
 # the address will be derived from it.
 HL_ACCOUNT_ADDRESS=
+
+# Key that signs `finalizeEvmContract` (step 2 of linking).
+# Must correspond to the address stored at slot keccak256("HyperCore deployer")
+# in the EVM contract being linked (set via `setHyperCoreDeployer` on
+# HlBridgeToken.sol). Can differ from HL_SECRET_KEY.
+EVM_SECRET_KEY=

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -4,12 +4,114 @@ Scripts and helpers for interacting with Hyperliquid HyperCore (HC) and HyperEVM
 
 ## Setup
 
-(fill in: dependencies, env vars, prerequisites)
+### 1. Create a Python environment
+
+Recommended: a dedicated conda env to isolate dependencies from the rest of the project.
+
+```bash
+conda create -n hl-utils python=3.11 -y
+conda activate hl-utils
+```
+
+(or use `venv` / `pyenv` if you prefer — any Python 3.10+ works)
+
+### 2. Install dependencies
+
+Install all three via `pip` (the conda env is just for Python isolation):
+
+```bash
+pip install hyperliquid-python-sdk python-dotenv eth-account
+```
+
+- `hyperliquid-python-sdk` — official Python client (gives `hyperliquid.exchange`, `hyperliquid.info`, `hyperliquid.utils`)
+- `python-dotenv` — loads secrets from `.env`
+- `eth-account` — Ethereum account / signing primitives (usually pulled in transitively, but we depend on it directly)
+
+> Note: `python-dotenv` and `eth-account` are available on `conda-forge`, but `hyperliquid-python-sdk` is **only** on PyPI. Mixing conda + pip in one env can occasionally break dependency resolution — easier to install all three with pip inside the activated conda env.
+
+### 3. Configure secrets — `.env`
+
+Copy the example and fill in your values:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+Required:
+
+- `HL_SECRET_KEY` — private key of your HyperCore deployer (hex, with or without `0x`).
+- `HL_ACCOUNT_ADDRESS` — leave empty if the secret key is your main account's. Set it only if `HL_SECRET_KEY` is an API/agent wallet and you want to act on behalf of a different main account.
+
+⚠️ Never commit `.env`. It's already covered by `.gitignore` patterns for env files in the repo.
+
+### 4. Configure deployment parameters — `deploy_params.json`
+
+This file is **not secret** and is meant to be committed. Edit it before running:
+
+| Field | Meaning |
+|---|---|
+| `network` | `"testnet"` or `"mainnet"` |
+| `token_id` | `null` initially. After step1 succeeds the script writes the returned token index here. |
+| `spot_id` | `null` initially. After step4 succeeds the script writes the returned spot index here. |
+| `last_step` | `null` initially. Updated after each step; controls resume logic. |
+| `token_name` | HIP-1 token name (e.g. `"NEAR"`) — immutable after step1. |
+| `token_description` | Free-form description. |
+| `sz_decimals` | Trading-precision decimals (typically 2). |
+| `wei_decimals` | Atomic-unit decimals (typically 8). |
+| `max_gas` | Max HYPE willing to pay in the spot-deploy auction, in HYPE wei (1 HYPE = 10^8 wei). |
+| `total_supply` | Genesis supply allocation, as a decimal string in atomic units. We use `2^64 - 1` to set the maximum HyperCore-representable cap (bridged tokens only ever circulate what is actually bridged in). |
+| `start_px` | Reference price for `register_hyperliquidity` (anchor price). With `noHyperliquidity = True` it's recorded but no orders are placed. |
 
 ## Scripts
 
-(fill in as scripts are added)
+### `spot_deploy.py`
+
+End-to-end HIP-1 token deploy on HyperCore (steps 1–5).
+
+Run:
+
+```bash
+python spot_deploy.py
+```
+
+The script:
+
+1. Loads `.env` and `deploy_params.json`.
+2. Connects to the network (`HL_NETWORK` from params).
+3. Walks through steps 1-5, **printing `spotDeployState` from HL before each** and **asking for `[y/N]` confirmation**.
+4. After each successful step, persists progress back to `deploy_params.json` (`last_step`, `token_id`, `spot_id`).
+
+Step skip-rules (so resume / partial runs are safe):
+
+| Step | Skipped if |
+|---|---|
+| 1. register_token | `last_step >= 1` **OR** `token_id` set |
+| 2. user_genesis | `last_step >= 2` **OR** `spot_id` set |
+| 3. genesis | `last_step >= 3` **OR** `spot_id` set |
+| 4. register_spot | `last_step >= 4` **OR** `spot_id` set |
+| 5. register_hyperliquidity | `last_step >= 5` |
+
+Replying `n` to a confirm prompt exits cleanly — progress is preserved, you can re-run later.
 
 ## Notes
 
-(fill in: gotchas, account-mode requirements, etc.)
+### Reversibility (read before running on mainnet)
+
+| Step | Reversible? | Notes |
+|---|---|---|
+| 1. register_token | ❌ if auction won | Costs HYPE. Name/decimals immutable after success. Re-running with `token_id = null` will register a *new* token. |
+| 2. user_genesis | ⚠️ until step 3 | Multiple calls allowed, but frozen after `genesis`. |
+| 3. genesis | ❌ | Locks `max_supply` and `noHyperliquidity` permanently. |
+| 4. register_spot | ❌ | Initial pair is `<token>/USDC`. Other quote tokens can be added later via a separate permissionless Dutch auction. |
+| 5. register_hyperliquidity | ❌ | With `noHyperliquidity = True` it's a formality (`n_orders = 0`), but still must be called. |
+
+### Hardcoded design choices (in code, not config)
+
+- `noHyperliquidity = True` (step 3) — we're deploying a bridged token, all liquidity comes from the bridge, never from a protocol-level AMM.
+- `order_sz = 0`, `n_orders = 0`, `n_seeded_levels = None` (step 5) — forced by the choice above.
+- Initial spot pair quote token = USDC (index 0) — required by HL at initial deployment.
+
+### Account-mode requirement
+
+Some deploy actions (especially admin-style ones like `setDeployerTradingFeeShare`, `enableQuoteToken`) require the deployer account to be in **Standard / Manual mode**, not Unified Account / Portfolio Margin. If a call returns `Action disabled when unified account is active`, disable Portfolio Margin and Unified Account Mode in the HL UI (settings, top-right) and retry.

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -1,0 +1,15 @@
+# Hyperliquid utils
+
+Scripts and helpers for interacting with Hyperliquid HyperCore (HC) and HyperEVM.
+
+## Setup
+
+(fill in: dependencies, env vars, prerequisites)
+
+## Scripts
+
+(fill in as scripts are added)
+
+## Notes
+
+(fill in: gotchas, account-mode requirements, etc.)

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -117,28 +117,6 @@ Run:
 python links_tokens.py
 ```
 
-The script:
-
-1. Loads `.env` and `link_tokens_params.json`.
-2. Validates that `token_id` and `evm_contract_address` are set; fails fast otherwise.
-3. Calls `requestEvmContract` immediately (reversible — can be re-issued before finalize).
-4. Prints `spotDeployState` from HL so you can sanity-check the pending request.
-5. Asks for `[y/N]` confirmation — replying `n` exits cleanly without finalizing.
-6. On `y`, calls `finalizeEvmContract` (**IRREVERSIBLE** — locks the link permanently).
-
-#### Prerequisites for `firstStorageSlot` mode
-
-⚠️ The chosen `evm_contract_address` **must have the signer's address in storage slot 0**. HL queries slot 0 on EVM and compares it to the action signer. Standard `ERC1967Proxy` does **not** put the deployer there (slot 0 holds `_name` on our `BridgeToken`-derived contracts), so this mode requires either a custom contract or an explicit slot-0 owner field.
-
-If the contract doesn't satisfy this, `finalizeEvmContract` will fail with an HL-side validation error — no on-chain consequences, but you'll need to fix slot 0 (deploy a new contract) and re-run.
-
-#### Reversibility
-
-| Step | Reversible? | Notes |
-|---|---|---|
-| `requestEvmContract` | ✅ | Sets a pending entry; later requests likely overwrite it (HL docs don't formally specify, but that's the practical pattern). |
-| `finalizeEvmContract` | ❌ | Permanently links the HC token to the specified EVM contract address. Cannot re-link to a different EVM contract afterwards. |
-
 ## Notes
 
 ### Reversibility (read before running on mainnet)

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -41,8 +41,6 @@ We never sign with the token owner's private key directly. Instead, create a bra
 
 The agent wallet does not hold funds — it only signs trading-style actions on behalf of the master. The fresh private key is what you will put into `.env` as `HL_SECRET_KEY` in the next step.
 
-> Note: agents are restricted to trading actions. Admin / deploy actions (`spotDeploy.*`, `finalizeEvmContract`, etc.) must still be signed by the master key directly. For those one-off operations you would temporarily put the master key into `.env`; for everyday operations the agent key is enough and safer.
-
 ### 4. Configure secrets — `.env`
 
 Copy the example and fill in your values:
@@ -54,8 +52,12 @@ $EDITOR .env
 
 Required:
 
-- `HL_SECRET_KEY` — private key of your HyperCore deployer (hex, with or without `0x`).
-- `HL_ACCOUNT_ADDRESS` — leave empty if the secret key is your main account's. Set it only if `HL_SECRET_KEY` is an API/agent wallet and you want to act on behalf of a different main account.
+- `HL_SECRET_KEY` — private key of the **agent** wallet you generated and approved in the previous step (hex, with or without `0x`). Not the owner's key.
+- `HL_ACCOUNT_ADDRESS` — address of the **owner** (master) account that approved the agent, *not* the agent's own address. The script signs with the agent key but acts on behalf of this owner.
+- `EVM_SECRET_KEY` — private key used at the **linking step** (`links_tokens.py`). The corresponding address must:
+  - be already registered on HyperEVM / HyperCore (at least one prior deposit / on-chain activity),
+  - hold some HYPE to pay for gas / fees on HC actions,
+  - match the address stored in the `hyper_core_deployer_slot` (`keccak256("HyperCore deployer")`) of the `HyperliquedBridgeToken` proxy on EVM — that's the address HL checks against during `finalizeEvmContract` in `customStorageSlot` mode.
 
 ⚠️ Never commit `.env`. It's already covered by `.gitignore` patterns for env files in the repo.
 

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -30,7 +30,20 @@ pip install hyperliquid-python-sdk python-dotenv eth-account requests
 
 > Note: `python-dotenv` and `eth-account` are available on `conda-forge`, but `hyperliquid-python-sdk` is **only** on PyPI. Mixing conda + pip in one env can occasionally break dependency resolution — easier to install all three with pip inside the activated conda env.
 
-### 3. Configure secrets — `.env`
+### 3. Create a fresh agent wallet and approve it on Hyperliquid
+
+We never sign with the token owner's private key directly. Instead, create a brand-new EVM key pair that will act as an **API (agent) wallet** for the owner account, and approve it through the Hyperliquid UI:
+
+1. Generate a fresh EVM key locally (any tool that gives you `(address, private key)` — e.g. `cast wallet new`, MetaMask "Create account", or a one-off Python snippet with `eth_account`).
+2. Open <https://app.hyperliquid.xyz/API> while logged in as the **token owner** (the master account).
+3. Add the fresh address as a new API wallet (give it a name like `deploy-script`).
+4. Confirm the approval transaction from the master account.
+
+The agent wallet does not hold funds — it only signs trading-style actions on behalf of the master. The fresh private key is what you will put into `.env` as `HL_SECRET_KEY` in the next step.
+
+> Note: agents are restricted to trading actions. Admin / deploy actions (`spotDeploy.*`, `finalizeEvmContract`, etc.) must still be signed by the master key directly. For those one-off operations you would temporarily put the master key into `.env`; for everyday operations the agent key is enough and safer.
+
+### 4. Configure secrets — `.env`
 
 Copy the example and fill in your values:
 
@@ -46,7 +59,7 @@ Required:
 
 ⚠️ Never commit `.env`. It's already covered by `.gitignore` patterns for env files in the repo.
 
-### 4. Configure deployment parameters — `deploy_params.json`
+### 5. Configure deployment parameters — `deploy_params.json`
 
 This file is **not secret** and is meant to be committed. Edit it before running:
 
@@ -64,7 +77,7 @@ This file is **not secret** and is meant to be committed. Edit it before running
 | `total_supply` | Genesis supply allocation, as a decimal string in atomic units. We use `2^64 - 1` to set the maximum HyperCore-representable cap (bridged tokens only ever circulate what is actually bridged in). |
 | `start_px` | Reference price for `register_hyperliquidity` (anchor price). With `noHyperliquidity = True` it's recorded but no orders are placed. |
 
-### 5. Configure link parameters — `link_tokens_params.json`
+### 6. Configure link parameters — `link_tokens_params.json`
 
 Separate non-secret config consumed by `links_tokens.py`. Fields:
 

--- a/evm/utils/hyperliquid/README.md
+++ b/evm/utils/hyperliquid/README.md
@@ -20,12 +20,13 @@ conda activate hl-utils
 Install all three via `pip` (the conda env is just for Python isolation):
 
 ```bash
-pip install hyperliquid-python-sdk python-dotenv eth-account
+pip install hyperliquid-python-sdk python-dotenv eth-account requests
 ```
 
 - `hyperliquid-python-sdk` — official Python client (gives `hyperliquid.exchange`, `hyperliquid.info`, `hyperliquid.utils`)
 - `python-dotenv` — loads secrets from `.env`
 - `eth-account` — Ethereum account / signing primitives (usually pulled in transitively, but we depend on it directly)
+- `requests` — HTTP client used by `links_tokens.py` to call `/exchange` and `/info` endpoints directly
 
 > Note: `python-dotenv` and `eth-account` are available on `conda-forge`, but `hyperliquid-python-sdk` is **only** on PyPI. Mixing conda + pip in one env can occasionally break dependency resolution — easier to install all three with pip inside the activated conda env.
 
@@ -63,6 +64,18 @@ This file is **not secret** and is meant to be committed. Edit it before running
 | `total_supply` | Genesis supply allocation, as a decimal string in atomic units. We use `2^64 - 1` to set the maximum HyperCore-representable cap (bridged tokens only ever circulate what is actually bridged in). |
 | `start_px` | Reference price for `register_hyperliquidity` (anchor price). With `noHyperliquidity = True` it's recorded but no orders are placed. |
 
+### 5. Configure link parameters — `link_tokens_params.json`
+
+Separate non-secret config consumed by `links_tokens.py`. Fields:
+
+| Field | Meaning |
+|---|---|
+| `network` | `"testnet"` or `"mainnet"` (independent of `deploy_params.json`'s `network`) |
+| `token_id` | HC token index to link (the same number `spot_deploy.py` writes into `deploy_params.json` after step 1) |
+| `evm_contract_address` | Address of the ERC-20 contract on HyperEVM that should be linked to `token_id` |
+| `evm_extra_wei_decimals` | Additional EVM-side decimals on top of `wei_decimals` (HC `wei_decimals` + `evm_extra_wei_decimals` = ERC-20 `decimals()`). Typical: `10` |
+| `last_link_step` | `null` initially. Reserved for future skip / resume logic (not yet enforced) |
+
 ## Scripts
 
 ### `spot_deploy.py`
@@ -93,6 +106,38 @@ Step skip-rules (so resume / partial runs are safe):
 | 5. register_hyperliquidity | `last_step >= 5` |
 
 Replying `n` to a confirm prompt exits cleanly — progress is preserved, you can re-run later.
+
+### `links_tokens.py`
+
+Links a HIP-1 HC token to an existing ERC-20 contract on HyperEVM. Uses the **`firstStorageSlot` verification mode**: HL reads storage slot 0 of the EVM contract and expects it to contain the signer's address.
+
+Run:
+
+```bash
+python links_tokens.py
+```
+
+The script:
+
+1. Loads `.env` and `link_tokens_params.json`.
+2. Validates that `token_id` and `evm_contract_address` are set; fails fast otherwise.
+3. Calls `requestEvmContract` immediately (reversible — can be re-issued before finalize).
+4. Prints `spotDeployState` from HL so you can sanity-check the pending request.
+5. Asks for `[y/N]` confirmation — replying `n` exits cleanly without finalizing.
+6. On `y`, calls `finalizeEvmContract` (**IRREVERSIBLE** — locks the link permanently).
+
+#### Prerequisites for `firstStorageSlot` mode
+
+⚠️ The chosen `evm_contract_address` **must have the signer's address in storage slot 0**. HL queries slot 0 on EVM and compares it to the action signer. Standard `ERC1967Proxy` does **not** put the deployer there (slot 0 holds `_name` on our `BridgeToken`-derived contracts), so this mode requires either a custom contract or an explicit slot-0 owner field.
+
+If the contract doesn't satisfy this, `finalizeEvmContract` will fail with an HL-side validation error — no on-chain consequences, but you'll need to fix slot 0 (deploy a new contract) and re-run.
+
+#### Reversibility
+
+| Step | Reversible? | Notes |
+|---|---|---|
+| `requestEvmContract` | ✅ | Sets a pending entry; later requests likely overwrite it (HL docs don't formally specify, but that's the practical pattern). |
+| `finalizeEvmContract` | ❌ | Permanently links the HC token to the specified EVM contract address. Cannot re-link to a different EVM contract afterwards. |
 
 ## Notes
 

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -10,7 +10,7 @@
   "wei_decimals": 8,
   "max_gas": 50000000000,
 
-  "total_supply": "130000000000000000",
+  "total_supply": "18446744073709551615",
 
   "start_px": 1.0
 }

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -7,5 +7,7 @@
   "token_description": "NEAR Protocol",
   "sz_decimals": 2,
   "wei_decimals": 8,
-  "max_gas": 50000000000
+  "max_gas": 50000000000,
+
+  "total_supply": "130000000000000000"
 }

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -2,6 +2,7 @@
   "network": "mainnet",
 
   "token_id": null,
+  "spot_id": null,
 
   "token_name": "NEAR",
   "token_description": "NEAR Protocol",
@@ -9,5 +10,7 @@
   "wei_decimals": 8,
   "max_gas": 50000000000,
 
-  "total_supply": "130000000000000000"
+  "total_supply": "130000000000000000",
+
+  "start_px": 1.0
 }

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -1,0 +1,11 @@
+{
+  "network": "mainnet",
+
+  "token_id": null,
+
+  "token_name": "NEAR",
+  "token_description": "NEAR Protocol",
+  "sz_decimals": 2,
+  "wei_decimals": 8,
+  "max_gas": 50000000000
+}

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -11,7 +11,7 @@
   "wei_decimals": 8,
   "max_gas": 50000000000,
 
-  "total_supply": "18446744073709551615",
+  "total_supply": "900000000000000000",
 
   "start_px": 1.0
 }

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -1,9 +1,9 @@
 {
   "network": "mainnet",
 
-  "token_id": null,
+  "token_id": 513,
   "spot_id": null,
-  "last_step": null,
+  "last_step": 1,
 
   "token_name": "NEAR",
   "token_description": "NEAR Protocol",

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -3,6 +3,7 @@
 
   "token_id": null,
   "spot_id": null,
+  "last_step": null,
 
   "token_name": "NEAR",
   "token_description": "NEAR Protocol",

--- a/evm/utils/hyperliquid/deploy_params.json
+++ b/evm/utils/hyperliquid/deploy_params.json
@@ -13,5 +13,5 @@
 
   "total_supply": "900000000000000000",
 
-  "start_px": 1.0
+  "start_px": 2.0
 }

--- a/evm/utils/hyperliquid/deploy_params_testnet.json
+++ b/evm/utils/hyperliquid/deploy_params_testnet.json
@@ -1,0 +1,13 @@
+{
+  "network": "testnet",
+  "token_id": 2007,
+  "spot_id": null,
+  "last_step": 1,
+  "token_name": "WNEAR",
+  "token_description": "NEAR Protocol",
+  "sz_decimals": 2,
+  "wei_decimals": 8,
+  "max_gas": 50000000000,
+  "total_supply": "900000000000000000",
+  "start_px": 2.9
+}

--- a/evm/utils/hyperliquid/deploy_params_testnet.json
+++ b/evm/utils/hyperliquid/deploy_params_testnet.json
@@ -9,5 +9,5 @@
   "wei_decimals": 8,
   "max_gas": 50000000000,
   "total_supply": "900000000000000000",
-  "start_px": 2.9
+  "start_px": 0
 }

--- a/evm/utils/hyperliquid/deploy_params_testnet.json
+++ b/evm/utils/hyperliquid/deploy_params_testnet.json
@@ -9,5 +9,5 @@
   "wei_decimals": 8,
   "max_gas": 50000000000,
   "total_supply": "900000000000000000",
-  "start_px": 0
+  "start_px": 2.0
 }

--- a/evm/utils/hyperliquid/link_tokens_params.json
+++ b/evm/utils/hyperliquid/link_tokens_params.json
@@ -1,12 +1,9 @@
 {
-  "network": "testnet",
+  "network": "mainnet",
 
   "token_id": null,
   "evm_contract_address": null,
   "evm_extra_wei_decimals": 10,
-
-  "finalization_mode": "create",
-  "creation_nonce": null,
 
   "last_link_step": null
 }

--- a/evm/utils/hyperliquid/link_tokens_params.json
+++ b/evm/utils/hyperliquid/link_tokens_params.json
@@ -1,7 +1,7 @@
 {
   "network": "mainnet",
 
-  "token_id": null,
+  "token_id": 513,
   "evm_contract_address": null,
   "evm_extra_wei_decimals": 10,
 

--- a/evm/utils/hyperliquid/link_tokens_params.json
+++ b/evm/utils/hyperliquid/link_tokens_params.json
@@ -1,0 +1,12 @@
+{
+  "network": "testnet",
+
+  "token_id": null,
+  "evm_contract_address": null,
+  "evm_extra_wei_decimals": 10,
+
+  "finalization_mode": "create",
+  "creation_nonce": null,
+
+  "last_link_step": null
+}

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -9,12 +9,10 @@ from eth_account.signers.local import LocalAccount
 from hyperliquid.utils import constants
 from hyperliquid.utils.signing import get_timestamp_ms, sign_l1_action
 
-# Load .env from the same directory as this script.
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params_testnet.json")
 
-# Type def for the finalize action (we only support the customStorageSlot mode).
 FinalizeEvmContractAction = TypedDict(
     "FinalizeEvmContractAction",
     {
@@ -39,9 +37,14 @@ def save_params(params):
 def get_secret_key():
     secret_key = os.environ.get("HL_SECRET_KEY")
     if not secret_key:
-        raise RuntimeError(
-            "HL_SECRET_KEY is not set. Add it to evm/utils/hyperliquid/.env (see .env.example)."
-        )
+        raise RuntimeError("HL_SECRET_KEY is not set. See .env.example.")
+    return secret_key
+
+
+def get_evm_secret_key():
+    secret_key = os.environ.get("EVM_SECRET_KEY")
+    if not secret_key:
+        raise RuntimeError("EVM_SECRET_KEY is not set. See .env.example.")
     return secret_key
 
 
@@ -59,12 +62,7 @@ def confirm(prompt):
 
 
 def show_state(base_url, token_index):
-    """Look up the hex tokenId for `token_index` via spotMeta and print tokenDetails.
-
-    Note: `tokenDetails` does NOT contain a "pending EVM contract" field. To see
-    the final link, we also fetch spotMeta and extract the `evmContract` entry
-    (populated only after finalizeEvmContract).
-    """
+    """Print spotMeta entry + tokenDetails for the token."""
     meta = requests.post(base_url + "/info", json={"type": "spotMeta"}).json()
     token = next(
         (t for t in meta.get("tokens", []) if t.get("index") == token_index),
@@ -91,7 +89,7 @@ def show_state(base_url, token_index):
 
 
 def requestEvmContract(account, base_url, params):
-    """Step 1 of linking: declare which EVM contract should be linked to the HC token."""
+    """Step 1: declare which EVM contract should be linked to the HC token."""
     action = {
         "type": "spotDeploy",
         "requestEvmContract": {
@@ -101,7 +99,8 @@ def requestEvmContract(account, base_url, params):
         },
     }
     nonce = get_timestamp_ms()
-    signature = sign_l1_action(account, action, None, nonce, None, False)
+    is_mainnet = base_url == constants.MAINNET_API_URL
+    signature = sign_l1_action(account, action, None, nonce, None, is_mainnet)
     payload = {
         "action": action,
         "nonce": nonce,
@@ -113,12 +112,8 @@ def requestEvmContract(account, base_url, params):
 
 
 def finalizeEvmContract(account, base_url, params):
-    """Step 2 of linking: prove ownership of the EVM contract so HL activates the link.
-
-    Uses the "customStorageSlot" verification mode: HL queries the namespaced slot
-    `keccak256("HyperCore deployer")` on the EVM contract and expects it to contain
-    the signer's address. The EVM contract must therefore have stored the signer's
-    address at that slot (see `setHyperCoreDeployer` in `HlBridgeToken.sol`).
+    """Step 2: signer's address must match slot keccak256('HyperCore deployer')
+    in the EVM contract (see `setHyperCoreDeployer` in `HlBridgeToken.sol`).
     """
     finalize_action: FinalizeEvmContractAction = {
         "type": "finalizeEvmContract",
@@ -126,7 +121,8 @@ def finalizeEvmContract(account, base_url, params):
         "input": "customStorageSlot",
     }
     nonce = get_timestamp_ms()
-    signature = sign_l1_action(account, finalize_action, None, nonce, None, False)
+    is_mainnet = base_url == constants.MAINNET_API_URL
+    signature = sign_l1_action(account, finalize_action, None, nonce, None, is_mainnet)
     payload = {
         "action": finalize_action,
         "nonce": nonce,
@@ -140,34 +136,31 @@ def finalizeEvmContract(account, base_url, params):
 def main():
     params = load_params()
 
-    # Sanity checks — fail early with a clear message if config is incomplete.
     if params.get("token_id") is None:
         raise RuntimeError("token_id is not set in link_tokens_params.json")
     if params.get("evm_contract_address") is None:
         raise RuntimeError("evm_contract_address is not set in link_tokens_params.json")
 
     base_url = get_base_url(params["network"])
-    account: LocalAccount = Account.from_key(get_secret_key())
-    print(f"Running with address {account.address}")
+    hl_account: LocalAccount = Account.from_key(get_secret_key())
+    evm_account: LocalAccount = Account.from_key(get_evm_secret_key())
+
+    print(f"HL signer (step 1, requestEvmContract):  {hl_account.address}")
+    print(f"EVM signer (step 2, finalizeEvmContract): {evm_account.address}")
     print(
         f"Linking HC token {params['token_id']} → EVM contract {params['evm_contract_address']} "
         f"(network={params['network']}, mode=customStorageSlot)"
     )
 
-    # --- requestEvmContract: reversible, always run without confirm ---
-    requestEvmContract(account, base_url, params)
+    requestEvmContract(hl_account, base_url, params)
 
-    # --- finalizeEvmContract: IRREVERSIBLE, confirm + sanity-check current state ---
-    # Show token state so we can sanity-check before finalizing. Note: HL info
-    # endpoints do NOT expose the pending requestEvmContract — we can only see
-    # the final `evmContract` field in spotMeta after finalize succeeds.
     show_state(base_url, params["token_id"])
     if not confirm(
         f"Run finalizeEvmContract? "
         f"IRREVERSIBLE: locks token {params['token_id']} ↔ EVM contract {params['evm_contract_address']}"
     ):
         return
-    finalizeEvmContract(account, base_url, params)
+    finalizeEvmContract(evm_account, base_url, params)
 
 
 if __name__ == "__main__":

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -1,40 +1,81 @@
-from typing import TypedDict, Literal, Union
+import json
+import os
+from typing import TypedDict, Literal
 
 import requests
+from dotenv import load_dotenv
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
-from web3 import Web3
-from web3.middleware import SignAndSendRawMiddlewareBuilder
 from hyperliquid.utils import constants
 from hyperliquid.utils.signing import get_timestamp_ms, sign_l1_action
 
-CreateInputParams = TypedDict("CreateInputParams", {"nonce": int})
-CreateInput = TypedDict("CreateInput", {"create": CreateInputParams})
-FinalizeEvmContractInput = Union[Literal["firstStorageSlot"], CreateInput]
+# Load .env from the same directory as this script.
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params.json")
+
+# Type def for the finalize action (we only support the firstStorageSlot mode).
 FinalizeEvmContractAction = TypedDict(
     "FinalizeEvmContractAction",
-    {"type": Literal["finalizeEvmContract"], "token": int, "input": FinalizeEvmContractInput},
+    {
+        "type": Literal["finalizeEvmContract"],
+        "token": int,
+        "input": Literal["firstStorageSlot"],
+    },
 )
 
-DEFAULT_CONTRACT_ADDRESS = Web3.to_checksum_address(
-    "0x2E98e98aB34b42b14FeC9d431F7B051B232Ba133"  # change this to your contract address if you are skipping deploying
-)
-TOKEN = 1562  # note that if changing this you likely should also change the abi to have a different name and perhaps also different decimals and initial supply
-PRIVATE_KEY = "0xPRIVATE_KEY"  # Change this to your private key
 
-# Connect to the JSON-RPC endpoint
-rpc_url = "https://rpc.hyperliquid-testnet.xyz/evm"
+def load_params():
+    with open(LINK_PARAMS_PATH) as f:
+        return json.load(f)
 
-contract_address = DEFAULT_CONTRACT_ADDRESS
 
-def requestEvmContract(account):
-    assert contract_address is not None
+def save_params(params):
+    with open(LINK_PARAMS_PATH, "w") as f:
+        json.dump(params, f, indent=2)
+        f.write("\n")
+
+
+def get_secret_key():
+    secret_key = os.environ.get("HL_SECRET_KEY")
+    if not secret_key:
+        raise RuntimeError(
+            "HL_SECRET_KEY is not set. Add it to evm/utils/hyperliquid/.env (see .env.example)."
+        )
+    return secret_key
+
+
+def get_base_url(network):
+    network = network.lower()
+    if network == "mainnet":
+        return constants.MAINNET_API_URL
+    if network == "testnet":
+        return constants.TESTNET_API_URL
+    raise RuntimeError(f"Invalid network={network!r}. Expected 'testnet' or 'mainnet'.")
+
+
+def confirm(prompt):
+    return input(f"\n{prompt} [y/N]: ").strip().lower() == "y"
+
+
+def show_state(base_url, user_address):
+    """Print spotDeployState for the user — useful to inspect pending requestEvmContract."""
+    response = requests.post(
+        base_url + "/info",
+        json={"type": "spotDeployState", "user": user_address},
+    )
+    print("\n=== spotDeployState ===")
+    print(json.dumps(response.json(), indent=2))
+
+
+def requestEvmContract(account, base_url, params):
+    """Step 1 of linking: declare which EVM contract should be linked to the HC token."""
     action = {
         "type": "spotDeploy",
         "requestEvmContract": {
-            "token": TOKEN,
-            "address": contract_address.lower(),
-            "evmExtraWeiDecimals": 10,
+            "token": params["token_id"],
+            "address": params["evm_contract_address"].lower(),
+            "evmExtraWeiDecimals": params["evm_extra_wei_decimals"],
         },
     }
     nonce = get_timestamp_ms()
@@ -45,22 +86,22 @@ def requestEvmContract(account):
         "signature": signature,
         "vaultAddress": None,
     }
-    response = requests.post(constants.TESTNET_API_URL + "/exchange", json=payload)
+    response = requests.post(base_url + "/exchange", json=payload)
     print(response.json())
 
-def finalizeEvmContract(account):
-    creation_nonce = 4
-    print(creation_nonce)
-    use_create_finalization = True
-    finalize_action: FinalizeEvmContractAction
-    if use_create_finalization:
-        finalize_action = {
-            "type": "finalizeEvmContract",
-            "token": TOKEN,
-            "input": {"create": {"nonce": creation_nonce}},
-        }
-    else:
-        finalize_action = {"type": "finalizeEvmContract", "token": TOKEN, "input": "firstStorageSlot"}
+
+def finalizeEvmContract(account, base_url, params):
+    """Step 2 of linking: prove ownership of the EVM contract so HL activates the link.
+
+    Uses the "firstStorageSlot" verification mode: HL queries storage slot 0 of the
+    EVM contract and expects it to contain the signer's address. The EVM contract
+    therefore must have the signer's address in slot 0 — verify this before running.
+    """
+    finalize_action: FinalizeEvmContractAction = {
+        "type": "finalizeEvmContract",
+        "token": params["token_id"],
+        "input": "firstStorageSlot",
+    }
     nonce = get_timestamp_ms()
     signature = sign_l1_action(account, finalize_action, None, nonce, None, False)
     payload = {
@@ -69,28 +110,41 @@ def finalizeEvmContract(account):
         "signature": signature,
         "vaultAddress": None,
     }
-    response = requests.post(constants.TESTNET_API_URL + "/exchange", json=payload)
+    response = requests.post(base_url + "/exchange", json=payload)
     print(response.json())
 
 
 def main():
-    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    params = load_params()
 
-    # The account will be used both for deploying the ERC20 contract and linking it to your native spot asset
-    # You can also switch this to create an account a different way if you don't want to include a secret key in code
-    if PRIVATE_KEY == "0xPRIVATE_KEY":
-        raise Exception("must set private key or create account another way")
-    account: LocalAccount = Account.from_key(PRIVATE_KEY)
+    # Sanity checks — fail early with a clear message if config is incomplete.
+    if params.get("token_id") is None:
+        raise RuntimeError("token_id is not set in link_tokens_params.json")
+    if params.get("evm_contract_address") is None:
+        raise RuntimeError("evm_contract_address is not set in link_tokens_params.json")
+
+    base_url = get_base_url(params["network"])
+    account: LocalAccount = Account.from_key(get_secret_key())
     print(f"Running with address {account.address}")
-    w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
-    w3.eth.default_account = account.address
-    # Verify connection
-    if not w3.is_connected():
-        raise Exception("Failed to connect to the Ethereum network")
+    print(
+        f"Linking HC token {params['token_id']} → EVM contract {params['evm_contract_address']} "
+        f"(network={params['network']}, mode=firstStorageSlot)"
+    )
 
-    print(TOKEN, contract_address.lower())
-    #requestEvmContract(account)
-    finalizeEvmContract(account)
+    # --- requestEvmContract: reversible, always run without confirm ---
+    requestEvmContract(account, base_url, params)
+
+    # --- finalizeEvmContract: IRREVERSIBLE, confirm + sanity-check pending state ---
+    # Show state so we can verify the pending request actually matches what
+    # we're about to finalize.
+    show_state(base_url, account.address)
+    if not confirm(
+        f"Run finalizeEvmContract? "
+        f"IRREVERSIBLE: locks token {params['token_id']} ↔ EVM contract {params['evm_contract_address']}"
+    ):
+        return
+    finalizeEvmContract(account, base_url, params)
+
 
 if __name__ == "__main__":
     main()

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -14,13 +14,13 @@ load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params.json")
 
-# Type def for the finalize action (we only support the firstStorageSlot mode).
+# Type def for the finalize action (we only support the customStorageSlot mode).
 FinalizeEvmContractAction = TypedDict(
     "FinalizeEvmContractAction",
     {
         "type": Literal["finalizeEvmContract"],
         "token": int,
-        "input": Literal["firstStorageSlot"],
+        "input": Literal["customStorageSlot"],
     },
 )
 
@@ -93,14 +93,15 @@ def requestEvmContract(account, base_url, params):
 def finalizeEvmContract(account, base_url, params):
     """Step 2 of linking: prove ownership of the EVM contract so HL activates the link.
 
-    Uses the "firstStorageSlot" verification mode: HL queries storage slot 0 of the
-    EVM contract and expects it to contain the signer's address. The EVM contract
-    therefore must have the signer's address in slot 0 — verify this before running.
+    Uses the "customStorageSlot" verification mode: HL queries the namespaced slot
+    `keccak256("HyperCore deployer")` on the EVM contract and expects it to contain
+    the signer's address. The EVM contract must therefore have stored the signer's
+    address at that slot (see `setHyperCoreDeployer` in `HlBridgeToken.sol`).
     """
     finalize_action: FinalizeEvmContractAction = {
         "type": "finalizeEvmContract",
         "token": params["token_id"],
-        "input": "firstStorageSlot",
+        "input": "customStorageSlot",
     }
     nonce = get_timestamp_ms()
     signature = sign_l1_action(account, finalize_action, None, nonce, None, False)
@@ -128,7 +129,7 @@ def main():
     print(f"Running with address {account.address}")
     print(
         f"Linking HC token {params['token_id']} → EVM contract {params['evm_contract_address']} "
-        f"(network={params['network']}, mode=firstStorageSlot)"
+        f"(network={params['network']}, mode=customStorageSlot)"
     )
 
     # --- requestEvmContract: reversible, always run without confirm ---

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -12,7 +12,7 @@ from hyperliquid.utils.signing import get_timestamp_ms, sign_l1_action
 # Load .env from the same directory as this script.
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
-LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params.json")
+LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params_testnet.json")
 
 # Type def for the finalize action (we only support the customStorageSlot mode).
 FinalizeEvmContractAction = TypedDict(
@@ -58,14 +58,36 @@ def confirm(prompt):
     return input(f"\n{prompt} [y/N]: ").strip().lower() == "y"
 
 
-def show_state(base_url, user_address):
-    """Print spotDeployState for the user — useful to inspect pending requestEvmContract."""
-    response = requests.post(
-        base_url + "/info",
-        json={"type": "spotDeployState", "user": user_address},
+def show_state(base_url, token_index):
+    """Look up the hex tokenId for `token_index` via spotMeta and print tokenDetails.
+
+    Note: `tokenDetails` does NOT contain a "pending EVM contract" field. To see
+    the final link, we also fetch spotMeta and extract the `evmContract` entry
+    (populated only after finalizeEvmContract).
+    """
+    meta = requests.post(base_url + "/info", json={"type": "spotMeta"}).json()
+    token = next(
+        (t for t in meta.get("tokens", []) if t.get("index") == token_index),
+        None,
     )
-    print("\n=== spotDeployState ===")
-    print(json.dumps(response.json(), indent=2))
+    if token is None:
+        print(
+            f"\n[show_state] token index {token_index} not found in spotMeta "
+            f"— token may not be deployed yet on this network"
+        )
+        return
+
+    token_id_hex = token["tokenId"]
+
+    details = requests.post(
+        base_url + "/info",
+        json={"type": "tokenDetails", "tokenId": token_id_hex},
+    ).json()
+
+    print("\n=== spotMeta entry ===")
+    print(json.dumps(token, indent=2))
+    print("\n=== tokenDetails ===")
+    print(json.dumps(details, indent=2))
 
 
 def requestEvmContract(account, base_url, params):
@@ -135,10 +157,11 @@ def main():
     # --- requestEvmContract: reversible, always run without confirm ---
     requestEvmContract(account, base_url, params)
 
-    # --- finalizeEvmContract: IRREVERSIBLE, confirm + sanity-check pending state ---
-    # Show state so we can verify the pending request actually matches what
-    # we're about to finalize.
-    show_state(base_url, account.address)
+    # --- finalizeEvmContract: IRREVERSIBLE, confirm + sanity-check current state ---
+    # Show token state so we can sanity-check before finalizing. Note: HL info
+    # endpoints do NOT expose the pending requestEvmContract — we can only see
+    # the final `evmContract` field in spotMeta after finalize succeeds.
+    show_state(base_url, params["token_id"])
     if not confirm(
         f"Run finalizeEvmContract? "
         f"IRREVERSIBLE: locks token {params['token_id']} ↔ EVM contract {params['evm_contract_address']}"

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -11,7 +11,7 @@ from hyperliquid.utils.signing import get_timestamp_ms, sign_l1_action
 
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
-LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params_testnet.json")
+LINK_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "link_tokens_params.json")
 
 FinalizeEvmContractAction = TypedDict(
     "FinalizeEvmContractAction",

--- a/evm/utils/hyperliquid/links_tokens.py
+++ b/evm/utils/hyperliquid/links_tokens.py
@@ -1,0 +1,96 @@
+from typing import TypedDict, Literal, Union
+
+import requests
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from web3 import Web3
+from web3.middleware import SignAndSendRawMiddlewareBuilder
+from hyperliquid.utils import constants
+from hyperliquid.utils.signing import get_timestamp_ms, sign_l1_action
+
+CreateInputParams = TypedDict("CreateInputParams", {"nonce": int})
+CreateInput = TypedDict("CreateInput", {"create": CreateInputParams})
+FinalizeEvmContractInput = Union[Literal["firstStorageSlot"], CreateInput]
+FinalizeEvmContractAction = TypedDict(
+    "FinalizeEvmContractAction",
+    {"type": Literal["finalizeEvmContract"], "token": int, "input": FinalizeEvmContractInput},
+)
+
+DEFAULT_CONTRACT_ADDRESS = Web3.to_checksum_address(
+    "0x2E98e98aB34b42b14FeC9d431F7B051B232Ba133"  # change this to your contract address if you are skipping deploying
+)
+TOKEN = 1562  # note that if changing this you likely should also change the abi to have a different name and perhaps also different decimals and initial supply
+PRIVATE_KEY = "0xPRIVATE_KEY"  # Change this to your private key
+
+# Connect to the JSON-RPC endpoint
+rpc_url = "https://rpc.hyperliquid-testnet.xyz/evm"
+
+contract_address = DEFAULT_CONTRACT_ADDRESS
+
+def requestEvmContract(account):
+    assert contract_address is not None
+    action = {
+        "type": "spotDeploy",
+        "requestEvmContract": {
+            "token": TOKEN,
+            "address": contract_address.lower(),
+            "evmExtraWeiDecimals": 10,
+        },
+    }
+    nonce = get_timestamp_ms()
+    signature = sign_l1_action(account, action, None, nonce, None, False)
+    payload = {
+        "action": action,
+        "nonce": nonce,
+        "signature": signature,
+        "vaultAddress": None,
+    }
+    response = requests.post(constants.TESTNET_API_URL + "/exchange", json=payload)
+    print(response.json())
+
+def finalizeEvmContract(account):
+    creation_nonce = 4
+    print(creation_nonce)
+    use_create_finalization = True
+    finalize_action: FinalizeEvmContractAction
+    if use_create_finalization:
+        finalize_action = {
+            "type": "finalizeEvmContract",
+            "token": TOKEN,
+            "input": {"create": {"nonce": creation_nonce}},
+        }
+    else:
+        finalize_action = {"type": "finalizeEvmContract", "token": TOKEN, "input": "firstStorageSlot"}
+    nonce = get_timestamp_ms()
+    signature = sign_l1_action(account, finalize_action, None, nonce, None, False)
+    payload = {
+        "action": finalize_action,
+        "nonce": nonce,
+        "signature": signature,
+        "vaultAddress": None,
+    }
+    response = requests.post(constants.TESTNET_API_URL + "/exchange", json=payload)
+    print(response.json())
+
+
+def main():
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+
+    # The account will be used both for deploying the ERC20 contract and linking it to your native spot asset
+    # You can also switch this to create an account a different way if you don't want to include a secret key in code
+    if PRIVATE_KEY == "0xPRIVATE_KEY":
+        raise Exception("must set private key or create account another way")
+    account: LocalAccount = Account.from_key(PRIVATE_KEY)
+    print(f"Running with address {account.address}")
+    w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
+    w3.eth.default_account = account.address
+    # Verify connection
+    if not w3.is_connected():
+        raise Exception("Failed to connect to the Ethereum network")
+
+    print(TOKEN, contract_address.lower())
+    #requestEvmContract(account)
+    finalizeEvmContract(account)
+
+if __name__ == "__main__":
+    main()

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -39,6 +39,19 @@ def get_secret_key():
             "HL_SECRET_KEY is not set. Add it to evm/utils/hyperliquid/.env (see .env.example)."
         )
     return secret_key
+
+
+def get_base_url():
+    network = os.environ.get("HL_NETWORK", "testnet").lower()
+    if network == "mainnet":
+        return constants.MAINNET_API_URL
+    if network == "testnet":
+        return constants.TESTNET_API_URL
+    raise RuntimeError(
+        f"Invalid HL_NETWORK={network!r}. Expected 'testnet' or 'mainnet'."
+    )
+
+
 def step1(exchange):
     # Step 1: Registering the Token
     #
@@ -109,7 +122,7 @@ def step5(exchange, spot):
     print(register_hyperliquidity_result)
 
 def main():
-    address, info, exchange = setup(constants.TESTNET_API_URL, skip_ws=True)
+    address, info, exchange = setup(get_base_url(), skip_ws=True)
     print(address, info, exchange)
 
     # token = step1()

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -163,7 +163,7 @@ def step5(exchange, spot, params):
     #   n_seeded_levels — how many bid levels to pre-fund with USDC instead of the
     #                     base token. None (or 0) means no USDC-funded levels.
     register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(
-        spot, params["start_px"], 0.0, 0, None
+        spot, params["start_px"], 1.0, 0, None
     )
     print(register_hyperliquidity_result)
 

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -98,6 +98,12 @@ def step2(address, exchange, token, params):
     # Allocate the entire total_supply to a single user — the deployer address.
     # All tokens are minted here at genesis and end up on the deployer's HC balance;
     # later they can be bridged to HyperEVM as the ERC-20 mirror.
+    #
+    # total_supply is set to 2**64 - 1 (= 18446744073709551615) — the maximum value
+    # HyperCore can represent (balances are stored as uint64). HIP-1 docs explicitly
+    # call this out as the "max flexibility" choice. Bridged tokens mint into this
+    # pool only what is actually transferred in from the EVM/NEAR side, so a large
+    # cap doesn't inflate circulating supply — it just removes an artificial ceiling.
     user_genesis_result = exchange.spot_deploy_user_genesis(
         token,
         [

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -167,33 +167,88 @@ def step5(exchange, spot, params):
     )
     print(register_hyperliquidity_result)
 
+def confirm(prompt):
+    return input(f"\n{prompt} [y/N]: ").strip().lower() == "y"
+
+
+def show_state(info, address):
+    """Print current spotDeployState from HL info endpoint."""
+    state = info.post("/info", {"type": "spotDeployState", "user": address})
+    print("\n=== spotDeployState ===")
+    print(json.dumps(state, indent=2))
+
+
 def main():
     params = load_params()
     address, info, exchange = setup(get_base_url(params["network"]), skip_ws=True)
     print(address, info, exchange)
 
+    last_step = params.get("last_step") or 0
     token = params.get("token_id")
-    if token is not None:
-        print(f"Skipping step1 — using token_id from deploy_params.json: {token}")
+    spot = params.get("spot_id")
+
+    # Step 1 — skip if last_step >= 1 OR token_id already set
+    if last_step >= 1 or token is not None:
+        print(f"\nSkipping step1 — last_step={last_step}, token_id={token}")
     else:
+        show_state(info, address)
+        if not confirm("Run step1 (register token — IRREVERSIBLE, costs HYPE)?"):
+            return
         token = step1(exchange, params)
         print(f"step1 done, registered token index: {token}")
         params["token_id"] = token
+        params["last_step"] = 1
         save_params(params)
 
-    step2(address, exchange, token, params)
-    step3(exchange, token, params)
-
-    spot = params.get("spot_id")
-    if spot is not None:
-        print(f"Skipping step4 — using spot_id from deploy_params.json: {spot}")
+    # Step 2 — also skip if spot_id is set (means step4 already passed)
+    if last_step >= 2 or spot is not None:
+        print(f"\nSkipping step2 — last_step={last_step}, spot_id={spot}")
     else:
+        show_state(info, address)
+        if not confirm("Run step2 (user genesis — can be re-run until step3)?"):
+            return
+        step2(address, exchange, token, params)
+        params["last_step"] = 2
+        save_params(params)
+
+    # Step 3 — also skip if spot_id is set (means step4 already passed)
+    if last_step >= 3 or spot is not None:
+        print(f"\nSkipping step3 — last_step={last_step}, spot_id={spot}")
+    else:
+        show_state(info, address)
+        if not confirm("Run step3 (genesis — IRREVERSIBLE, finalizes max_supply)?"):
+            return
+        step3(exchange, token, params)
+        params["last_step"] = 3
+        save_params(params)
+
+    # Step 4 — skip if last_step >= 4 OR spot_id already set
+    if last_step >= 4 or spot is not None:
+        print(f"\nSkipping step4 — last_step={last_step}, spot_id={spot}")
+    else:
+        show_state(info, address)
+        if not confirm("Run step4 (register <token>/USDC spot pair — IRREVERSIBLE)?"):
+            return
         spot = step4(exchange, token)
         print(f"step4 done, registered spot index: {spot}")
         params["spot_id"] = spot
+        params["last_step"] = 4
         save_params(params)
 
-    step5(exchange, spot, params)
+    # Step 5
+    if last_step >= 5:
+        print(f"\nSkipping step5 — last_step={last_step}")
+    else:
+        show_state(info, address)
+        if not confirm("Run step5 (register hyperliquidity — formal call, n_orders=0)?"):
+            return
+        step5(exchange, spot, params)
+        params["last_step"] = 5
+        save_params(params)
+
+    show_state(info, address)
+    print("\nDeployment complete.")
+
 
 if __name__ == "__main__":
     main()

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -13,7 +13,7 @@ from hyperliquid.utils import constants
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 
-DEPLOY_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "deploy_params_testnet.json")
+DEPLOY_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "deploy_params.json")
 
 
 def load_params():
@@ -185,6 +185,14 @@ def confirm(prompt):
     return input(f"\n{prompt} [y/N]: ").strip().lower() == "y"
 
 
+def describe_call(func_name, args):
+    """Print the function call we're about to make, with all arguments."""
+    print(f"\nAbout to call:\n  {func_name}(")
+    for arg in args:
+        print(f"    {arg!r},")
+    print("  )")
+
+
 def show_state(info, address):
     """Print current spotDeployState from HL info endpoint."""
     state = info.post("/info", {"type": "spotDeployState", "user": address})
@@ -206,6 +214,16 @@ def main():
         print(f"\nSkipping step1 — last_step={last_step}, token_id={token}")
     else:
         show_state(info, address)
+        describe_call(
+            "exchange.spot_deploy_register_token",
+            [
+                params["token_name"],
+                params["sz_decimals"],
+                params["wei_decimals"],
+                params["max_gas"],
+                params["token_description"],
+            ],
+        )
         if not confirm("Run step1 (register token — IRREVERSIBLE, costs HYPE)?"):
             return
         token = step1(exchange, params)
@@ -219,6 +237,11 @@ def main():
         print(f"\nSkipping step2 — last_step={last_step}, spot_id={spot}")
     else:
         show_state(info, address)
+        system_address = system_address_for_token(token)
+        describe_call(
+            "exchange.spot_deploy_user_genesis",
+            [token, [(system_address, params["total_supply"])], []],
+        )
         if not confirm("Run step2 (user genesis — can be re-run until step3)?"):
             return
         step2(exchange, token, params)
@@ -230,6 +253,10 @@ def main():
         print(f"\nSkipping step3 — last_step={last_step}, spot_id={spot}")
     else:
         show_state(info, address)
+        describe_call(
+            "exchange.spot_deploy_genesis",
+            [token, params["total_supply"], True],
+        )
         if not confirm("Run step3 (genesis — IRREVERSIBLE, finalizes max_supply)?"):
             return
         step3(exchange, token, params)
@@ -241,6 +268,7 @@ def main():
         print(f"\nSkipping step4 — last_step={last_step}, spot_id={spot}")
     else:
         show_state(info, address)
+        describe_call("exchange.spot_deploy_register_spot", [token, 0])
         if not confirm("Run step4 (register <token>/USDC spot pair — IRREVERSIBLE)?"):
             return
         spot = step4(exchange, token)
@@ -254,6 +282,10 @@ def main():
         print(f"\nSkipping step5 — last_step={last_step}")
     else:
         show_state(info, address)
+        describe_call(
+            "exchange.spot_deploy_register_hyperliquidity",
+            [spot, 2.0, 0, 0, None],
+        )
         if not confirm("Run step5 (register hyperliquidity — formal call, n_orders=0)?"):
             return
         step5(exchange, spot, params)

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -69,6 +69,16 @@ def get_base_url(network):
     )
 
 
+def system_address_for_token(token_id: int) -> str:
+    """Compute the HyperCore system address for a given token index.
+
+    Format (from HL docs): an EVM address whose first byte is 0x20 and the
+    remaining 19 bytes are the token index in big-endian. So for token index 513
+    the system address is 0x2000000000000000000000000000000000000201.
+    """
+    return "0x" + f"{(0x20 << 152) | token_id:040x}"
+
+
 def step1(exchange, params):
     # Step 1: Registering the Token
     #
@@ -92,22 +102,26 @@ def step1(exchange, params):
         return
     return token
 
-def step2(address, exchange, token, params):
+def step2(exchange, token, params):
     # Step 2: User Genesis
     #
-    # Allocate the entire total_supply to a single user — the deployer address.
-    # All tokens are minted here at genesis and end up on the deployer's HC balance;
-    # later they can be bridged to HyperEVM as the ERC-20 mirror.
+    # Allocate the entire total_supply directly to the token's system address
+    # (the per-token HC address derived as 0x20...<token_id_BE>). HC↔EVM transfers
+    # debit/credit this pool: putting genesis supply there means there is liquidity
+    # for bridge-in operations immediately, with no extra transfer step from the
+    # deployer.
     #
     # total_supply is set to 2**64 - 1 (= 18446744073709551615) — the maximum value
     # HyperCore can represent (balances are stored as uint64). HIP-1 docs explicitly
     # call this out as the "max flexibility" choice. Bridged tokens mint into this
     # pool only what is actually transferred in from the EVM/NEAR side, so a large
     # cap doesn't inflate circulating supply — it just removes an artificial ceiling.
+    system_address = system_address_for_token(token)
+    print(f"step2 will allocate total_supply to system address {system_address}")
     user_genesis_result = exchange.spot_deploy_user_genesis(
         token,
         [
-            (address, params["total_supply"]),
+            (system_address, params["total_supply"]),
         ],
         [],
     )
@@ -207,7 +221,7 @@ def main():
         show_state(info, address)
         if not confirm("Run step2 (user genesis — can be re-run until step3)?"):
             return
-        step2(address, exchange, token, params)
+        step2(exchange, token, params)
         params["last_step"] = 2
         save_params(params)
 

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -177,7 +177,7 @@ def step5(exchange, spot, params):
     #   n_seeded_levels — how many bid levels to pre-fund with USDC instead of the
     #                     base token. None (or 0) means no USDC-funded levels.
     register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(
-        spot, 0, 0, 0, None
+        spot, 2.0, 0, 0, None
     )
     print(register_hyperliquidity_result)
 

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -1,22 +1,21 @@
-import getpass
-import json
 import os
 
 import eth_account
+from dotenv import load_dotenv
 from eth_account.signers.local import LocalAccount
 
 from hyperliquid.exchange import Exchange
 from hyperliquid.info import Info
 from hyperliquid.utils import constants
 
+# Load .env from the same directory as this script (not the cwd).
+load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+
 def setup(base_url=None, skip_ws=False, perp_dexs=None):
-    config_path = os.path.join(os.path.dirname(__file__), "config.json")
-    with open(config_path) as f:
-        config = json.load(f)
-    account: LocalAccount = eth_account.Account.from_key(get_secret_key(config))
-    address = config["account_address"]
-    if address == "":
-        address = account.address
+    secret_key = get_secret_key()
+    account: LocalAccount = eth_account.Account.from_key(secret_key)
+    address = os.environ.get("HL_ACCOUNT_ADDRESS", "") or account.address
     print("Running with account address:", address)
     if address != account.address:
         print("Running with agent address:", account.address)
@@ -27,14 +26,19 @@ def setup(base_url=None, skip_ws=False, perp_dexs=None):
     if float(margin_summary["accountValue"]) == 0 and len(spot_user_state["balances"]) == 0:
         print("Not running the example because the provided account has no equity.")
         url = info.base_url.split(".", 1)[1]
-        error_string = f"No accountValue:\nIf you think this is a mistake, make sure that {address} has a balance on {url}.\nIf address shown is your API wallet address, update the config to specify the address of your account, not the address of the API wallet."
+        error_string = f"No accountValue:\nIf you think this is a mistake, make sure that {address} has a balance on {url}.\nIf address shown is your API wallet address, set HL_ACCOUNT_ADDRESS in .env to the address of your main account (not the API wallet)."
         raise Exception(error_string)
     exchange = Exchange(account, base_url, account_address=address, perp_dexs=perp_dexs)
     return address, info, exchange
 
 
-def get_secret_key(config):
-    return config["secret_key"]
+def get_secret_key():
+    secret_key = os.environ.get("HL_SECRET_KEY")
+    if not secret_key:
+        raise RuntimeError(
+            "HL_SECRET_KEY is not set. Add it to evm/utils/hyperliquid/.env (see .env.example)."
+        )
+    return secret_key
 def step1(exchange):
     # Step 1: Registering the Token
     #

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -13,11 +13,20 @@ from hyperliquid.utils import constants
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 
+DEPLOY_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "deploy_params.json")
+
+
 def load_params():
     """Read non-secret operational parameters from deploy_params.json."""
-    params_path = os.path.join(os.path.dirname(__file__), "deploy_params.json")
-    with open(params_path) as f:
+    with open(DEPLOY_PARAMS_PATH) as f:
         return json.load(f)
+
+
+def save_params(params):
+    """Persist updated parameters back to deploy_params.json (loses blank-line groups)."""
+    with open(DEPLOY_PARAMS_PATH, "w") as f:
+        json.dump(params, f, indent=2)
+        f.write("\n")
 
 
 def setup(base_url=None, skip_ws=False, perp_dexs=None):
@@ -128,16 +137,28 @@ def step4(exchange, token):
 
     return spot
 
-def step5(exchange, spot):
-
+def step5(exchange, spot, params):
     # Step 5: Register Hyperliquidity
     #
-    # Registers hyperliquidity for the spot pair. In this example, hyperliquidity is registered
-    # with a starting price of $2, an order size of 4, and 100 total orders.
+    # This step is mandatory in the deployment pipeline even when noHyperliquidity = True
+    # (which we set in step 3). In that case the call is essentially a formality:
+    # n_orders MUST be 0, and the other order-related args become unused.
     #
-    # This step is required even if "noHyperliquidity" was set to True.
-    # If "noHyperliquidity" was set to True during step 3 (genesis), then "n_orders" is required to be 0.
-    register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(spot, 2.0, 4.0, 0, None)
+    # Arguments to spot_deploy_register_hyperliquidity:
+    #   spot            — the spot index returned by step 4 (NOT the token index!).
+    #   start_px        — anchor price for the Hyperliquidity grid. Each adjacent
+    #                     level is +0.3% above and -0.3% below (geometric step).
+    #                     With noHyperliquidity = True, no orders are placed but
+    #                     this is still recorded as the reference price.
+    #   order_sz        — size of each individual order (in floating-form, not wei).
+    #                     Ignored when n_orders = 0; we pass 0.
+    #   n_orders        — total number of price levels the AMM seeds. MUST be 0
+    #                     because we disabled hyperliquidity at step 3.
+    #   n_seeded_levels — how many bid levels to pre-fund with USDC instead of the
+    #                     base token. None (or 0) means no USDC-funded levels.
+    register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(
+        spot, params["start_px"], 0.0, 0, None
+    )
     print(register_hyperliquidity_result)
 
 def main():
@@ -151,13 +172,22 @@ def main():
     else:
         token = step1(exchange, params)
         print(f"step1 done, registered token index: {token}")
+        params["token_id"] = token
+        save_params(params)
 
     step2(address, exchange, token, params)
     step3(exchange, token, params)
-    spot = step4(exchange, token)
-    # print(spot)
-    # spot = 1436
-    # step5(exchange, spot)
+
+    spot = params.get("spot_id")
+    if spot is not None:
+        print(f"Skipping step4 — using spot_id from deploy_params.json: {spot}")
+    else:
+        spot = step4(exchange, token)
+        print(f"step4 done, registered spot index: {spot}")
+        params["spot_id"] = spot
+        save_params(params)
+
+    step5(exchange, spot, params)
 
 if __name__ == "__main__":
     main()

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -13,7 +13,7 @@ from hyperliquid.utils import constants
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 
 
-DEPLOY_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "deploy_params.json")
+DEPLOY_PARAMS_PATH = os.path.join(os.path.dirname(__file__), "deploy_params_testnet.json")
 
 
 def load_params():
@@ -177,7 +177,7 @@ def step5(exchange, spot, params):
     #   n_seeded_levels — how many bid levels to pre-fund with USDC instead of the
     #                     base token. None (or 0) means no USDC-funded levels.
     register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(
-        spot, params["start_px"], 1.0, 0, None
+        spot, 0, 0, 0, None
     )
     print(register_hyperliquidity_result)
 

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -113,8 +113,10 @@ def step3(exchange, token, params):
 def step4(exchange, token):
     # Step 4: Register Spot
     #
-    # Register the spot pair (TEST0/USDC) given base and quote token indices. 0 represents USDC.
-    # The base token is the first token in the pair and the quote token is the second token.
+    # Register the initial spot pair <token>/USDC. The first arg is the base token
+    # index (our just-deployed HIP-1 token), the second is the quote token index —
+    # at initial deployment this must be 0 (USDC). Any other quote can only be
+    # added later via a separate permissionless Dutch auction.
     register_spot_result = exchange.spot_deploy_register_spot(token, 0)
     print(register_spot_result)
     # If registration is successful, a spot index will be returned. This spot index is required for
@@ -152,7 +154,7 @@ def main():
 
     step2(address, exchange, token, params)
     step3(exchange, token, params)
-    # spot = step4(exchange, token)
+    spot = step4(exchange, token)
     # print(spot)
     # spot = 1436
     # step5(exchange, spot)

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -83,15 +83,16 @@ def step1(exchange, params):
         return
     return token
 
-def step2(address, exchange, token):
+def step2(address, exchange, token, params):
     # Step 2: User Genesis
     #
-    # User genesis can be called multiple times to associate balances to specific users and/or
-    # tokens for genesis.
+    # Allocate the entire total_supply to a single user — the deployer address.
+    # All tokens are minted here at genesis and end up on the deployer's HC balance;
+    # later they can be bridged to HyperEVM as the ERC-20 mirror.
     user_genesis_result = exchange.spot_deploy_user_genesis(
         token,
         [
-            (address, "100000000900000000"),
+            (address, params["total_supply"]),
         ],
         [],
     )
@@ -148,7 +149,7 @@ def main():
         token = step1(exchange, params)
         print(f"step1 done, registered token index: {token}")
 
-    # step2(address, exchange, token)
+    step2(address, exchange, token, params)
     # step3(exchange, token)
     # spot = step4(exchange, token)
     # print(spot)

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -98,15 +98,16 @@ def step2(address, exchange, token, params):
     )
     print(user_genesis_result)
 
-def step3(exchange, token):
+def step3(exchange, token, params):
     # Step 3: Genesis
     #
-    # Finalize genesis. The max supply of 300000000000000 wei needs to match the total
-    # allocation above from user genesis.
+    # Finalize genesis. The max supply must match the total allocation from step 2
+    # (user genesis) — we use the same total_supply value from deploy_params.json.
     #
-    # "noHyperliquidity" can also be set to disable hyperliquidity. In that case, no balance
-    # should be associated with hyperliquidity from step 2 (user genesis).
-    genesis_result = exchange.spot_deploy_genesis(token, "100000000900000000", True)
+    # noHyperliquidity is hardcoded to True: this is a bridged token, all liquidity
+    # comes from the bridge, never from a protocol-level AMM. This also implies that
+    # step 5 (register_hyperliquidity) must use n_orders = 0.
+    genesis_result = exchange.spot_deploy_genesis(token, params["total_supply"], True)
     print(genesis_result)
 
 def step4(exchange, token):
@@ -150,7 +151,7 @@ def main():
         print(f"step1 done, registered token index: {token}")
 
     step2(address, exchange, token, params)
-    # step3(exchange, token)
+    step3(exchange, token, params)
     # spot = step4(exchange, token)
     # print(spot)
     # spot = 1436

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import eth_account
@@ -10,6 +11,13 @@ from hyperliquid.utils import constants
 
 # Load .env from the same directory as this script (not the cwd).
 load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
+
+
+def load_params():
+    """Read non-secret operational parameters from deploy_params.json."""
+    params_path = os.path.join(os.path.dirname(__file__), "deploy_params.json")
+    with open(params_path) as f:
+        return json.load(f)
 
 
 def setup(base_url=None, skip_ws=False, perp_dexs=None):
@@ -41,24 +49,31 @@ def get_secret_key():
     return secret_key
 
 
-def get_base_url():
-    network = os.environ.get("HL_NETWORK", "testnet").lower()
+def get_base_url(network):
+    network = network.lower()
     if network == "mainnet":
         return constants.MAINNET_API_URL
     if network == "testnet":
         return constants.TESTNET_API_URL
     raise RuntimeError(
-        f"Invalid HL_NETWORK={network!r}. Expected 'testnet' or 'mainnet'."
+        f"Invalid network={network!r}. Expected 'testnet' or 'mainnet'."
     )
 
 
-def step1(exchange):
+def step1(exchange, params):
     # Step 1: Registering the Token
     #
-    # Takes part in the spot deploy auction and if successful, registers token "TEST0"
-    # with sz_decimals 2 and wei_decimals 8.
-    # The max gas is 10,000 HYPE and represents the max amount to be paid for the spot deploy auction.
-    register_token_result = exchange.spot_deploy_register_token("TEST0", 2, 8, 1000000000000, "Test token example")
+    # Takes part in the spot deploy auction and if successful, registers a HIP-1 token
+    # with the (name, sz_decimals, wei_decimals, description) defined in deploy_params.json.
+    # The max_gas argument is the maximum amount willing to be paid for the spot deploy
+    # auction, denominated in HYPE wei (1 HYPE = 10^8 wei).
+    register_token_result = exchange.spot_deploy_register_token(
+        params["token_name"],
+        params["sz_decimals"],
+        params["wei_decimals"],
+        params["max_gas"],
+        params["token_description"],
+    )
     print(register_token_result)
     # If registration is successful, a token index will be returned. This token index is required for
     # later steps in the spot deploy process.
@@ -122,11 +137,17 @@ def step5(exchange, spot):
     print(register_hyperliquidity_result)
 
 def main():
-    address, info, exchange = setup(get_base_url(), skip_ws=True)
+    params = load_params()
+    address, info, exchange = setup(get_base_url(params["network"]), skip_ws=True)
     print(address, info, exchange)
 
-    # token = step1()
-    # token = 1562
+    token = params.get("token_id")
+    if token is not None:
+        print(f"Skipping step1 — using token_id from deploy_params.json: {token}")
+    else:
+        token = step1(exchange, params)
+        print(f"step1 done, registered token index: {token}")
+
     # step2(address, exchange, token)
     # step3(exchange, token)
     # spot = step4(exchange, token)

--- a/evm/utils/hyperliquid/spot_deploy.py
+++ b/evm/utils/hyperliquid/spot_deploy.py
@@ -1,0 +1,121 @@
+import getpass
+import json
+import os
+
+import eth_account
+from eth_account.signers.local import LocalAccount
+
+from hyperliquid.exchange import Exchange
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+def setup(base_url=None, skip_ws=False, perp_dexs=None):
+    config_path = os.path.join(os.path.dirname(__file__), "config.json")
+    with open(config_path) as f:
+        config = json.load(f)
+    account: LocalAccount = eth_account.Account.from_key(get_secret_key(config))
+    address = config["account_address"]
+    if address == "":
+        address = account.address
+    print("Running with account address:", address)
+    if address != account.address:
+        print("Running with agent address:", account.address)
+    info = Info(base_url, skip_ws, perp_dexs=perp_dexs)
+    user_state = info.user_state(address)
+    spot_user_state = info.spot_user_state(address)
+    margin_summary = user_state["marginSummary"]
+    if float(margin_summary["accountValue"]) == 0 and len(spot_user_state["balances"]) == 0:
+        print("Not running the example because the provided account has no equity.")
+        url = info.base_url.split(".", 1)[1]
+        error_string = f"No accountValue:\nIf you think this is a mistake, make sure that {address} has a balance on {url}.\nIf address shown is your API wallet address, update the config to specify the address of your account, not the address of the API wallet."
+        raise Exception(error_string)
+    exchange = Exchange(account, base_url, account_address=address, perp_dexs=perp_dexs)
+    return address, info, exchange
+
+
+def get_secret_key(config):
+    return config["secret_key"]
+def step1(exchange):
+    # Step 1: Registering the Token
+    #
+    # Takes part in the spot deploy auction and if successful, registers token "TEST0"
+    # with sz_decimals 2 and wei_decimals 8.
+    # The max gas is 10,000 HYPE and represents the max amount to be paid for the spot deploy auction.
+    register_token_result = exchange.spot_deploy_register_token("TEST0", 2, 8, 1000000000000, "Test token example")
+    print(register_token_result)
+    # If registration is successful, a token index will be returned. This token index is required for
+    # later steps in the spot deploy process.
+    if register_token_result["status"] == "ok":
+        token = register_token_result["response"]["data"]
+    else:
+        return
+    return token
+
+def step2(address, exchange, token):
+    # Step 2: User Genesis
+    #
+    # User genesis can be called multiple times to associate balances to specific users and/or
+    # tokens for genesis.
+    user_genesis_result = exchange.spot_deploy_user_genesis(
+        token,
+        [
+            (address, "100000000900000000"),
+        ],
+        [],
+    )
+    print(user_genesis_result)
+
+def step3(exchange, token):
+    # Step 3: Genesis
+    #
+    # Finalize genesis. The max supply of 300000000000000 wei needs to match the total
+    # allocation above from user genesis.
+    #
+    # "noHyperliquidity" can also be set to disable hyperliquidity. In that case, no balance
+    # should be associated with hyperliquidity from step 2 (user genesis).
+    genesis_result = exchange.spot_deploy_genesis(token, "100000000900000000", True)
+    print(genesis_result)
+
+def step4(exchange, token):
+    # Step 4: Register Spot
+    #
+    # Register the spot pair (TEST0/USDC) given base and quote token indices. 0 represents USDC.
+    # The base token is the first token in the pair and the quote token is the second token.
+    register_spot_result = exchange.spot_deploy_register_spot(token, 0)
+    print(register_spot_result)
+    # If registration is successful, a spot index will be returned. This spot index is required for
+    # registering hyperliquidity.
+    if register_spot_result["status"] == "ok":
+        spot = register_spot_result["response"]["data"]
+    else:
+        return
+
+    return spot
+
+def step5(exchange, spot):
+
+    # Step 5: Register Hyperliquidity
+    #
+    # Registers hyperliquidity for the spot pair. In this example, hyperliquidity is registered
+    # with a starting price of $2, an order size of 4, and 100 total orders.
+    #
+    # This step is required even if "noHyperliquidity" was set to True.
+    # If "noHyperliquidity" was set to True during step 3 (genesis), then "n_orders" is required to be 0.
+    register_hyperliquidity_result = exchange.spot_deploy_register_hyperliquidity(spot, 2.0, 4.0, 0, None)
+    print(register_hyperliquidity_result)
+
+def main():
+    address, info, exchange = setup(constants.TESTNET_API_URL, skip_ws=True)
+    print(address, info, exchange)
+
+    # token = step1()
+    # token = 1562
+    # step2(address, exchange, token)
+    # step3(exchange, token)
+    # spot = step4(exchange, token)
+    # print(spot)
+    # spot = 1436
+    # step5(exchange, spot)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Python helpers under `evm/utils/hyperliquid/`:

- **`spot_deploy.py`** — interactive walkthrough of the 5-step HIP-1 token deploy on HyperCore, with `spotDeployState` inspection between steps, `[y/N]` confirmation gates, and resume support via `deploy_params.json` (`last_step` / `token_id` / `spot_id` are persisted after each successful step).
- **`links_tokens.py`** — links an HC token to an existing HyperEVM ERC-20 via `requestEvmContract` + `finalizeEvmContract` in `firstStorageSlot` mode, with a confirmation gate before the irreversible finalize.

Secrets (`HL_SECRET_KEY`, `HL_ACCOUNT_ADDRESS`) live in `.env` (gitignored, `.env.example` provided). Operational params (network, token IDs, decimals, supply, EVM contract address, etc.) live in `deploy_params.json` and `link_tokens_params.json` (committed, no secrets). Setup and step-by-step usage documented in `README.md`.