### PR TITLE
fix: cargo build for mpc-types

### DIFF
--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -2672,6 +2672,7 @@ dependencies = [
  "rlp",
  "schemars 0.8.22",
  "serde",
+ "serde_with",
  "sha2",
  "sha3",
  "strum 0.27.2",

--- a/near/omni-types/Cargo.toml
+++ b/near/omni-types/Cargo.toml
@@ -26,3 +26,9 @@ near-mpc-sdk = { workspace = true, features = ["abi"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sha3.workspace = true
 sha2.workspace = true
+# Work around upstream bug in near-mpc-crypto-types 0.0.1: its `abi` feature
+# derives `JsonSchema` on types with `#[serde_as(as = "Hex")]` fields, but its
+# `serde_with` dep is declared without the `schemars_0_8` feature. Enabling it
+# here (only off-wasm, where schemars is actually available) makes
+# `As<Hex>: JsonSchema` resolve via cargo feature unification.
+serde_with = { version = "3", features = ["schemars_0_8"] }


### PR DESCRIPTION
This pull request addresses a compatibility issue with the `near-mpc-crypto-types` crate by adding a workaround dependency in the `Cargo.toml` file. The change ensures that the `JsonSchema` trait can be derived for types using `serde_with::As<Hex>` by enabling the required feature on the `serde_with` crate, but only for non-WASM targets.

Dependency compatibility fix:

* Added `serde_with` as a dependency with the `schemars_0_8` feature enabled for non-WASM targets in `near/omni-types/Cargo.toml` to work around an upstream bug in `near-mpc-crypto-types` that affects `JsonSchema` derivation for hex-encoded fields.