### PR TITLE
feat(aptos): add wormhole support

### DIFF
--- a/aptos/CLAUDE.md
+++ b/aptos/CLAUDE.md
@@ -34,9 +34,13 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
   (`bytes[i]`), `for (i in 0..n)` range loops, `package fun` for
   cross-module-restricted entry points, and resource-index expressions
   (`&BridgeState[addr]`).
-- **Optional Wormhole publish**: `Admin` may call `enable_wormhole` once
-  to register the bridge as a Wormhole emitter (at the deployed Wormhole
-  core at `@wormhole = 0x5bc1…`). When enabled, every `init_transfer`,
+- **Optional Wormhole publish**: the bridge registers as a Wormhole
+  emitter inside `initialize` (`wormhole::register_emitter` against the
+  deployed Wormhole core at `@wormhole = 0x5bc1…`) and stores the
+  resulting `EmitterCapability` in `BridgeState`. `Admin` then flips
+  publishing on/off via `set_wormhole_enabled(enable: bool)` — a pure
+  flag flip, the same emitter id is reused across cycles so off-chain
+  consumers see a stable identity. When enabled, every `init_transfer`,
   `fin_transfer`, `deploy_token`, and `log_metadata` also publishes a
   Wormhole VAA whose payload mirrors the EVM `OmniBridgeWormhole.sol`
   byte layout. The caller of each entry pays the Wormhole `message_fee`
@@ -69,7 +73,7 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
 | `set_near_bridge_derived_address` | Rotate the NEAR MPC signer address | `Admin` |
 | `grant_role` | Add an address to a role | `Admin` |
 | `revoke_role` | Remove an address from a role (refuses last Admin) | `Admin` |
-| `enable_wormhole` | Register as Wormhole emitter (one-shot) | `Admin` |
+| `set_wormhole_enabled` | Turn Wormhole publishing on/off (pure flag flip; emitter registered at `initialize`) | `Admin` |
 | `bridge_object_address` | Deterministic address of `BridgeState` / locked-token custody | View |
 | `get_token_address` | NEAR token id → deployed FA metadata object address | View |
 | `role_holders` | All addresses currently holding a role | View |
@@ -127,22 +131,30 @@ side. In particular:
    `(name, id)` registry for off-chain discovery.
 7. **Last-admin guard**: `revoke_role(Admin, last_admin)` aborts with
    `E_CANNOT_REMOVE_LAST_ADMIN`. Prevents bricking via accidental rotation.
-8. **Wormhole opt-in + stub package**: `enable_wormhole` is a one-shot
-   `Admin` switch. Once flipped, the bridge stores an `EmitterCapability`
-   from `wormhole::wormhole::register_emitter()` in `BridgeState`, and
-   every public bridge action also calls `publish_message` with a payload
-   that mirrors the corresponding `OmniBridgeWormhole.sol` extension byte
-   layout (`init_transfer_wormhole_payload`, `fin_transfer_wormhole_payload`,
-   `deploy_token_wormhole_payload`, `log_metadata_wormhole_payload` in
-   `bridge_types`). The Wormhole nonce is always `0` — the bridge's own
-   `origin_nonce` is the replay-prevention identifier and is carried in
-   the payload. The Wormhole Move package is vendored as a compile-time
-   **stub** at `vendor/wormhole/` (modules `wormhole::wormhole`,
-   `wormhole::emitter`, `wormhole::state`). The stub mirrors the deployed
-   Wormhole's public ABI so the bridge can compile against the modern
-   Aptos framework; the stub modules are NOT republished by
-   `aptos move publish` (only `aptos/sources/` modules go on chain), and
-   at runtime calls dispatch by `(address, name)` to the real Wormhole at
+8. **Wormhole emitter + stub package**: `initialize` calls
+   `wormhole::wormhole::register_emitter()` unconditionally and stores
+   the resulting `EmitterCapability` in `BridgeState`. There's only ever
+   one bridge instance, the cap has no `drop` ability (matching the
+   deployed Wormhole's ABI), and registration is cheap — so we pay the
+   one-time cost up front instead of conditionally on first enable. As a
+   consequence, `initialize` has a hard dependency on Wormhole being
+   deployed at `@wormhole`; on chains without a Wormhole deployment the
+   bridge cannot be initialized. `set_wormhole_enabled(admin, bool)`
+   then toggles publishing on/off as a pure flag flip. When enabled,
+   every public bridge action also calls `publish_message` with a
+   payload that mirrors the corresponding `OmniBridgeWormhole.sol`
+   extension byte layout (`init_transfer_wormhole_payload`,
+   `fin_transfer_wormhole_payload`, `deploy_token_wormhole_payload`,
+   `log_metadata_wormhole_payload` in `bridge_types`). The Wormhole
+   nonce is always `0` — the bridge's own `origin_nonce` is the
+   replay-prevention identifier and is carried in the payload. The
+   Wormhole Move package is vendored as a compile-time **stub** at
+   `vendor/wormhole/` (modules `wormhole::wormhole`, `wormhole::emitter`,
+   `wormhole::state`). The stub mirrors the deployed Wormhole's public
+   ABI so the bridge can compile against the modern Aptos framework; the
+   stub modules are NOT republished by `aptos move publish` (only
+   `aptos/sources/` modules go on chain), and at runtime calls dispatch
+   by `(address, name)` to the real Wormhole at
    `@wormhole = 0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625`.
    Never change struct field layouts or function signatures in the stub
    without confirming the deployed Wormhole's ABI hasn't drifted.
@@ -206,8 +218,9 @@ Coverage:
 - **Wormhole payload layouts** (5 tests): tag byte, chain-id offsets, and
   total length for each of `init_transfer`, `fin_transfer` (with and
   without fee_recipient), `deploy_token`, `log_metadata`
-- **`enable_wormhole` gating** (3 tests): admin can enable; second enable
-  aborts; non-admin rejected
+- **`set_wormhole_enabled` gating** (3 tests): admin can round-trip
+  off/on/off/on; setting the flag to its current value is a no-op;
+  non-admin rejected
 
 ## File References
 - Main contract: [sources/omni_bridge.move](sources/omni_bridge.move)

--- a/aptos/CLAUDE.md
+++ b/aptos/CLAUDE.md
@@ -34,14 +34,23 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
   (`bytes[i]`), `for (i in 0..n)` range loops, `package fun` for
   cross-module-restricted entry points, and resource-index expressions
   (`&BridgeState[addr]`).
+- **Optional Wormhole publish**: `Admin` may call `enable_wormhole` once
+  to register the bridge as a Wormhole emitter (at the deployed Wormhole
+  core at `@wormhole = 0x5bc1…`). When enabled, every `init_transfer`,
+  `fin_transfer`, `deploy_token`, and `log_metadata` also publishes a
+  Wormhole VAA whose payload mirrors the EVM `OmniBridgeWormhole.sol`
+  byte layout. The caller of each entry pays the Wormhole `message_fee`
+  in `Coin<AptosCoin>` from their own balance. The Wormhole modules are
+  vendored as a compile-time stub at `vendor/wormhole/` — see that
+  package's `Move.toml` for the rationale.
 
 ## Module Layout
 
 | Module | Purpose |
 |--------|---------|
-| `omni_bridge::omni_bridge` | Main contract: init, deploy_token, init_transfer, fin_transfer, log_metadata, role management, pause, metadata mutation, events, views |
+| `omni_bridge::omni_bridge` | Main contract: init, deploy_token, init_transfer, fin_transfer, log_metadata, role management, pause, metadata mutation, optional Wormhole publish, events, views |
 | `omni_bridge::bridge_token` | Fungible Asset wrapper exposing `create`/`mint`/`burn`/`mutate_metadata` as `package fun` (package-internal only). Holds the per-token capability bundle on the FA object's address |
-| `omni_bridge::bridge_types` | Payload structs (`MetadataPayload`, `TransferMessagePayload`) and their Borsh encoders. Events live in `omni_bridge` because Aptos requires `#[event]` and emit-site in the same module |
+| `omni_bridge::bridge_types` | Payload structs (`MetadataPayload`, `TransferMessagePayload`) and their Borsh encoders, plus the four Wormhole `*_wormhole_payload` encoders mirroring `OmniBridgeWormhole.sol`. Events live in `omni_bridge` because Aptos requires `#[event]` and emit-site in the same module |
 | `omni_bridge::borsh` | Borsh sequence encoders (`encode_string`, `encode_byte_vec`). Fixed-width integers and addresses delegate to `std::bcs::to_bytes` directly at call sites (BCS == Borsh for those types) |
 | `omni_bridge::utils` | `verify_eth_signature` (secp256k1 + keccak256), `normalize_decimals` |
 
@@ -60,6 +69,7 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
 | `set_near_bridge_derived_address` | Rotate the NEAR MPC signer address | `Admin` |
 | `grant_role` | Add an address to a role | `Admin` |
 | `revoke_role` | Remove an address from a role (refuses last Admin) | `Admin` |
+| `enable_wormhole` | Register as Wormhole emitter (one-shot) | `Admin` |
 | `bridge_object_address` | Deterministic address of `BridgeState` / locked-token custody | View |
 | `get_token_address` | NEAR token id → deployed FA metadata object address | View |
 | `role_holders` | All addresses currently holding a role | View |
@@ -117,6 +127,25 @@ side. In particular:
    `(name, id)` registry for off-chain discovery.
 7. **Last-admin guard**: `revoke_role(Admin, last_admin)` aborts with
    `E_CANNOT_REMOVE_LAST_ADMIN`. Prevents bricking via accidental rotation.
+8. **Wormhole opt-in + stub package**: `enable_wormhole` is a one-shot
+   `Admin` switch. Once flipped, the bridge stores an `EmitterCapability`
+   from `wormhole::wormhole::register_emitter()` in `BridgeState`, and
+   every public bridge action also calls `publish_message` with a payload
+   that mirrors the corresponding `OmniBridgeWormhole.sol` extension byte
+   layout (`init_transfer_wormhole_payload`, `fin_transfer_wormhole_payload`,
+   `deploy_token_wormhole_payload`, `log_metadata_wormhole_payload` in
+   `bridge_types`). The Wormhole nonce is always `0` — the bridge's own
+   `origin_nonce` is the replay-prevention identifier and is carried in
+   the payload. The Wormhole Move package is vendored as a compile-time
+   **stub** at `vendor/wormhole/` (modules `wormhole::wormhole`,
+   `wormhole::emitter`, `wormhole::state`). The stub mirrors the deployed
+   Wormhole's public ABI so the bridge can compile against the modern
+   Aptos framework; the stub modules are NOT republished by
+   `aptos move publish` (only `aptos/sources/` modules go on chain), and
+   at runtime calls dispatch by `(address, name)` to the real Wormhole at
+   `@wormhole = 0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625`.
+   Never change struct field layouts or function signatures in the stub
+   without confirming the deployed Wormhole's ABI hasn't drifted.
 
 ### Security Invariants
 - **No replay**: `destination_nonce` is checked against `completed_transfers`
@@ -174,6 +203,11 @@ Coverage:
 - **`init_transfer`** (7 tests): bridged-token burn, non-bridge-token lock,
   origin nonce increment, paused, zero amount, fee≥amount, amount>u64::MAX
 - Decimal normalization cap
+- **Wormhole payload layouts** (5 tests): tag byte, chain-id offsets, and
+  total length for each of `init_transfer`, `fin_transfer` (with and
+  without fee_recipient), `deploy_token`, `log_metadata`
+- **`enable_wormhole` gating** (3 tests): admin can enable; second enable
+  aborts; non-admin rejected
 
 ## File References
 - Main contract: [sources/omni_bridge.move](sources/omni_bridge.move)

--- a/aptos/Move.toml
+++ b/aptos/Move.toml
@@ -20,3 +20,11 @@ rev = "mainnet"
 git = "https://github.com/aptos-labs/aptos-core.git"
 subdir = "aptos-move/framework/move-stdlib"
 rev = "mainnet"
+
+# Compile-time-only stub for Wormhole. See `vendor/wormhole/Move.toml`
+# for the full rationale — the stub mirrors the deployed Wormhole's
+# public ABI at `@wormhole = 0x5bc1…` so we can compile against modern
+# framework features while still dispatching to the real Wormhole at
+# runtime. The stub modules are NOT republished by `aptos move publish`.
+[dependencies.Wormhole]
+local = "vendor/wormhole"

--- a/aptos/sources/bridge_types.move
+++ b/aptos/sources/bridge_types.move
@@ -19,6 +19,15 @@ module omni_bridge::bridge_types {
     const PAYLOAD_TYPE_TRANSFER_MESSAGE: u8 = 0;
     const PAYLOAD_TYPE_METADATA: u8 = 1;
 
+    // Wormhole `MessageType` discriminants. Numeric values are on-wire ABI —
+    // they match the enum in `OmniBridgeWormhole.sol` byte-for-byte so that
+    // Wormhole consumers can dispatch identically regardless of which chain
+    // emitted the VAA.
+    const WH_MSG_INIT_TRANSFER: u8 = 0;
+    const WH_MSG_FIN_TRANSFER: u8 = 1;
+    const WH_MSG_DEPLOY_TOKEN: u8 = 2;
+    const WH_MSG_LOG_METADATA: u8 = 3;
+
     /// `deploy_token` payload signed by the NEAR MPC.
     struct MetadataPayload has copy, drop, store {
         /// Source-chain token id (e.g. NEAR account id of the underlying token).
@@ -146,6 +155,112 @@ module omni_bridge::bridge_types {
             buf.append(borsh::encode_byte_vec(&msg));
         };
 
+        buf
+    }
+
+    // -------- Wormhole payload encoders --------
+    //
+    // Byte layout mirrors the corresponding `*Extension` functions in
+    // `evm/src/omni-bridge/contracts/OmniBridgeWormhole.sol`. The encoding
+    // is plain Borsh — same primitives as the NEAR-MPC payloads above —
+    // except `MessageType` tags are taken from the `WH_MSG_*` constants
+    // (NOT the `PAYLOAD_TYPE_*` constants, which key a different enum).
+    //
+    // Optional string fields are encoded as the empty string when absent
+    // (rather than with a Borsh `Option` tag) to match the EVM layout,
+    // which has no Optional concept and represents "no value" with `""`.
+
+    /// Wormhole payload for an outbound transfer. Mirrors
+    /// `initTransferExtension` in OmniBridgeWormhole.sol.
+    public fun init_transfer_wormhole_payload(
+        chain_id: u8,
+        sender: address,
+        token_address: address,
+        origin_nonce: u64,
+        amount: u128,
+        fee: u128,
+        native_fee: u128,
+        recipient: &String,
+        message: &vector<u8>
+    ): vector<u8> {
+        let buf = vector[];
+        buf.push_back(WH_MSG_INIT_TRANSFER);
+        buf.push_back(chain_id);
+        buf.append(bcs::to_bytes(&sender));
+        buf.push_back(chain_id);
+        buf.append(bcs::to_bytes(&token_address));
+        buf.append(bcs::to_bytes(&origin_nonce));
+        buf.append(bcs::to_bytes(&amount));
+        buf.append(bcs::to_bytes(&fee));
+        buf.append(bcs::to_bytes(&native_fee));
+        buf.append(borsh::encode_string(recipient));
+        buf.append(borsh::encode_byte_vec(message));
+        buf
+    }
+
+    /// Wormhole payload for finalizing an inbound transfer. Mirrors
+    /// `finTransferExtension` in OmniBridgeWormhole.sol. `fee_recipient`
+    /// `None` is encoded as the empty string to match EVM's non-Optional
+    /// `string`.
+    public fun fin_transfer_wormhole_payload(
+        chain_id: u8,
+        origin_chain: u8,
+        origin_nonce: u64,
+        token_address: address,
+        amount: u128,
+        fee_recipient: &Option<String>
+    ): vector<u8> {
+        let buf = vector[];
+        buf.push_back(WH_MSG_FIN_TRANSFER);
+        buf.push_back(origin_chain);
+        buf.append(bcs::to_bytes(&origin_nonce));
+        buf.push_back(chain_id);
+        buf.append(bcs::to_bytes(&token_address));
+        buf.append(bcs::to_bytes(&amount));
+        if (fee_recipient.is_some()) {
+            buf.append(borsh::encode_string(fee_recipient.borrow()));
+        } else {
+            // 4-byte LE length prefix of zero, no body.
+            buf.append(x"00000000");
+        };
+        buf
+    }
+
+    /// Wormhole payload for a token deploy. Mirrors `deployTokenExtension`
+    /// in OmniBridgeWormhole.sol.
+    public fun deploy_token_wormhole_payload(
+        chain_id: u8,
+        token: &String,
+        token_address: address,
+        decimals: u8,
+        origin_decimals: u8
+    ): vector<u8> {
+        let buf = vector[];
+        buf.push_back(WH_MSG_DEPLOY_TOKEN);
+        buf.append(borsh::encode_string(token));
+        buf.push_back(chain_id);
+        buf.append(bcs::to_bytes(&token_address));
+        buf.push_back(decimals);
+        buf.push_back(origin_decimals);
+        buf
+    }
+
+    /// Wormhole payload for a `log_metadata` event. Mirrors
+    /// `logMetadataExtension` in OmniBridgeWormhole.sol.
+    public fun log_metadata_wormhole_payload(
+        chain_id: u8,
+        token_address: address,
+        name: &String,
+        symbol: &String,
+        decimals: u8
+    ): vector<u8> {
+        let buf = vector[];
+        buf.push_back(WH_MSG_LOG_METADATA);
+        buf.push_back(chain_id);
+        buf.append(bcs::to_bytes(&token_address));
+        buf.append(borsh::encode_string(name));
+        buf.append(borsh::encode_string(symbol));
+        buf.push_back(decimals);
         buf
     }
 }

--- a/aptos/sources/omni_bridge.move
+++ b/aptos/sources/omni_bridge.move
@@ -374,23 +374,29 @@ module omni_bridge::omni_bridge {
     /// `deploy_token` payload for the mirror token on its side. `caller`
     /// pays the Wormhole message fee if Wormhole is enabled; the signer is
     /// otherwise not read on-chain.
-    public entry fun log_metadata(caller: &signer, token: Object<Metadata>) {
+    public entry fun log_metadata(
+        caller: &signer, token: Object<Metadata>
+    ) {
         let state = &mut BridgeState[bridge_object_address()];
         let token_address = token.object_address();
         let name = fungible_asset::name(token);
         let symbol = fungible_asset::symbol(token);
         let decimals = fungible_asset::decimals(token);
-        event::emit(LogMetadata { token_address, name, symbol, decimals });
+        event::emit(
+            LogMetadata { token_address, name, symbol, decimals }
+        );
 
-        let payload =
-            bridge_types::log_metadata_wormhole_payload(
-                state.chain_id,
-                token_address,
-                &name,
-                &symbol,
-                decimals
-            );
-        publish_wormhole_if_enabled(state, caller, payload);
+        if (is_wormhole_enabled(state)) {
+            let payload =
+                bridge_types::log_metadata_wormhole_payload(
+                    state.chain_id,
+                    token_address,
+                    &name,
+                    &symbol,
+                    decimals
+                );
+            publish_wormhole(state, caller, payload);
+        };
     }
 
     // -------- Bridge operations --------
@@ -455,15 +461,17 @@ module omni_bridge::omni_bridge {
             }
         );
 
-        let wh_payload =
-            bridge_types::deploy_token_wormhole_payload(
-                state.chain_id,
-                &payload.metadata_token(),
-                token_addr,
-                normalized_decimals,
-                payload.metadata_decimals()
-            );
-        publish_wormhole_if_enabled(state, caller, wh_payload);
+        if (is_wormhole_enabled(state)) {
+            let wh_payload =
+                bridge_types::deploy_token_wormhole_payload(
+                    state.chain_id,
+                    &payload.metadata_token(),
+                    token_addr,
+                    normalized_decimals,
+                    payload.metadata_decimals()
+                );
+            publish_wormhole(state, caller, wh_payload);
+        };
     }
 
     /// Finalize an inbound transfer from another chain. Permissionless —
@@ -539,17 +547,19 @@ module omni_bridge::omni_bridge {
             }
         );
 
-        let fr = payload.transfer_fee_recipient();
-        let wh_payload =
-            bridge_types::fin_transfer_wormhole_payload(
-                state.chain_id,
-                origin_chain,
-                origin_nonce,
-                token_address,
-                amount,
-                &fr
-            );
-        publish_wormhole_if_enabled(state, caller, wh_payload);
+        if (is_wormhole_enabled(state)) {
+            let fr = payload.transfer_fee_recipient();
+            let wh_payload =
+                bridge_types::fin_transfer_wormhole_payload(
+                    state.chain_id,
+                    origin_chain,
+                    origin_nonce,
+                    token_address,
+                    amount,
+                    &fr
+                );
+            publish_wormhole(state, caller, wh_payload);
+        };
     }
 
     /// Start an outbound transfer from Aptos to another chain.
@@ -614,19 +624,21 @@ module omni_bridge::omni_bridge {
             }
         );
 
-        let wh_payload =
-            bridge_types::init_transfer_wormhole_payload(
-                state.chain_id,
-                sender_addr,
-                token_address,
-                origin_nonce,
-                amount,
-                fee,
-                native_fee,
-                &recipient,
-                &message
-            );
-        publish_wormhole_if_enabled(state, sender, wh_payload);
+        if (is_wormhole_enabled(state)) {
+            let wh_payload =
+                bridge_types::init_transfer_wormhole_payload(
+                    state.chain_id,
+                    sender_addr,
+                    token_address,
+                    origin_nonce,
+                    amount,
+                    fee,
+                    native_fee,
+                    &recipient,
+                    &message
+                );
+            publish_wormhole(state, sender, wh_payload);
+        };
     }
 
     // -------- Views --------
@@ -820,19 +832,26 @@ module omni_bridge::omni_bridge {
         );
     }
 
-    /// Publish `payload` as a Wormhole VAA iff the bridge has been
-    /// registered as a Wormhole emitter via `enable_wormhole`. No-op
-    /// otherwise. The Wormhole nonce is `0` for every message — the
-    /// bridge's own `current_origin_nonce` (carried inside the payload)
-    /// is the replay-prevention identifier. `payer` funds the Wormhole
-    /// message fee from `Coin<AptosCoin>`. With the current Wormhole
-    /// `message_fee` at 0 the withdrawal is a no-op, but we still wire
-    /// the path through so a future fee increase doesn't require a
-    /// contract upgrade.
-    fun publish_wormhole_if_enabled(
+    /// True iff `enable_wormhole` has been called. Each entry point uses
+    /// this to short-circuit Wormhole payload construction when the
+    /// integration is off, avoiding a several-hundred-byte allocation
+    /// + memcopy per transfer in the common (Wormhole-disabled) case.
+    inline fun is_wormhole_enabled(state: &BridgeState): bool {
+        state.wormhole_emitter.is_some()
+    }
+
+    /// Publish `payload` as a Wormhole VAA. Caller must have already
+    /// confirmed `is_wormhole_enabled(state)` — borrowing the emitter
+    /// here when it's `None` would abort. The Wormhole nonce is `0` for
+    /// every message; the bridge's own `current_origin_nonce` (carried
+    /// inside the payload) is the replay-prevention identifier. `payer`
+    /// funds the Wormhole message fee from `Coin<AptosCoin>`. With the
+    /// current Wormhole `message_fee` at 0 the withdrawal is a no-op,
+    /// but we still wire the path through so a future fee increase
+    /// doesn't require a contract upgrade.
+    fun publish_wormhole(
         state: &mut BridgeState, payer: &signer, payload: vector<u8>
     ) {
-        if (state.wormhole_emitter.is_none()) { return };
         let fee = wormhole_state::get_message_fee();
         let fee_coin = coin::withdraw<AptosCoin>(payer, fee);
         wormhole::publish_message(

--- a/aptos/sources/omni_bridge.move
+++ b/aptos/sources/omni_bridge.move
@@ -60,11 +60,6 @@ module omni_bridge::omni_bridge {
     /// brick the bridge (no one could grant/revoke roles again).
     const E_CANNOT_REMOVE_LAST_ADMIN: u64 = 12;
 
-    // Wormhole
-    /// `enable_wormhole` was called when the bridge already holds an
-    /// `EmitterCapability`. Re-registering would leak the prior cap.
-    const E_WORMHOLE_ALREADY_ENABLED: u64 = 13;
-
     /// Largest amount that fits in `u64`, used to bound `u128` payload
     /// amounts before they're handed to the Aptos Fungible Asset APIs.
     const MAX_U64_AS_U128: u128 = 0xFFFFFFFFFFFFFFFF;
@@ -126,14 +121,16 @@ module omni_bridge::omni_bridge {
         ///   - creating new FA objects in `deploy_token`
         ///   - moving locked tokens out in `fin_transfer` (non-bridge tokens)
         extend_ref: ExtendRef,
-        /// Wormhole emitter capability. `None` until `ROLE_ADMIN` calls
-        /// `enable_wormhole`. When `Some`, every public bridge action
-        /// (`init_transfer`, `fin_transfer`, `deploy_token`, `log_metadata`)
-        /// also publishes a Wormhole VAA whose payload mirrors the EVM
-        /// `OmniBridgeWormhole.sol` byte layout. The caller of each entry
-        /// pays the Wormhole message fee in `Coin<AptosCoin>` from their
-        /// own balance.
-        wormhole_emitter: Option<EmitterCapability>
+        /// Wormhole emitter capability. Registered in `initialize` by
+        /// calling `wormhole::register_emitter()` and held for the
+        /// lifetime of the bridge. `EmitterCapability` has no `drop`
+        /// ability (matching the deployed Wormhole's ABI), and there's
+        /// only ever one bridge instance — so a single up-front
+        /// registration gives off-chain consumers a stable emitter id
+        /// across enable/disable cycles.
+        wormhole_emitter: EmitterCapability,
+        /// Master switch for Wormhole publishing.
+        wormhole_enabled: bool
     }
 
     // -------- Events --------
@@ -246,7 +243,8 @@ module omni_bridge::omni_bridge {
                 native_token_metadata,
                 near_to_aptos_token: table::new<String, address>(),
                 extend_ref,
-                wormhole_emitter: option::none()
+                wormhole_emitter: wormhole::register_emitter(),
+                wormhole_enabled: false
             }
         );
     }
@@ -319,18 +317,17 @@ module omni_bridge::omni_bridge {
         );
     }
 
-    /// Register the bridge as a Wormhole emitter. Once enabled, every
-    /// successful `init_transfer`, `fin_transfer`, `deploy_token`, and
-    /// `log_metadata` also publishes a Wormhole VAA whose payload mirrors
-    /// the corresponding `OmniBridgeWormhole.sol` extension. Callable once;
-    /// re-enabling aborts to avoid leaking the prior emitter cap. The
-    /// caller of each subsequent bridge action pays the Wormhole message
-    /// fee in `Coin<AptosCoin>` from their own balance.
-    public entry fun enable_wormhole(admin: &signer) {
+    /// Turn Wormhole publishing on or off. When on, every successful
+    /// `init_transfer`, `fin_transfer`, `deploy_token`, and `log_metadata`
+    /// also publishes a Wormhole VAA whose payload mirrors the
+    /// `OmniBridgeWormhole.sol` extension. When off, the bridge runs as
+    /// if Wormhole had never been wired up. The caller of each bridge
+    /// action pays the Wormhole message fee in `Coin<AptosCoin>` from
+    /// their own balance.
+    public entry fun set_wormhole_enabled(admin: &signer, enable: bool) {
         let state = &mut BridgeState[bridge_object_address()];
         assert_role(state, ROLE_ADMIN, admin, E_UNAUTHORIZED);
-        assert!(state.wormhole_emitter.is_none(), E_WORMHOLE_ALREADY_ENABLED);
-        state.wormhole_emitter.fill(wormhole::register_emitter());
+        state.wormhole_enabled = enable;
     }
 
     /// Update mutable metadata (`icon_uri`, `project_uri`) on a
@@ -832,30 +829,28 @@ module omni_bridge::omni_bridge {
         );
     }
 
-    /// True iff `enable_wormhole` has been called. Each entry point uses
-    /// this to short-circuit Wormhole payload construction when the
-    /// integration is off, avoiding a several-hundred-byte allocation
-    /// + memcopy per transfer in the common (Wormhole-disabled) case.
+    /// True iff `set_wormhole_enabled(true)` is the most recent toggle.
     inline fun is_wormhole_enabled(state: &BridgeState): bool {
-        state.wormhole_emitter.is_some()
+        state.wormhole_enabled
     }
 
     /// Publish `payload` as a Wormhole VAA. Caller must have already
-    /// confirmed `is_wormhole_enabled(state)` — borrowing the emitter
-    /// here when it's `None` would abort. The Wormhole nonce is `0` for
-    /// every message; the bridge's own `current_origin_nonce` (carried
-    /// inside the payload) is the replay-prevention identifier. `payer`
-    /// funds the Wormhole message fee from `Coin<AptosCoin>`. With the
-    /// current Wormhole `message_fee` at 0 the withdrawal is a no-op,
-    /// but we still wire the path through so a future fee increase
-    /// doesn't require a contract upgrade.
+    /// confirmed `is_wormhole_enabled(state)` — this helper itself does
+    /// no flag check, so calling it when disabled would still emit a
+    /// VAA. The Wormhole nonce is `0` for every message; the bridge's
+    /// own `current_origin_nonce` (carried inside the payload) is the
+    /// replay-prevention identifier. `payer` funds the Wormhole message
+    /// fee from `Coin<AptosCoin>`. With the current Wormhole
+    /// `message_fee` at 0 the withdrawal is a no-op, but we still wire
+    /// the path through so a future fee increase doesn't require a
+    /// contract upgrade.
     fun publish_wormhole(
         state: &mut BridgeState, payer: &signer, payload: vector<u8>
     ) {
         let fee = wormhole_state::get_message_fee();
         let fee_coin = coin::withdraw<AptosCoin>(payer, fee);
         wormhole::publish_message(
-            state.wormhole_emitter.borrow_mut(),
+            &mut state.wormhole_emitter,
             0u64,
             payload,
             fee_coin

--- a/aptos/sources/omni_bridge.move
+++ b/aptos/sources/omni_bridge.move
@@ -13,10 +13,15 @@ module omni_bridge::omni_bridge {
     use std::string::{Self, String};
     use std::option::{Self, Option};
     use aptos_std::table::{Self, Table};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin;
     use aptos_framework::event;
     use aptos_framework::fungible_asset::{Self, Metadata};
     use aptos_framework::object::{Self, ExtendRef, Object};
     use aptos_framework::primary_fungible_store;
+    use wormhole::emitter::EmitterCapability;
+    use wormhole::state as wormhole_state;
+    use wormhole::wormhole;
 
     use omni_bridge::bridge_token;
     use omni_bridge::bridge_types;
@@ -54,6 +59,11 @@ module omni_bridge::omni_bridge {
     /// Revoking would leave the `Admin` role with zero holders — would
     /// brick the bridge (no one could grant/revoke roles again).
     const E_CANNOT_REMOVE_LAST_ADMIN: u64 = 12;
+
+    // Wormhole
+    /// `enable_wormhole` was called when the bridge already holds an
+    /// `EmitterCapability`. Re-registering would leak the prior cap.
+    const E_WORMHOLE_ALREADY_ENABLED: u64 = 13;
 
     /// Largest amount that fits in `u64`, used to bound `u128` payload
     /// amounts before they're handed to the Aptos Fungible Asset APIs.
@@ -115,7 +125,15 @@ module omni_bridge::omni_bridge {
         /// on demand for:
         ///   - creating new FA objects in `deploy_token`
         ///   - moving locked tokens out in `fin_transfer` (non-bridge tokens)
-        extend_ref: ExtendRef
+        extend_ref: ExtendRef,
+        /// Wormhole emitter capability. `None` until `ROLE_ADMIN` calls
+        /// `enable_wormhole`. When `Some`, every public bridge action
+        /// (`init_transfer`, `fin_transfer`, `deploy_token`, `log_metadata`)
+        /// also publishes a Wormhole VAA whose payload mirrors the EVM
+        /// `OmniBridgeWormhole.sol` byte layout. The caller of each entry
+        /// pays the Wormhole message fee in `Coin<AptosCoin>` from their
+        /// own balance.
+        wormhole_emitter: Option<EmitterCapability>
     }
 
     // -------- Events --------
@@ -227,7 +245,8 @@ module omni_bridge::omni_bridge {
                 completed_transfers: table::new<u64, u128>(),
                 native_token_metadata,
                 near_to_aptos_token: table::new<String, address>(),
-                extend_ref
+                extend_ref,
+                wormhole_emitter: option::none()
             }
         );
     }
@@ -300,6 +319,20 @@ module omni_bridge::omni_bridge {
         );
     }
 
+    /// Register the bridge as a Wormhole emitter. Once enabled, every
+    /// successful `init_transfer`, `fin_transfer`, `deploy_token`, and
+    /// `log_metadata` also publishes a Wormhole VAA whose payload mirrors
+    /// the corresponding `OmniBridgeWormhole.sol` extension. Callable once;
+    /// re-enabling aborts to avoid leaking the prior emitter cap. The
+    /// caller of each subsequent bridge action pays the Wormhole message
+    /// fee in `Coin<AptosCoin>` from their own balance.
+    public entry fun enable_wormhole(admin: &signer) {
+        let state = &mut BridgeState[bridge_object_address()];
+        assert_role(state, ROLE_ADMIN, admin, E_UNAUTHORIZED);
+        assert!(state.wormhole_emitter.is_none(), E_WORMHOLE_ALREADY_ENABLED);
+        state.wormhole_emitter.fill(wormhole::register_emitter());
+    }
+
     /// Update mutable metadata (`icon_uri`, `project_uri`) on a
     /// bridge-deployed FA. `None` fields are left unchanged. Gated on the
     /// `metadata_admin` role (separate from the main admin so metadata
@@ -338,22 +371,36 @@ module omni_bridge::omni_bridge {
 
     /// Permissionless: emit a `LogMetadata` event describing an existing FA.
     /// The NEAR side picks this event up to decide whether to sign a
-    /// `deploy_token` payload for the mirror token on its side.
-    public entry fun log_metadata(token: Object<Metadata>) {
+    /// `deploy_token` payload for the mirror token on its side. `caller`
+    /// pays the Wormhole message fee if Wormhole is enabled; the signer is
+    /// otherwise not read on-chain.
+    public entry fun log_metadata(caller: &signer, token: Object<Metadata>) {
+        let state = &mut BridgeState[bridge_object_address()];
+        let token_address = token.object_address();
         let name = fungible_asset::name(token);
         let symbol = fungible_asset::symbol(token);
         let decimals = fungible_asset::decimals(token);
-        event::emit(
-            LogMetadata { token_address: token.object_address(), name, symbol, decimals }
-        );
+        event::emit(LogMetadata { token_address, name, symbol, decimals });
+
+        let payload =
+            bridge_types::log_metadata_wormhole_payload(
+                state.chain_id,
+                token_address,
+                &name,
+                &symbol,
+                decimals
+            );
+        publish_wormhole_if_enabled(state, caller, payload);
     }
 
     // -------- Bridge operations --------
 
     /// Deploy a bridged FA token. Anyone may submit the transaction —
     /// security comes from the NEAR MPC signature over the payload, not
-    /// access control. The transaction signer is not read on-chain.
+    /// access control. `caller` pays the Wormhole message fee if Wormhole
+    /// is enabled; the signer is otherwise not read on-chain.
     public entry fun deploy_token(
+        caller: &signer,
         signature_rs: vector<u8>,
         signature_v: u8,
         token: String,
@@ -407,12 +454,24 @@ module omni_bridge::omni_bridge {
                 origin_decimals: payload.metadata_decimals()
             }
         );
+
+        let wh_payload =
+            bridge_types::deploy_token_wormhole_payload(
+                state.chain_id,
+                &payload.metadata_token(),
+                token_addr,
+                normalized_decimals,
+                payload.metadata_decimals()
+            );
+        publish_wormhole_if_enabled(state, caller, wh_payload);
     }
 
     /// Finalize an inbound transfer from another chain. Permissionless —
-    /// the NEAR MPC signature is the authorization. The transaction signer
-    /// is not read on-chain.
+    /// the NEAR MPC signature is the authorization. `caller` pays the
+    /// Wormhole message fee if Wormhole is enabled; the signer is
+    /// otherwise not read on-chain.
     public entry fun fin_transfer(
+        caller: &signer,
         signature_rs: vector<u8>,
         signature_v: u8,
         destination_nonce: u64,
@@ -479,6 +538,18 @@ module omni_bridge::omni_bridge {
                 message: payload.transfer_message()
             }
         );
+
+        let fr = payload.transfer_fee_recipient();
+        let wh_payload =
+            bridge_types::fin_transfer_wormhole_payload(
+                state.chain_id,
+                origin_chain,
+                origin_nonce,
+                token_address,
+                amount,
+                &fr
+            );
+        publish_wormhole_if_enabled(state, caller, wh_payload);
     }
 
     /// Start an outbound transfer from Aptos to another chain.
@@ -542,6 +613,20 @@ module omni_bridge::omni_bridge {
                 message
             }
         );
+
+        let wh_payload =
+            bridge_types::init_transfer_wormhole_payload(
+                state.chain_id,
+                sender_addr,
+                token_address,
+                origin_nonce,
+                amount,
+                fee,
+                native_fee,
+                &recipient,
+                &message
+            );
+        publish_wormhole_if_enabled(state, sender, wh_payload);
     }
 
     // -------- Views --------
@@ -732,6 +817,29 @@ module omni_bridge::omni_bridge {
             signature_rs,
             signature_v,
             state.near_bridge_derived_address
+        );
+    }
+
+    /// Publish `payload` as a Wormhole VAA iff the bridge has been
+    /// registered as a Wormhole emitter via `enable_wormhole`. No-op
+    /// otherwise. The Wormhole nonce is `0` for every message — the
+    /// bridge's own `current_origin_nonce` (carried inside the payload)
+    /// is the replay-prevention identifier. `payer` funds the Wormhole
+    /// message fee from `Coin<AptosCoin>`. With the current Wormhole
+    /// `message_fee` at 0 the withdrawal is a no-op, but we still wire
+    /// the path through so a future fee increase doesn't require a
+    /// contract upgrade.
+    fun publish_wormhole_if_enabled(
+        state: &mut BridgeState, payer: &signer, payload: vector<u8>
+    ) {
+        if (state.wormhole_emitter.is_none()) { return };
+        let fee = wormhole_state::get_message_fee();
+        let fee_coin = coin::withdraw<AptosCoin>(payer, fee);
+        wormhole::publish_message(
+            state.wormhole_emitter.borrow_mut(),
+            0u64,
+            payload,
+            fee_coin
         );
     }
 

--- a/aptos/tests/omni_bridge_tests.move
+++ b/aptos/tests/omni_bridge_tests.move
@@ -937,30 +937,36 @@ module omni_bridge::omni_bridge_tests {
         assert!(bytes[len - 1] == 6u8, 543);
     }
 
-    // -------- enable_wormhole gating --------
+    // -------- set_wormhole_enabled gating --------
 
     #[test(deployer = @omni_bridge)]
-    fun admin_can_enable_wormhole(deployer: signer) {
+    fun admin_can_toggle_wormhole(deployer: signer) {
+        // Round-trip: off → on → off → on. Confirms the bool flips
+        // cleanly. The emitter cap is registered once in `initialize` and
+        // never re-registered, so all four calls are pure flag flips.
         let _ = setup(&deployer);
-        omni_bridge::enable_wormhole(&deployer);
+        omni_bridge::set_wormhole_enabled(&deployer, true);
+        omni_bridge::set_wormhole_enabled(&deployer, false);
+        omni_bridge::set_wormhole_enabled(&deployer, true);
     }
 
-    // Re-enabling aborts with E_WORMHOLE_ALREADY_ENABLED = 13.
     #[test(deployer = @omni_bridge)]
-    #[expected_failure(abort_code = 13, location = omni_bridge::omni_bridge)]
-    fun cannot_enable_wormhole_twice(deployer: signer) {
+    fun toggling_wormhole_is_idempotent(deployer: signer) {
+        // Setting the flag to its current value is a no-op — no abort.
         let _ = setup(&deployer);
-        omni_bridge::enable_wormhole(&deployer);
-        omni_bridge::enable_wormhole(&deployer);
+        omni_bridge::set_wormhole_enabled(&deployer, false);
+        omni_bridge::set_wormhole_enabled(&deployer, false);
+        omni_bridge::set_wormhole_enabled(&deployer, true);
+        omni_bridge::set_wormhole_enabled(&deployer, true);
     }
 
-    // Non-admin cannot enable wormhole. E_UNAUTHORIZED = 2.
+    // Non-admin cannot toggle wormhole. E_UNAUTHORIZED = 2.
     #[test(deployer = @omni_bridge, intruder = @0xBADBAD)]
     #[expected_failure(abort_code = 2, location = omni_bridge::omni_bridge)]
-    fun non_admin_cannot_enable_wormhole(deployer: signer, intruder: signer) {
+    fun non_admin_cannot_toggle_wormhole(deployer: signer, intruder: signer) {
         let _ = setup(&deployer);
         account::create_account_for_test(intruder.address_of());
-        omni_bridge::enable_wormhole(&intruder);
+        omni_bridge::set_wormhole_enabled(&intruder, true);
     }
 }
 

--- a/aptos/tests/omni_bridge_tests.move
+++ b/aptos/tests/omni_bridge_tests.move
@@ -812,5 +812,155 @@ module omni_bridge::omni_bridge_tests {
             b""
         );
     }
+
+    // -------- Wormhole payload encoding tests --------
+    //
+    // Verify each wormhole payload matches the layout that
+    // `OmniBridgeWormhole.sol` produces for the equivalent extension. We
+    // assert on the leading tag byte + chain-id positions + total length
+    // rather than every byte — the underlying primitives (`bcs::to_bytes`,
+    // `borsh::encode_string`) are already exhaustively tested in
+    // `borsh_tests` and the borsh-layout tests above.
+
+    #[test]
+    fun init_transfer_wormhole_payload_layout() {
+        let recipient = string::utf8(b"alice.near");
+        let message = b"hi";
+        let bytes =
+            bridge_types::init_transfer_wormhole_payload(
+                13u8, // chain_id
+                @0xAA,
+                @0xBB,
+                42u64,
+                1_000u128,
+                10u128,
+                5u128,
+                &recipient,
+                &message
+            );
+        // Tag = WH_MSG_INIT_TRANSFER = 0.
+        assert!(bytes[0] == 0u8, 500);
+        // chain_id at byte 1 and again before token_address (at 1 + 1 + 32 = 34).
+        assert!(bytes[1] == 13u8, 501);
+        assert!(bytes[34] == 13u8, 502);
+        // Layout: tag(1) + cid(1) + sender(32) + cid(1) + token(32)
+        //       + origin_nonce(8) + amount(16) + fee(16) + native_fee(16)
+        //       + len(4)+"alice.near"(10) + len(4)+"hi"(2)
+        // = 1+1+32+1+32+8+16+16+16+4+10+4+2 = 143
+        assert!(bytes.length() == 143, 503);
+    }
+
+    #[test]
+    fun fin_transfer_wormhole_payload_layout_with_fee_recipient() {
+        let fr = option::some(string::utf8(b"fee.near"));
+        let bytes =
+            bridge_types::fin_transfer_wormhole_payload(
+                13u8, // chain_id
+                7u8, // origin_chain
+                42u64,
+                @0xCC,
+                999u128,
+                &fr
+            );
+        // Tag = WH_MSG_FIN_TRANSFER = 1.
+        assert!(bytes[0] == 1u8, 510);
+        // origin_chain at byte 1.
+        assert!(bytes[1] == 7u8, 511);
+        // chain_id at 1 + 1 + 8 = 10 (after tag, origin_chain, origin_nonce).
+        assert!(bytes[10] == 13u8, 512);
+        // Layout: 1 + 1 + 8 + 1 + 32 + 16 + (4 + 8) = 71
+        assert!(bytes.length() == 71, 513);
+    }
+
+    #[test]
+    fun fin_transfer_wormhole_payload_layout_without_fee_recipient() {
+        let fr = option::none<string::String>();
+        let bytes =
+            bridge_types::fin_transfer_wormhole_payload(
+                13u8, 7u8, 42u64, @0xCC, 999u128, &fr
+            );
+        assert!(bytes[0] == 1u8, 520);
+        // Layout: 1 + 1 + 8 + 1 + 32 + 16 + 4 (empty length prefix) = 63
+        assert!(bytes.length() == 63, 521);
+        // Last 4 bytes are the zero-length prefix.
+        let len = bytes.length();
+        assert!(bytes[len - 4] == 0u8, 522);
+        assert!(bytes[len - 3] == 0u8, 523);
+        assert!(bytes[len - 2] == 0u8, 524);
+        assert!(bytes[len - 1] == 0u8, 525);
+    }
+
+    #[test]
+    fun deploy_token_wormhole_payload_layout() {
+        let token = string::utf8(b"usdc.near");
+        let bytes =
+            bridge_types::deploy_token_wormhole_payload(
+                13u8,
+                &token,
+                @0xDD,
+                8u8, // decimals
+                6u8 // origin_decimals
+            );
+        // Tag = WH_MSG_DEPLOY_TOKEN = 2.
+        assert!(bytes[0] == 2u8, 530);
+        // chain_id sits after tag + encoded token (4-byte len + 9 utf-8 bytes).
+        let chain_id_offset = 1 + 4 + 9;
+        assert!(bytes[chain_id_offset] == 13u8, 531);
+        // Layout: 1 + (4 + 9) + 1 + 32 + 1 + 1 = 49
+        assert!(bytes.length() == 49, 532);
+        // Last two bytes are decimals + origin_decimals.
+        let len = bytes.length();
+        assert!(bytes[len - 2] == 8u8, 533);
+        assert!(bytes[len - 1] == 6u8, 534);
+    }
+
+    #[test]
+    fun log_metadata_wormhole_payload_layout() {
+        let name = string::utf8(b"USDC");
+        let symbol = string::utf8(b"USDC");
+        let bytes =
+            bridge_types::log_metadata_wormhole_payload(
+                13u8,
+                @0xEE,
+                &name,
+                &symbol,
+                6u8
+            );
+        // Tag = WH_MSG_LOG_METADATA = 3.
+        assert!(bytes[0] == 3u8, 540);
+        // chain_id at byte 1.
+        assert!(bytes[1] == 13u8, 541);
+        // Layout: 1 + 1 + 32 + (4 + 4) + (4 + 4) + 1 = 51
+        assert!(bytes.length() == 51, 542);
+        // Last byte is decimals.
+        let len = bytes.length();
+        assert!(bytes[len - 1] == 6u8, 543);
+    }
+
+    // -------- enable_wormhole gating --------
+
+    #[test(deployer = @omni_bridge)]
+    fun admin_can_enable_wormhole(deployer: signer) {
+        let _ = setup(&deployer);
+        omni_bridge::enable_wormhole(&deployer);
+    }
+
+    // Re-enabling aborts with E_WORMHOLE_ALREADY_ENABLED = 13.
+    #[test(deployer = @omni_bridge)]
+    #[expected_failure(abort_code = 13, location = omni_bridge::omni_bridge)]
+    fun cannot_enable_wormhole_twice(deployer: signer) {
+        let _ = setup(&deployer);
+        omni_bridge::enable_wormhole(&deployer);
+        omni_bridge::enable_wormhole(&deployer);
+    }
+
+    // Non-admin cannot enable wormhole. E_UNAUTHORIZED = 2.
+    #[test(deployer = @omni_bridge, intruder = @0xBADBAD)]
+    #[expected_failure(abort_code = 2, location = omni_bridge::omni_bridge)]
+    fun non_admin_cannot_enable_wormhole(deployer: signer, intruder: signer) {
+        let _ = setup(&deployer);
+        account::create_account_for_test(intruder.address_of());
+        omni_bridge::enable_wormhole(&intruder);
+    }
 }
 

--- a/aptos/vendor/wormhole/Move.toml
+++ b/aptos/vendor/wormhole/Move.toml
@@ -1,0 +1,49 @@
+[package]
+name = "Wormhole"
+version = "0.1.0"
+authors = ["Near One"]
+
+# Minimal stand-in for `wormhole-foundation/wormhole/aptos/wormhole`.
+#
+# This package is a COMPILE-TIME ONLY stub. It declares just enough of
+# the Wormhole modules — `wormhole::wormhole`, `wormhole::emitter`,
+# `wormhole::state` — for our bridge to compile against. The function
+# bodies here are placeholders that never execute on chain.
+#
+# Why this works:
+#   - At compile time the Move compiler resolves `use wormhole::wormhole;`
+#     against this stub and verifies signatures.
+#   - At publish time only modules from `aptos/sources/` go on chain.
+#     The `wormhole::*` modules are NOT republished (we don't own
+#     `@wormhole`); they're treated as already-deployed deps.
+#   - At runtime calls to `wormhole::wormhole::publish_message` dispatch
+#     by module identity (`(address, name)`) to the REAL Wormhole at
+#     `@wormhole = 0x5bc1…`, which was published by Wormhole and contains
+#     the actual implementation.
+#
+# Critical: do NOT add fields, change field types, reorder fields, or
+# change function signatures here without verifying the deployed
+# Wormhole's ABI hasn't drifted. The deployed bytecode is the source of
+# truth; this stub only mirrors its public ABI.
+
+[addresses]
+# Mainnet Wormhole core address. Override via `--named-addresses` for
+# testnet (`0x57641…`) or devnet.
+wormhole = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+
+# Same modern framework rev as the parent `aptos/` package, so the bridge
+# and this stub agree on `aptos_framework::coin::Coin<AptosCoin>` identity.
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-core.git"
+subdir = "aptos-move/framework/aptos-framework"
+rev = "mainnet"
+
+[dependencies.AptosStdlib]
+git = "https://github.com/aptos-labs/aptos-core.git"
+subdir = "aptos-move/framework/aptos-stdlib"
+rev = "mainnet"
+
+[dependencies.MoveStdlib]
+git = "https://github.com/aptos-labs/aptos-core.git"
+subdir = "aptos-move/framework/move-stdlib"
+rev = "mainnet"

--- a/aptos/vendor/wormhole/sources/emitter.move
+++ b/aptos/vendor/wormhole/sources/emitter.move
@@ -1,0 +1,25 @@
+/// Stub mirror of `wormhole::emitter` — see `Move.toml` for rationale.
+///
+/// The `EmitterCapability` struct layout matches the deployed Wormhole's
+/// (`emitter: u64, sequence: u64`, ability `store`). Layout must not
+/// drift from upstream; the runtime VM identifies types by `(address,
+/// name)` and rejects struct-shape mismatches.
+module wormhole::emitter {
+    struct EmitterCapability has store {
+        emitter: u64,
+        sequence: u64
+    }
+
+    public fun get_emitter(emitter_cap: &EmitterCapability): u64 {
+        emitter_cap.emitter
+    }
+
+    /// Stub-only constructor used by `wormhole::register_emitter` in this
+    /// stub. The deployed Wormhole has its own internal emitter registry.
+    /// Never called at production runtime.
+    public(friend) fun new_for_testing(): EmitterCapability {
+        EmitterCapability { emitter: 0, sequence: 0 }
+    }
+
+    friend wormhole::wormhole;
+}

--- a/aptos/vendor/wormhole/sources/state.move
+++ b/aptos/vendor/wormhole/sources/state.move
@@ -1,0 +1,11 @@
+/// Stub mirror of `wormhole::state` — see `Move.toml` for rationale.
+///
+/// Only the public functions the bridge calls are declared.
+module wormhole::state {
+    public fun get_message_fee(): u64 {
+        // Stub: never executes on chain. The deployed Wormhole at
+        // `@wormhole` reads the real configured fee from its on-chain
+        // state and returns it.
+        0
+    }
+}

--- a/aptos/vendor/wormhole/sources/wormhole.move
+++ b/aptos/vendor/wormhole/sources/wormhole.move
@@ -1,0 +1,41 @@
+/// Stub mirror of `wormhole::wormhole` — see `Move.toml` for rationale.
+///
+/// Bodies here are placeholders. At runtime, calls dispatch by module
+/// identity to the deployed Wormhole at `@wormhole`, where the real
+/// implementation lives.
+module wormhole::wormhole {
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
+    use wormhole::emitter::{Self, EmitterCapability};
+
+    /// Register an emitter with Wormhole and receive its capability.
+    /// The deployed Wormhole assigns a fresh sequential emitter id.
+    public fun register_emitter(): EmitterCapability {
+        // Stub: never executes on chain. The deployed Wormhole returns
+        // a freshly registered EmitterCapability. We return a zero-init
+        // value here so Move unit tests of consumers can exercise the
+        // "wormhole enabled" code path without aborting.
+        emitter::new_for_testing()
+    }
+
+    /// Publish a Wormhole message. Withdraws the fee from `message_fee`
+    /// (must be at least `state::get_message_fee()`), increments the
+    /// emitter's sequence, and emits a wormhole event that guardians
+    /// observe.
+    public fun publish_message(
+        emitter_cap: &mut EmitterCapability,
+        nonce: u64,
+        payload: vector<u8>,
+        message_fee: Coin<AptosCoin>
+    ): u64 {
+        // Stub: dispose of arguments so the body type-checks. None of
+        // this runs on chain.
+        let _ = emitter_cap;
+        let _ = nonce;
+        let _ = payload;
+        // `Coin` has no `drop`; must consume it. Depositing back to
+        // `@wormhole` is consistent with what the real impl does.
+        coin::deposit(@wormhole, message_fee);
+        0
+    }
+}


### PR DESCRIPTION
This pull request introduces optional Wormhole integration into the Aptos OmniBridge, enabling the bridge to emit Wormhole VAAs (Verifiable Action Approvals) for key bridge actions, with full parity to the EVM implementation. The integration is controlled by an admin-settable flag, and includes new payload encoders, on-chain wiring to the Wormhole emitter, and comprehensive test coverage. The bridge remains fully functional when Wormhole publishing is disabled.

The most important changes are:

**Wormhole Integration and Control**
- The bridge now registers as a Wormhole emitter in `initialize` and stores the `EmitterCapability` in `BridgeState`. Admins can enable or disable Wormhole publishing at any time using the new `set_wormhole_enabled` entry function, which simply toggles a flag. The same emitter ID is used across enable/disable cycles, providing a stable identity for off-chain consumers. [[1]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR37-R57) [[2]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aL118-R133) [[3]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aL230-R247) [[4]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aR320-R332) [[5]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR76) [[6]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR134-R160)

**Wormhole Payload Publishing in Bridge Actions**
- When Wormhole publishing is enabled, every successful `init_transfer`, `fin_transfer`, `deploy_token`, and `log_metadata` action emits a Wormhole VAA. The caller pays the Wormhole message fee in `Coin<AptosCoin>`, and the payloads mirror the EVM `OmniBridgeWormhole.sol` byte layout for cross-chain compatibility. [[1]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aL341-R406) [[2]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aR460-R479) [[3]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aR546-R559) [[4]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aR623-R638) [[5]](diffhunk://#diff-806c8cf2e04bc998768762f8fed7cb31bd869dfb5f026d12ce6ea44e372c731aR832-R859)

**Wormhole Payload Encoders**
- Four new Wormhole payload encoder functions are added to `bridge_types.move`, matching the EVM-side byte layouts exactly: `init_transfer_wormhole_payload`, `fin_transfer_wormhole_payload`, `deploy_token_wormhole_payload`, and `log_metadata_wormhole_payload`. These ensure consistent cross-chain message formats. [[1]](diffhunk://#diff-b23a87888fd1632df3fbc712f0d6ab35db58393cada72ee04ba068dfb9a0bc39R22-R30) [[2]](diffhunk://#diff-b23a87888fd1632df3fbc712f0d6ab35db58393cada72ee04ba068dfb9a0bc39R160-R265)

**Stubbed Wormhole Dependency**
- The Wormhole Move package is vendored as a compile-time-only stub at `vendor/wormhole`, allowing the bridge to compile against the deployed Wormhole ABI without republishing the modules. This is documented in both `Move.toml` and the code. [[1]](diffhunk://#diff-0e590fe2ead9e899d3c435c8df9635241a7a4f7556a4df335a0614e425ffba0eR23-R30) [[2]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR134-R160)

**Expanded Documentation and Test Coverage**
- The documentation (`CLAUDE.md`) is updated to reflect the new Wormhole integration, including module layout, admin controls, and rationale for the stub. Test coverage is expanded to include Wormhole payload layouts and the gating logic for enabling/disabling publishing. [[1]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR37-R57) [[2]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR76) [[3]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR134-R160) [[4]](diffhunk://#diff-b1077a1333adda40bf48f9269390a35dac112dd744bb029e7d1782e292a5a1bbR218-R223)