### PR TITLE
fix(solana): allow program-owned recipients in finalizeTransferSol

### DIFF
--- a/solana/programs/bridge_token_factory/src/instructions/user/finalize_transfer_sol.rs
+++ b/solana/programs/bridge_token_factory/src/instructions/user/finalize_transfer_sol.rs
@@ -49,8 +49,9 @@ pub struct FinalizeTransferSol<'info> {
     )]
     pub authority: SystemAccount<'info>,
 
+    /// CHECK: this can be any type of account
     #[account(mut)]
-    pub recipient: SystemAccount<'info>,
+    pub recipient: UncheckedAccount<'info>,
 
     #[account(
         mut,


### PR DESCRIPTION
## Summary

Relaxes the `recipient` account in `finalize_transfer_sol` from `SystemAccount<'info>` to `UncheckedAccount<'info>`, mirroring the SPL `finalize_transfer` path (which already uses `UncheckedAccount` for the recipient).

Previously, a NEAR→Solana native SOL transfer whose recipient account was **not owned by the System Program** (e.g. a smart wallet, a multisig/vault PDA, or any account reassigned via `assign`) would revert at Anchor account validation, since `SystemAccount` enforces `owner == SystemProgram`. This made such transfers impossible to finalize even though the underlying `system_program::transfer` only requires the *source* (`sol_vault`) to be system-owned — the destination can have any owner.

## Why this is safe

- The recipient is already committed in the NEAR MPC signature (`verify_signature` is called with `recipient.key()`), so this does **not** change which account can be paid — only what account *types* are accepted.
- A SOL transfer only credits lamports; no code is invoked on the recipient, so there is no callback/reentrancy surface.
- Replay protection (`use_nonce`) and Wormhole posting are unaffected.

## Tradeoff

This removes the implicit "recipient must be a plain, key-controlled wallet" guard. SOL can now be delivered to program-owned accounts that may not expose a withdrawal path. Since the recipient is chosen and signed on the source chain, this is the initiator's responsibility — but a downstream risk/denylist check could be worth adding separately.

## Testing

`make solana-run-tests` — 43 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)