### PR TITLE
chore(solana): bump bridge_token_factory to 0.2.9

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "bridge_token_factory"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/solana/programs/bridge_token_factory/Cargo.toml
+++ b/solana/programs/bridge_token_factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bridge_token_factory"
-version = "0.2.8"
+version = "0.2.9"
 description = "Created with Anchor"
 edition = "2021"
 


### PR DESCRIPTION
## Summary

The on-chain program version reported via the `get_version` instruction is sourced from `CARGO_PKG_VERSION`. PR #630 (`fix(solana): allow program-owned recipients in finalizeTransferSol`) shipped without a version bump, so this bumps `bridge_token_factory` from `0.2.8` → `0.2.9`.

## Changes

- `solana/programs/bridge_token_factory/Cargo.toml`: `version = "0.2.9"`
- `solana/Cargo.lock`: matching lockfile update

🤖 Generated with [Claude Code](https://claude.com/claude-code)