### PR TITLE
feat(HL): add coreNonce to CoreReceived event

### DIFF
--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -42,6 +42,7 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     event CoreReceived(
         address indexed sender,
         uint8 indexed action,
+        uint64 indexed coreNonce,
         uint256 amount,
         bytes data
     );
@@ -84,8 +85,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
 
     /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
     /// HyperCore user triggers `sendToEvmWithData` targeting this token.
-    /// `destinationRecipient`, `destinationChainId`, and `coreNonce` are CCTP-shaped
-    /// and not used here; all routing info comes from `data`.
+    /// `destinationRecipient` and `destinationChainId` are unused here; all routing
+    /// info comes from `data`. `coreNonce` is the HyperCore-side sequence number,
+    /// re-emitted in `CoreReceived` for off-chain correlation with the HL event.
     /// @dev Accounting model: the 3-arg `mint` parks HyperCore-bound tokens at
     /// `_systemAddress`, so that account holds the standing pool that mirrors total
     /// HyperCore-side balance. HyperLiquid does NOT pre-transfer tokens before this
@@ -108,7 +110,7 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         bytes32 /*destinationRecipient*/,
         uint32 /*destinationChainId*/,
         uint256 amount,
-        uint64 /*coreNonce*/,
+        uint64 coreNonce,
         bytes calldata data
     ) external override {
         if (msg.sender != _systemAddress) revert NotSystemAddress();
@@ -137,6 +139,6 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
             revert UnknownAction(action);
         }
 
-        emit CoreReceived(from, action, amount, data);
+        emit CoreReceived(from, action, coreNonce, amount, data);
     }
 }

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -140,7 +140,7 @@ describe("HyperliquedBridgeToken", () => {
           .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data),
       )
         .to.emit(token, "CoreReceived")
-        .withArgs(user1.address, ACTION_TRANSFER, AMOUNT, data)
+        .withArgs(user1.address, ACTION_TRANSFER, 0, AMOUNT, data)
 
       expect(await token.balanceOf(user2.address)).to.equal(AMOUNT)
       expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(0n)
@@ -202,7 +202,7 @@ describe("HyperliquedBridgeToken", () => {
 
       await expect(tx)
         .to.emit(token, "CoreReceived")
-        .withArgs(user1.address, ACTION_INIT_TRANSFER, AMOUNT, data)
+        .withArgs(user1.address, ACTION_INIT_TRANSFER, 0, AMOUNT, data)
 
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
       expect(await token.totalSupply()).to.equal(0n)


### PR DESCRIPTION
This pull request updates the `HyperliquedBridgeToken` contract to improve tracking and correlation of cross-chain events by including the `coreNonce` (HyperCore-side sequence number) in the `CoreReceived` event and method signatures. This change aids off-chain systems in correlating HyperCore and Hyperliqued events more reliably.

**Event and function signature updates:**

* Added a `coreNonce` parameter to the `CoreReceived` event, allowing off-chain correlation between HyperCore and Hyperliqued events.
* Updated the `coreReceiveWithData` function to accept and emit the `coreNonce` parameter, ensuring the sequence number is passed through and logged. [[1]](diffhunk://#diff-e523b53d18de81376b70c2efc3182c67d9bcdf2d84e8aa55db6e4761bdd1407cL111-R113) [[2]](diffhunk://#diff-e523b53d18de81376b70c2efc3182c67d9bcdf2d84e8aa55db6e4761bdd1407cL140-R142)

**Documentation improvements:**

* Clarified in the function documentation that `coreNonce` is now re-emitted in `CoreReceived` for off-chain correlation, and that other routing info comes from `data`.