### PR TITLE
chore: trim derivable content from per-chain CLAUDE.md files

### DIFF
--- a/aptos/CLAUDE.md
+++ b/aptos/CLAUDE.md
@@ -29,11 +29,6 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
   can have any number of holders, all equally privileged. The `Admin` role
   grants/revokes any role (including itself) via `grant_role`/`revoke_role`.
   Revoking the last `Admin` aborts with `E_CANNOT_REMOVE_LAST_ADMIN`.
-- **Modern Move (V2)**: Receiver-style method calls (`v.push_back(x)`,
-  `t.contains(k)`, `payload.metadata_to_borsh()`), vector indexing
-  (`bytes[i]`), `for (i in 0..n)` range loops, `package fun` for
-  cross-module-restricted entry points, and resource-index expressions
-  (`&BridgeState[addr]`).
 
 ## Module Layout
 
@@ -44,29 +39,6 @@ and [evm/src/omni-bridge/contracts/OmniBridge.sol](../evm/src/omni-bridge/contra
 | `omni_bridge::bridge_types` | Payload structs (`MetadataPayload`, `TransferMessagePayload`) and their Borsh encoders. Events live in `omni_bridge` because Aptos requires `#[event]` and emit-site in the same module |
 | `omni_bridge::borsh` | Borsh sequence encoders (`encode_string`, `encode_byte_vec`). Fixed-width integers and addresses delegate to `std::bcs::to_bytes` directly at call sites (BCS == Borsh for those types) |
 | `omni_bridge::utils` | `verify_eth_signature` (secp256k1 + keccak256), `normalize_decimals` |
-
-## Core Functions
-
-| Function | Purpose | Access |
-|----------|---------|--------|
-| `initialize` | One-shot: creates the bridge object and seeds all roles to the deployer | Deployer (only `@omni_bridge`) |
-| `init_transfer` | Send tokens from Aptos to another chain. Burns (bridged FA) or locks (native FA), charges optional `native_fee` | Public |
-| `fin_transfer` | Receive tokens from another chain; verifies NEAR MPC signature, marks `destination_nonce` used, mints or unlocks | Public |
-| `deploy_token` | Deploy a new bridged FA; verifies NEAR MPC signature | Public |
-| `log_metadata` | Emit a `LogMetadata` event describing an existing FA | Public |
-| `set_token_metadata` | Update `icon_uri` / `project_uri` on a bridge-deployed FA | `MetadataAdmin` |
-| `set_pause_flags` | Set the full pause-flags bitmap | `Admin` |
-| `pause_all` | Set all pause flags at once (incident response) | `Pauser` |
-| `set_near_bridge_derived_address` | Rotate the NEAR MPC signer address | `Admin` |
-| `grant_role` | Add an address to a role | `Admin` |
-| `revoke_role` | Remove an address from a role (refuses last Admin) | `Admin` |
-| `bridge_object_address` | Deterministic address of `BridgeState` / locked-token custody | View |
-| `get_token_address` | NEAR token id → deployed FA metadata object address | View |
-| `role_holders` | All addresses currently holding a role | View |
-| `has_role` | True if `addr` holds `role` | View |
-| `all_roles` | Registry of `(name, id)` for every defined role | View |
-| `is_transfer_finalised` | Whether a destination nonce has been used | View |
-| `current_origin_nonce` / `pause_flags` / `chain_id` | Plain state views | View |
 
 ## Borsh Encoding
 
@@ -156,28 +128,3 @@ Run unit tests with:
 ```sh
 aptos move test --named-addresses omni_bridge=0xCAFE
 ```
-
-Coverage:
-- Borsh encoding: length-prefix exhaustiveness, empty strings, multi-byte
-  length encoding
-- Metadata and TransferMessage Borsh layouts (length, field offsets, dual
-  chain-id tag, Option-tag semantics for `fee_recipient` vs untagged `message`)
-- Nonce bitmap edge cases (word boundary at 127/128, idempotent mark)
-- Pause flags: admin can set, non-admin rejected, init/fin/deploy gates
-- Role management: grant adds (idempotent), revoke removes, last-admin
-  guard, admin can step down when another admin exists, non-admin cannot
-  grant/revoke
-- Metadata mutation: `MetadataAdmin` can update `icon_uri`/`project_uri`,
-  non-holder rejected, non-bridge tokens rejected
-- Bridge token: create / mint / burn round-trip
-- Signature verification: invalid signature and wrong length both abort
-- **`init_transfer`** (7 tests): bridged-token burn, non-bridge-token lock,
-  origin nonce increment, paused, zero amount, fee≥amount, amount>u64::MAX
-- Decimal normalization cap
-
-## File References
-- Main contract: [sources/omni_bridge.move](sources/omni_bridge.move)
-- Bridge token: [sources/bridge_token.move](sources/bridge_token.move)
-- Payload types and Borsh: [sources/bridge_types.move](sources/bridge_types.move)
-- Borsh primitives: [sources/borsh.move](sources/borsh.move)
-- Signature verification: [sources/utils.move](sources/utils.move)

--- a/near/CLAUDE.md
+++ b/near/CLAUDE.md
@@ -22,37 +22,9 @@ make clippy-near                             # Clippy with pedantic mode
 make fmt-near                                # Check formatting
 ```
 
-## Workspace Structure
-
-```
-near/
-├── omni-bridge/       # Main bridge contract
-├── omni-types/        # Shared type definitions
-├── omni-token/        # NEP-141 bridged token implementation
-├── token-deployer/    # Token deployment factory
-├── omni-prover/
-│   ├── evm-prover/                    # EVM light client verification
-│   ├── wormhole-omni-prover-proxy/    # Wormhole VAA verification
-│   └── mpc-omni-prover/              # MPC read-RPC signature verification
-├── omni-tests/        # Integration tests (near-workspaces)
-└── mock/              # Test mocks
-```
-
 ## omni-bridge
 
-The main bridge contract handling cross-chain transfers. Key state in `Contract` struct:
-
-**Token Mappings:**
-- `token_id_to_address` - NEAR token ID → foreign chain address
-- `token_address_to_id` - Foreign address → NEAR token ID
-- `deployed_tokens` - Set of tokens deployed by bridge
-- `factories` - Bridge factory addresses per chain
-
-**Transfer State:**
-- `pending_transfers` - Transfers awaiting finalization
-- `finalised_transfers` - Completed transfer IDs
-- `fast_transfers` - Two-leg fast transfer status
-- `current_origin_nonce` / `destination_nonces` - Transfer sequencing
+The main bridge contract handling cross-chain transfers.
 
 **Key Functions:**
 - `ft_on_transfer()` - Entry point for bridging (receives NEP-141 transfer from token contract)
@@ -65,59 +37,6 @@ The main bridge contract handling cross-chain transfers. Key state in `Contract`
 **UTXO Support (btc.rs):**
 - `submit_transfer_to_utxo_chain_connector()` - Send to Bitcoin/Zcash (called by relayer)
 - `rbf_increase_gas_fee()` - Replace-by-fee for stuck BTC transactions (DAO/RbfOperator only)
-
-## omni-types
-
-Shared types library - defines core types used across all contracts.
-
-**Main types (lib.rs):**
-- `ChainKind` - Supported chains enum
-- `OmniAddress` - Unified address for any chain
-- `TransferId`, `TransferMessage` - Transfer identification and data
-- `Fee` - Token fee + native fee structure
-- `FastTransfer`, `FastTransferId` - Fast transfer types
-
-**Modules:**
-- `errors.rs` - Error types
-- `evm/` - EVM-specific types (BlockHeader, Receipt, LogEntry)
-- `prover_args.rs` - Prover input structs (`EvmVerifyProofArgs`, `WormholeVerifyProofArgs`, `MpcVerifyProofArgs`)
-- `prover_result.rs` - Prover verification results
-- `btc.rs` - Bitcoin/UTXO types
-- `locker_args.rs` - Function argument structs
-
-## omni-token
-
-NEP-141 fungible token contract for bridged tokens.
-
-**State:**
-```rust
-pub struct OmniToken {
-    pub controller: AccountId,  // Bridge contract - can mint/burn
-    pub token: FungibleToken,   // NEP-141 implementation
-    pub metadata: LazyOption<FungibleTokenMetadata>,
-}
-```
-
-**Traits:** FungibleTokenCore, FungibleTokenResolver, StorageManagement, FungibleTokenMetadataProvider
-
-**Custom Traits (omni_ft/):**
-- `MintAndBurn` - `mint()` / `burn()` (controller only)
-- `MetadataManagment` - `set_metadata()`
-
-## token-deployer
-
-Factory for deploying omni-token instances using NEAR global contracts.
-
-**State:**
-```rust
-pub struct TokenDeployer {
-    pub global_code_hash: CryptoHash,  // Hash of omni-token WASM
-}
-```
-
-**Key Method:** `deploy_token()` - Creates account, transfers deposit, deploys global contract, initializes token
-
-**Roles:** DAO, PauseManager, UpgradableCodeStager, UpgradableCodeDeployer, Controller, LegacyController
 
 ## omni-prover
 
@@ -162,20 +81,8 @@ Verifies foreign chain events by calling the NEAR MPC network's `verify_foreign_
 
 ## Code Style
 
-- Rust 2021 edition, 4-space indentation
-- Clippy pedantic mode (see `LINT_OPTIONS` in Makefile)
 - Test naming: `subject_action_expected` pattern
 - Commits: Conventional Commits (`feat:`, `fix:`, `chore:`)
-
-## Key Dependencies
-
-- `near-sdk`, `near-contract-standards` - Core NEAR SDK (versions defined in workspace Cargo.toml)
-- `near-plugins` - Access control (roles) and upgradeable patterns
-- `omni-utils` - Shared utilities (external repo)
-- `alloy` - EVM types and RLP encoding
-- `near-mpc-sdk` - MPC SDK for cross-contract calls to the MPC signer contract (used by mpc-omni-prover)
-- `contract-interface` - MPC network types from `github.com/near/mpc` (used by mpc-omni-prover via near-mpc-sdk)
-- `near-workspaces` - Integration testing
 
 ## Security Audit Notes
 

--- a/starknet/CLAUDE.md
+++ b/starknet/CLAUDE.md
@@ -9,18 +9,6 @@ Cross-chain bridge contract enabling token transfers between Starknet and other 
 - **Token Model**: Bridge-deployed tokens (mint/burn) or native tokens (lock/unlock)
 - **Access Control**: OpenZeppelin AccessControl with DEFAULT_ADMIN_ROLE and PAUSER_ROLE
 
-## Core Functions
-
-| Function | Purpose | Access |
-|----------|---------|--------|
-| `init_transfer` | Send tokens from Starknet to another chain | Public |
-| `fin_transfer` | Receive tokens from another chain (requires signature) | Public |
-| `deploy_token` | Deploy new bridged token (requires signature) | Public |
-| `log_metadata` | Log token metadata for indexers | Public |
-| `get_token_address` | Query deployed token by NEAR token ID | View |
-| `upgrade_token` | Upgrade deployed bridge token | Admin only |
-| `set_pause_flags` / `pause_all` | Pause operations | Admin/Pauser |
-
 ## Key Implementation Details
 
 ### Token Deployment
@@ -53,11 +41,3 @@ Cross-chain bridge contract enabling token transfers between Starknet and other 
 - ✅ Reentrancy safe (CEI pattern + nonce check)
 - ✅ Transfer success validation for all external ERC20 calls
 
-## Testing
-Run tests with `scarb test`
-
-## File References
-- Main contract: [src/omni_bridge.cairo](src/omni_bridge.cairo)
-- Bridge token: [src/bridge_token.cairo](src/bridge_token.cairo)
-- Type definitions: [src/bridge_types.cairo](src/bridge_types.cairo)
-- Borsh encoding: [src/utils/borsh.cairo](src/utils/borsh.cairo)


### PR DESCRIPTION
## What

Trims the per-chain `CLAUDE.md` files (`aptos/`, `near/`, `starknet/`) down to content a Claude session cannot derive from the code itself — 166 lines / ~9 KB removed (~2.2k est. tokens per session working under those directories). `evm/` and `solana/` were already lean and are untouched.

## Why

Surfaced by a `claude doctor` health-check run, which flagged these blocks as dead weight: every session pays for them while the code answers the same questions directly. The result aligns the files with Anthropic's context-engineering guidance for Claude 5-generation models — keep CLAUDE.md lightweight, spend the tokens on gotchas, and avoid stating what the model can discover from the file structure:
https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models

The repo's structure already follows the post's progressive-disclosure rule (no root CLAUDE.md; nested per-chain files load only when working under that directory), so this PR only removes the derivable content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)