### PR TITLE
chore: add events for grant/revoke roles & update readme 

### DIFF
--- a/aptos/README.md
+++ b/aptos/README.md
@@ -197,13 +197,23 @@ The remaining integration step is operational, not code:
 
 **Register the Aptos factory with the bridge contract on NEAR.** After
 deploying the Aptos package, call the bridge's `add_factory` admin function
-with the bridge object's address:
+with the **package address** (`@omni_bridge`) — the address the package was
+deployed under:
 
 ```bash
 near call omni.bridge.near add_factory \
-  '{"address": "aptos:0x<BRIDGE_OBJECT_ADDRESS>"}' \
+  '{"address": "aptos:0x<PACKAGE_ADDRESS>"}' \
   --accountId <dao-admin>
 ```
 
-`<BRIDGE_OBJECT_ADDRESS>` is the value returned by the
-`bridge_object_address()` view on the deployed Aptos package.
+`<PACKAGE_ADDRESS>` is the `<deployer-address>` you passed to
+`--named-addresses omni_bridge=…` at publish time. Every bridge event is
+declared in `omni_bridge::omni_bridge`, so its Move struct type tag
+carries the package address — that is the emitter the NEAR side extracts
+and matches against the registered factory.
+
+> **Do not register `bridge_object_address()`.** That view returns the
+> derived object address where `BridgeState` and locked-token custody
+> live; it never appears as an event emitter, so registering it as the
+> factory rejects every Aptos proof with `UnknownFactory` and silently
+> disables the Aptos-to-NEAR direction.

--- a/aptos/sources/omni_bridge.move
+++ b/aptos/sources/omni_bridge.move
@@ -185,6 +185,24 @@ module omni_bridge::omni_bridge {
         admin: address
     }
 
+    // Emitted on every `grant_role` call, including no-ops where `holder`
+    // already held `role`.
+    #[event]
+    struct RoleGranted has drop, store {
+        role: u8,
+        holder: address,
+        admin: address
+    }
+
+    // Emitted on every `revoke_role` call, including no-ops where `holder`
+    // did not hold `role`.
+    #[event]
+    struct RoleRevoked has drop, store {
+        role: u8,
+        holder: address,
+        admin: address
+    }
+
     // -------- Initialization --------
 
     /// Initialize the bridge. Callable exactly once by the module deployer.
@@ -254,6 +272,7 @@ module omni_bridge::omni_bridge {
         let state = &mut BridgeState[bridge_object_address()];
         assert_role(state, ROLE_ADMIN, admin, E_UNAUTHORIZED);
         add_role_holder(state, role, new_holder);
+        event::emit(RoleGranted { role, holder: new_holder, admin: admin.address_of() });
     }
 
     /// Remove `holder` from the set of `role` holders. No-op if the
@@ -266,6 +285,7 @@ module omni_bridge::omni_bridge {
         let state = &mut BridgeState[bridge_object_address()];
         assert_role(state, ROLE_ADMIN, admin, E_UNAUTHORIZED);
         remove_role_holder(state, role, holder);
+        event::emit(RoleRevoked { role, holder, admin: admin.address_of() });
     }
 
     public entry fun set_near_bridge_derived_address(


### PR DESCRIPTION
This pull request updates the `omni_bridge` Move module and clarifies the integration documentation for registering the Aptos factory with the NEAR bridge contract. The main changes are the addition of events for role management actions and an important correction to the registration process to avoid common integration errors.

**Role management events:**

* Added a `RoleGranted` event struct, emitted on every `grant_role` call (including no-ops), to record role assignments.
* Added a `RoleRevoked` event struct, emitted on every `revoke_role` call (including no-ops), to record role removals.
* Modified the `grant_role` function to emit the `RoleGranted` event after adding a role holder.
* Modified the `revoke_role` function to emit the `RoleRevoked` event after removing a role holder.

**Documentation and integration clarity:**

* Updated `aptos/README.md` to clarify that the NEAR bridge contract should be registered with the package address (not the bridge object address), and added a warning about the consequences of registering the wrong address.