### PR TITLE
chore: upgrade hyperliqued contract

### DIFF
--- a/evm/.openzeppelin/unknown-999.json
+++ b/evm/.openzeppelin/unknown-999.json
@@ -90,7 +90,7 @@
             "label": "multiTokens",
             "offset": 0,
             "slot": "8",
-            "type": "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)",
+            "type": "t_mapping(t_address,t_struct(MultiTokenInfo)9973_storage)",
             "contract": "OmniBridge",
             "src": "src/omni-bridge/contracts/OmniBridge.sol:48"
           },
@@ -106,7 +106,7 @@
             "label": "_wormhole",
             "offset": 0,
             "slot": "58",
-            "type": "t_contract(IWormhole)11143",
+            "type": "t_contract(IWormhole)11442",
             "contract": "OmniBridgeWormhole",
             "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:27"
           },
@@ -140,7 +140,7 @@
             "label": "bool",
             "numberOfBytes": "1"
           },
-          "t_contract(IWormhole)11143": {
+          "t_contract(IWormhole)11442": {
             "label": "contract IWormhole",
             "numberOfBytes": "20"
           },
@@ -156,7 +156,7 @@
             "label": "mapping(address => string)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_address,t_struct(MultiTokenInfo)9674_storage)": {
+          "t_mapping(t_address,t_struct(MultiTokenInfo)9973_storage)": {
             "label": "mapping(address => struct MultiTokenInfo)",
             "numberOfBytes": "32"
           },
@@ -176,7 +176,259 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(MultiTokenInfo)9674_storage": {
+          "t_struct(MultiTokenInfo)9973_storage": {
+            "label": "struct MultiTokenInfo",
+            "members": [
+              {
+                "label": "tokenAddress",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tokenId",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)27_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_struct(RoleData)27_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32"
+              }
+            ]
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)27_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xAfDa1b2ad1cFe85FdFD34cD87930Ff56f07CDbe3",
+        "0x047a5C612D1AF591065EF1e8f48dc9FbCE1773d9"
+      ]
+    },
+    "bb303034ab0fd2e664edc72a9744f8790c1a75106a1fb9da37a76d78849b6b61": {
+      "address": "0x4448cE24aa8CaAEE5C80E4D46D7494D3b3af9A67",
+      "txHash": "0xa26681715a5da975d7304da6ac43a21156ea56d34960718564b3303618814192",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "ethToNearToken",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_string_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:36"
+          },
+          {
+            "label": "nearToEthToken",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_string_memory_ptr,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:37"
+          },
+          {
+            "label": "isBridgeToken",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:38"
+          },
+          {
+            "label": "tokenImplementationAddress",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:40"
+          },
+          {
+            "label": "nearBridgeDerivedAddress",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_address",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:41"
+          },
+          {
+            "label": "omniBridgeChainId",
+            "offset": 20,
+            "slot": "4",
+            "type": "t_uint8",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:42"
+          },
+          {
+            "label": "completedTransfers",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint64,t_bool)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:44"
+          },
+          {
+            "label": "currentOriginNonce",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_uint64",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:45"
+          },
+          {
+            "label": "customMinters",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_address,t_address)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:47"
+          },
+          {
+            "label": "multiTokens",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_address,t_struct(MultiTokenInfo)12796_storage)",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:48"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OmniBridge",
+            "src": "src/omni-bridge/contracts/OmniBridge.sol:596"
+          },
+          {
+            "label": "_wormhole",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_contract(IWormhole)14283",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:27"
+          },
+          {
+            "label": "_consistencyLevel",
+            "offset": 20,
+            "slot": "58",
+            "type": "t_uint8",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:29"
+          },
+          {
+            "label": "wormholeNonce",
+            "offset": 21,
+            "slot": "58",
+            "type": "t_uint32",
+            "contract": "OmniBridgeWormhole",
+            "src": "src/omni-bridge/contracts/OmniBridgeWormhole.sol:30"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(IWormhole)14283": {
+            "label": "contract IWormhole",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_string_storage)": {
+            "label": "mapping(address => string)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_struct(MultiTokenInfo)12796_storage)": {
+            "label": "mapping(address => struct MultiTokenInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_string_memory_ptr,t_address)": {
+            "label": "mapping(string => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint64,t_bool)": {
+            "label": "mapping(uint64 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_string_memory_ptr": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(MultiTokenInfo)12796_storage": {
             "label": "struct MultiTokenInfo",
             "members": [
               {

--- a/evm/hardhat.config.ts
+++ b/evm/hardhat.config.ts
@@ -622,6 +622,14 @@ const config: HardhatUserConfig = {
           browserURL: "https://abscan.org",
         },
       },
+      {
+        network: "hyperEvmMainnet",
+        chainId: 999,
+        urls: {
+          apiURL: "https://api.etherscan.io/v2/api?chainid=999",
+          browserURL: "https://hyperevmscan.io",
+        },
+      },
     ],
   },
 }


### PR DESCRIPTION
This pull request updates the Hardhat configuration and the OpenZeppelin deployment metadata to support the HyperEVM Mainnet (chain ID 999) and to improve contract storage layout descriptions. The most important changes are summarized below.

**Support for HyperEVM Mainnet**

* Added a new network configuration for `hyperEvmMainnet` (chain ID 999) in `evm/hardhat.config.ts`, including API and block explorer URLs.

**OpenZeppelin Storage Layout Updates**

* Updated the `evm/.openzeppelin/unknown-999.json` file with:
  - New or revised type definitions for contract storage, including `MultiTokenInfo` and `IWormhole` types. [[1]](diffhunk://#diff-57c906884f52e47cfcd53b76624e88e5dbabb24f98edc1b653b39812787e73bbL93-R93) [[2]](diffhunk://#diff-57c906884f52e47cfcd53b76624e88e5dbabb24f98edc1b653b39812787e73bbL109-R109) [[3]](diffhunk://#diff-57c906884f52e47cfcd53b76624e88e5dbabb24f98edc1b653b39812787e73bbL143-R143) [[4]](diffhunk://#diff-57c906884f52e47cfcd53b76624e88e5dbabb24f98edc1b653b39812787e73bbL159-R159) [[5]](diffhunk://#diff-57c906884f52e47cfcd53b76624e88e5dbabb24f98edc1b653b39812787e73bbL179-R431)
  - Additional details for struct members, primitive types, and mappings, improving the accuracy and clarity of the storage layout for deployed contracts.
  - Inclusion of `erc7201` namespace entries for `AccessControlUpgradeable` and `Initializable` contracts.
  - Updated addresses and type references to match the latest deployments on chain 999.