### PR TITLE
feat(near): added sui support in mpc prover

### DIFF
--- a/near/CLAUDE.md
+++ b/near/CLAUDE.md
@@ -60,11 +60,11 @@ Proxy to Wormhole protocol for chains without light clients (Solana, BNB, EVM L2
 4. Return typed `ProverResult`
 
 ### mpc-omni-prover
-Verifies foreign chain events by calling the NEAR MPC network's `verify_foreign_transaction` API on-chain. The prover initiates the MPC verification as a cross-contract call and validates the response in a callback. Each deployed instance is configured for a specific chain and finality level via `MpcFinality`. Supports any chain supported by the MPC network (currently EVM chains and Starknet, extensible to others).
+Verifies foreign chain events by calling the NEAR MPC network's `verify_foreign_transaction` API on-chain. The prover initiates the MPC verification as a cross-contract call and validates the response in a callback. Each deployed instance is configured for a specific chain and finality level via `MpcFinality`. Supports any chain supported by the MPC network (currently EVM chains, Starknet, Aptos and Sui).
 
 **State:**
 - `mpc_contract_id` — AccountId of the MPC signer contract (e.g. `v1.signer`)
-- `finality` — `MpcFinality::Evm(EvmFinality)` or `MpcFinality::Starknet(StarknetFinality)`
+- `finalities` — `ChainKind -> MpcFinality` (`Evm` / `Starknet` / `Aptos` / `Sui`)
 - `chain_kind` — the chain this prover instance verifies
 
 **Flow:**
@@ -75,7 +75,11 @@ Verifies foreign chain events by calling the NEAR MPC network's `verify_foreign_
 5. In callback: verify `SHA-256(borsh(sign_payload)) == response.payload_hash`
 6. For EVM chains: extract the EVM log, convert to RLP, parse via `parse_evm_event`
 7. For Starknet: extract the Starknet log, parse via `parse_starknet_proof` (felt-based event decoding)
-8. Return typed `ProverResult`
+8. For Aptos: extract the Move event, parse its JSON `data` via `parse_aptos_proof`
+9. For Sui: extract the Move event, BCS-decode `event.bcs` via `parse_sui_proof`. The
+   emitter is the defining package id from `type_tag` (stable across package upgrades),
+   and each event's `token_address` is checked to equal `keccak256(coin_type)`
+10. Return typed `ProverResult`
 
 **Dependencies:** Uses `near-mpc-sdk` crate from the MPC repo (pinned git rev) for MPC types (`ForeignTxSignPayload`, `VerifyForeignTransactionRequestArgs`, `VerifyForeignTransactionResponse`, `EvmLog`, `StarknetLog`, etc.).
 

--- a/near/Cargo.lock
+++ b/near/Cargo.lock
@@ -2494,8 +2494,8 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.11.0"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+version = "3.13.0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "near-mpc-bounded-collections"
 version = "0.0.1"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "near-mpc-contract-interface"
 version = "0.0.1"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2774,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "near-mpc-crypto-types"
 version = "0.0.1"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "borsh",
  "bs58 0.5.1",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "near-mpc-sdk"
 version = "0.0.1"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "near-mpc-signature-verifier"
 version = "0.0.1"
-source = "git+https://github.com/near/mpc?rev=dcc9e042cad6784d33cfa736afb61b876a14ded0#dcc9e042cad6784d33cfa736afb61b876a14ded0"
+source = "git+https://github.com/near/mpc?rev=70c40b0f83143550c053a12cf446a87b3f324331#70c40b0f83143550c053a12cf446a87b3f324331"
 dependencies = [
  "near-mpc-contract-interface",
  "near-sdk",

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -54,4 +54,4 @@ sha3 = "0.10.0"
 sha2 = "0.10.0"
 k256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 rstest = "0.26.1"
-near-mpc-sdk = { git = "https://github.com/near/mpc", rev = "dcc9e042cad6784d33cfa736afb61b876a14ded0" }
+near-mpc-sdk = { git = "https://github.com/near/mpc", rev = "70c40b0f83143550c053a12cf446a87b3f324331" }

--- a/near/omni-prover/mpc-omni-prover/src/lib.rs
+++ b/near/omni-prover/mpc-omni-prover/src/lib.rs
@@ -10,8 +10,8 @@ use near_mpc_sdk::{
     near_mpc_contract_interface::types::{
         AptosExtractedValue, AptosFinality, EvmExtractedValue, EvmFinality, ExtractedValue,
         ForeignChainRpcRequest, ForeignTxSignPayload, ForeignTxSignPayloadV1,
-        StarknetExtractedValue, StarknetFinality, VerifyForeignTransactionRequestArgs,
-        VerifyForeignTransactionResponse,
+        StarknetExtractedValue, StarknetFinality, SuiExtractedValue, SuiFinality,
+        VerifyForeignTransactionRequestArgs, VerifyForeignTransactionResponse,
     },
     sign::DomainId,
 };
@@ -24,6 +24,7 @@ use omni_types::{
     prover_args::MpcVerifyProofArgs,
     prover_result::{ProofKind, ProverResult},
     starknet::events::parse_starknet_proof,
+    sui::events::parse_sui_proof,
     ChainKind,
 };
 use omni_utils::near_expect::NearExpect;
@@ -65,6 +66,7 @@ impl MpcOmniProver {
             ChainKind::Aptos,
             MpcFinality::Aptos(AptosFinality::Committed),
         );
+        finalities.insert(ChainKind::Sui, MpcFinality::Sui(SuiFinality::Checkpointed));
 
         Self {
             mpc_contract_id,
@@ -152,6 +154,7 @@ impl MpcOmniProver {
         match chain_kind {
             ChainKind::Strk => Self::parse_starknet_result(proof_kind, chain_kind, payload_v1),
             ChainKind::Aptos => Self::parse_aptos_result(proof_kind, payload_v1),
+            ChainKind::Sui => Self::parse_sui_result(proof_kind, payload_v1),
             _ => {
                 let log_entry_data = Self::extract_evm_log(payload_v1)?;
                 parse_evm_proof(proof_kind, chain_kind, log_entry_data)
@@ -165,6 +168,7 @@ impl MpcOmniProver {
             ForeignChainRpcRequest::Ethereum(_) => Some(ChainKind::Eth),
             ForeignChainRpcRequest::Starknet(_) => Some(ChainKind::Strk),
             ForeignChainRpcRequest::Aptos(_) => Some(ChainKind::Aptos),
+            ForeignChainRpcRequest::Sui(_) => Some(ChainKind::Sui),
             _ => None,
         }
     }
@@ -179,6 +183,9 @@ impl MpcOmniProver {
                 args.finality == *finality
             }
             (ForeignChainRpcRequest::Aptos(args), MpcFinality::Aptos(finality)) => {
+                args.finality == *finality
+            }
+            (ForeignChainRpcRequest::Sui(args), MpcFinality::Sui(finality)) => {
                 args.finality == *finality
             }
             _ => false,
@@ -235,6 +242,23 @@ impl MpcOmniProver {
         };
 
         parse_aptos_proof(kind, ChainKind::Aptos, &event.type_tag, &event.data)
+    }
+
+    fn parse_sui_result(
+        kind: ProofKind,
+        payload: &ForeignTxSignPayloadV1,
+    ) -> Result<ProverResult, String> {
+        if payload.values.len() != 1 {
+            return Err(ProverError::InvalidPayloadValuesLength.to_string());
+        }
+
+        let Some(ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(event))) =
+            payload.values.first()
+        else {
+            return Err(ProverError::InvalidProof.to_string());
+        };
+
+        parse_sui_proof(kind, ChainKind::Sui, &event.type_tag, &event.bcs)
     }
 }
 

--- a/near/omni-prover/mpc-omni-prover/src/tests.rs
+++ b/near/omni-prover/mpc-omni-prover/src/tests.rs
@@ -6,7 +6,8 @@ use near_mpc_sdk::near_mpc_contract_interface::types::{
     ExtractedValue, ForeignChainRpcRequest, ForeignTxSignPayload, ForeignTxSignPayloadV1, Hash160,
     Hash256, SolanaFinality, SolanaRpcRequest, SolanaTxId, StarknetExtractedValue,
     StarknetExtractor, StarknetFelt, StarknetFinality, StarknetLog, StarknetRpcRequest,
-    StarknetTxId,
+    StarknetTxId, SuiAddress, SuiEvent, SuiExtractedValue, SuiExtractor, SuiFinality,
+    SuiRpcRequest, SuiTxId,
 };
 
 use near_sdk::base64::Engine;
@@ -622,4 +623,136 @@ fn test_starknet_sepolia_verify_proof_args() {
     let base64_encoded = near_sdk::base64::engine::general_purpose::STANDARD.encode(&call_bytes);
 
     assert!(!base64_encoded.is_empty());
+}
+
+// -------- Sui --------
+
+/// Package id of the bridge deployment in the fixtures below.
+const SUI_PKG: &str = "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf";
+
+/// BCS of an `InitTransfer` event for coin type `<SUI_PKG>::token::TOKEN`
+/// (nonce 7, amount 1000, fee 10, native_fee 5, recipient near:frolik.testnet).
+const SUI_INIT_TRANSFER_BCS: &str = "111111111111111111111111111111111111111111111111111111111111111197f8c20b1395b10de4b6abba1504cf6481f696a1c1530a9c86bdb479eb19b4ab4e613061316132613361346135613661376138613961616162616361646165616662306231623262336234623562366237623862396261626262636264626562663a3a746f6b656e3a3a544f4b454e0700000000000000e80300000000000000000000000000000a00000000000000000000000000000005000000000000000000000000000000136e6561723a66726f6c696b2e746573746e657400";
+
+fn test_sui_request() -> SuiRpcRequest {
+    SuiRpcRequest {
+        tx_id: SuiTxId([0xdd; 32]),
+        finality: SuiFinality::Checkpointed,
+        extractors: vec![SuiExtractor::Event { event_index: 0 }],
+    }
+}
+
+fn sui_pkg_bytes() -> [u8; 32] {
+    hex::decode(SUI_PKG).unwrap().try_into().unwrap()
+}
+
+fn test_sui_init_transfer_event() -> SuiEvent {
+    SuiEvent {
+        package_id: SuiAddress(sui_pkg_bytes()),
+        transaction_module: "omni_bridge".to_string(),
+        sender: SuiAddress([0x11; 32]),
+        type_tag: format!("0x{SUI_PKG}::omni_bridge::InitTransfer"),
+        bcs: hex::decode(SUI_INIT_TRANSFER_BCS).unwrap(),
+    }
+}
+
+#[test]
+fn test_request_to_chain_kind_sui() {
+    let request = ForeignChainRpcRequest::Sui(test_sui_request());
+    assert_eq!(
+        MpcOmniProver::request_to_chain_kind(&request),
+        Some(ChainKind::Sui)
+    );
+}
+
+#[test]
+fn test_request_matches_finality_sui_match() {
+    let request = ForeignChainRpcRequest::Sui(test_sui_request());
+    assert!(MpcOmniProver::request_matches_finality(
+        &request,
+        &MpcFinality::Sui(SuiFinality::Checkpointed)
+    ));
+}
+
+#[test]
+fn test_request_matches_finality_sui_cross_chain_mismatch() {
+    let sui_request = ForeignChainRpcRequest::Sui(test_sui_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &sui_request,
+        &MpcFinality::Aptos(AptosFinality::Committed)
+    ));
+    let aptos_request = ForeignChainRpcRequest::Aptos(test_aptos_request());
+    assert!(!MpcOmniProver::request_matches_finality(
+        &aptos_request,
+        &MpcFinality::Sui(SuiFinality::Checkpointed)
+    ));
+}
+
+#[test]
+fn test_sui_sign_payload_roundtrip() {
+    let payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Sui(test_sui_request()),
+        values: vec![ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+            test_sui_init_transfer_event(),
+        ))],
+    });
+
+    let bytes = borsh::to_vec(&payload).unwrap();
+    let deserialized = ForeignTxSignPayload::try_from_slice(&bytes).unwrap();
+    assert_eq!(
+        payload.compute_msg_hash().unwrap().0,
+        deserialized.compute_msg_hash().unwrap().0
+    );
+}
+
+#[test]
+fn test_parse_sui_result_init_transfer() {
+    let payload = ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Sui(test_sui_request()),
+        values: vec![ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+            test_sui_init_transfer_event(),
+        ))],
+    };
+
+    let result = MpcOmniProver::parse_sui_result(ProofKind::InitTransfer, &payload).unwrap();
+    match result {
+        ProverResult::InitTransfer(m) => {
+            assert_eq!(m.origin_nonce, 7);
+            assert_eq!(m.amount.0, 1000);
+            assert_eq!(m.fee.fee.0, 10);
+            assert_eq!(m.fee.native_fee.0, 5);
+            assert_eq!(m.recipient.to_string(), "near:frolik.testnet");
+            // Emitter comes from the type_tag's defining package id, which is
+            // stable across bridge package upgrades (unlike event.package_id).
+            assert_eq!(m.emitter_address, OmniAddress::Sui(H256(sui_pkg_bytes())));
+        }
+        _ => panic!("expected InitTransfer"),
+    }
+}
+
+#[test]
+fn test_parse_sui_result_rejects_non_sui_value() {
+    let payload = ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Sui(test_sui_request()),
+        values: vec![ExtractedValue::EvmExtractedValue(EvmExtractedValue::Log(
+            test_evm_log(),
+        ))],
+    };
+    assert!(MpcOmniProver::parse_sui_result(ProofKind::InitTransfer, &payload).is_err());
+}
+
+#[test]
+fn test_parse_sui_result_rejects_multiple_values() {
+    let payload = ForeignTxSignPayloadV1 {
+        request: ForeignChainRpcRequest::Sui(test_sui_request()),
+        values: vec![
+            ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+                test_sui_init_transfer_event(),
+            )),
+            ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+                test_sui_init_transfer_event(),
+            )),
+        ],
+    };
+    assert!(MpcOmniProver::parse_sui_result(ProofKind::InitTransfer, &payload).is_err());
 }

--- a/near/omni-types/src/lib.rs
+++ b/near/omni-types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod prover_args;
 pub mod prover_result;
 pub mod sol_address;
 pub mod starknet;
+pub mod sui;
 pub mod utils;
 
 #[cfg(test)]

--- a/near/omni-types/src/mpc_types.rs
+++ b/near/omni-types/src/mpc_types.rs
@@ -1,16 +1,17 @@
 use near_mpc_sdk::{
     foreign_chain::starknet::StarknetFinality,
-    near_mpc_contract_interface::types::{AptosFinality, EvmFinality},
+    near_mpc_contract_interface::types::{AptosFinality, EvmFinality, SuiFinality},
 };
 use near_sdk::near;
 
-/// Finality enum that supports both EVM and Starknet chains.
+/// Per-chain finality level a `mpc-omni-prover` instance accepts.
 #[near(serializers = [borsh, json])]
 #[derive(Debug, Clone, PartialEq)]
 pub enum MpcFinality {
     Evm(EvmFinality),
     Starknet(StarknetFinality),
     Aptos(AptosFinality),
+    Sui(SuiFinality),
 }
 
 #[near(serializers = [json])]

--- a/near/omni-types/src/sui/bcs.rs
+++ b/near/omni-types/src/sui/bcs.rs
@@ -1,0 +1,183 @@
+//! Minimal BCS reader for Move event payloads.
+//!
+//! The MPC network delivers Sui events as raw BCS (`SuiEvent.bcs`) rather than
+//! a JSON rendering, so the layout is positional and must match the Move struct
+//! declaration field-for-field. `Reader::finish` rejects trailing bytes, which
+//! turns a layout mismatch into an error instead of a silent misparse.
+//!
+//! Only the types the omni-bridge Sui events use are supported. Note that BCS
+//! length prefixes are ULEB128, unlike Borsh's fixed u32.
+
+pub struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub const fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8], String> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or_else(|| "BCS: length overflow".to_string())?;
+        let slice = self
+            .buf
+            .get(self.pos..end)
+            .ok_or_else(|| format!("BCS: unexpected end of input (wanted {n} bytes)"))?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    pub fn u8(&mut self) -> Result<u8, String> {
+        Ok(self.take(1)?[0])
+    }
+
+    pub fn u64(&mut self) -> Result<u64, String> {
+        let bytes: [u8; 8] = self.take(8)?.try_into().map_err(|_| "BCS: bad u64")?;
+        Ok(u64::from_le_bytes(bytes))
+    }
+
+    pub fn u128(&mut self) -> Result<u128, String> {
+        let bytes: [u8; 16] = self.take(16)?.try_into().map_err(|_| "BCS: bad u128")?;
+        Ok(u128::from_le_bytes(bytes))
+    }
+
+    /// BCS sequence length: ULEB128-encoded `u32`, canonical form only.
+    pub fn uleb128(&mut self) -> Result<usize, String> {
+        let mut value: u64 = 0;
+        let mut shift = 0u32;
+        loop {
+            let byte = self.u8()?;
+            value |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                // Reject non-canonical encodings: a continuation must never be
+                // followed by a group that contributes nothing.
+                if shift > 0 && byte == 0 {
+                    return Err("BCS: non-canonical ULEB128".to_string());
+                }
+                if value > u64::from(u32::MAX) {
+                    return Err("BCS: ULEB128 exceeds u32".to_string());
+                }
+                return usize::try_from(value).map_err(|_| "BCS: length exceeds usize".to_string());
+            }
+            shift += 7;
+            if shift >= 32 {
+                return Err("BCS: ULEB128 too long".to_string());
+            }
+        }
+    }
+
+    /// Move `address` / Sui object id: 32 raw bytes, no length prefix.
+    pub fn address(&mut self) -> Result<[u8; 32], String> {
+        self.take(32)?
+            .try_into()
+            .map_err(|_| "BCS: address is not 32 bytes".to_string())
+    }
+
+    /// Move `vector<u8>`.
+    pub fn bytes(&mut self) -> Result<Vec<u8>, String> {
+        let len = self.uleb128()?;
+        Ok(self.take(len)?.to_vec())
+    }
+
+    /// Move `std::string::String` (a `vector<u8>` that must be valid UTF-8).
+    pub fn string(&mut self) -> Result<String, String> {
+        String::from_utf8(self.bytes()?).map_err(|e| format!("BCS: string is not UTF-8: {e}"))
+    }
+
+    /// Move `Option<T>`: a single tag byte, then the value if present.
+    pub fn option<T>(
+        &mut self,
+        read: impl FnOnce(&mut Self) -> Result<T, String>,
+    ) -> Result<Option<T>, String> {
+        match self.u8()? {
+            0 => Ok(None),
+            1 => read(self).map(Some),
+            tag => Err(format!("BCS: invalid Option tag {tag}")),
+        }
+    }
+
+    /// Fail if any bytes are left over.
+    pub fn finish(self) -> Result<(), String> {
+        if self.pos == self.buf.len() {
+            Ok(())
+        } else {
+            Err(format!(
+                "BCS: {} trailing byte(s) after event payload",
+                self.buf.len() - self.pos
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_scalars_and_sequences() {
+        // u8=1, u64=2, u128=3, string="hi", vector<u8>=[9,9], Option::Some("x")
+        let mut buf = vec![1u8];
+        buf.extend_from_slice(&2u64.to_le_bytes());
+        buf.extend_from_slice(&3u128.to_le_bytes());
+        buf.extend_from_slice(&[2, b'h', b'i']);
+        buf.extend_from_slice(&[2, 9, 9]);
+        buf.extend_from_slice(&[1, 1, b'x']);
+
+        let mut r = Reader::new(&buf);
+        assert_eq!(r.u8().unwrap(), 1);
+        assert_eq!(r.u64().unwrap(), 2);
+        assert_eq!(r.u128().unwrap(), 3);
+        assert_eq!(r.string().unwrap(), "hi");
+        assert_eq!(r.bytes().unwrap(), vec![9, 9]);
+        assert_eq!(r.option(Reader::string).unwrap(), Some("x".to_string()));
+        r.finish().unwrap();
+    }
+
+    #[test]
+    fn option_none_and_bad_tag() {
+        let mut r = Reader::new(&[0]);
+        assert_eq!(r.option(Reader::string).unwrap(), None);
+        r.finish().unwrap();
+
+        let mut r = Reader::new(&[2]);
+        assert!(r.option(Reader::string).is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        let mut r = Reader::new(&[1, 0xFF]);
+        assert_eq!(r.u8().unwrap(), 1);
+        assert!(r.finish().is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_input() {
+        let mut r = Reader::new(&[5, b'a']);
+        assert!(r.string().is_err());
+    }
+
+    #[test]
+    fn uleb128_canonical_only() {
+        // 0x80 0x01 == 128, canonical
+        let mut r = Reader::new(&[0x80, 0x01]);
+        assert_eq!(r.uleb128().unwrap(), 128);
+
+        // 0x80 0x00 encodes 0 with a redundant group -> rejected
+        let mut r = Reader::new(&[0x80, 0x00]);
+        assert!(r.uleb128().is_err());
+
+        // five continuation bytes overflow u32
+        let mut r = Reader::new(&[0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+        assert!(r.uleb128().is_err());
+    }
+
+    #[test]
+    fn rejects_non_utf8_string() {
+        let mut r = Reader::new(&[1, 0xFF]);
+        assert!(r.string().is_err());
+    }
+}

--- a/near/omni-types/src/sui/events.rs
+++ b/near/omni-types/src/sui/events.rs
@@ -1,0 +1,402 @@
+//! Sui Move event parsing for the MPC omni-prover.
+//!
+//! The MPC network delivers a Sui event as `SuiEvent { package_id,
+//! transaction_module, sender, type_tag, bcs }`. Unlike Aptos, whose `data` is a
+//! JSON rendering, `bcs` is the canonical BCS encoding of the Move struct — so
+//! parsing is positional and must mirror `sui/sources/omni_bridge.move`
+//! field-for-field. See [`crate::sui::bcs`].
+//!
+//! The emitter is taken from the address in `type_tag`, not from
+//! `SuiEvent.package_id`: a Move type keeps its *defining* package id across
+//! package upgrades, while `package_id` becomes the upgraded package's id. Only
+//! the former stays equal to the factory address registered on NEAR. Same rule
+//! as the Aptos type-tag-address convention.
+//!
+//! Sui coins are types rather than addresses, so every event carries both the
+//! 32-byte wire id and the `coin_type` string it was derived from; the parsers
+//! assert `keccak256(coin_type) == token_address` to bind the two.
+
+use near_sdk::json_types::U128;
+
+use crate::{
+    prover_result::{
+        DeployTokenMessage, FinTransferMessage, InitTransferMessage, LogMetadataMessage, ProofKind,
+        ProverResult,
+    },
+    stringify,
+    sui::bcs::Reader,
+    utils::keccak256,
+    ChainKind, Fee, OmniAddress, TransferId, H256,
+};
+
+/// Move struct-tag suffixes for the omni-bridge events. The leading
+/// `0x<package_id>` varies per deployment, so only the `module::Event` tail is
+/// fixed.
+const INIT_TRANSFER_TAG: &str = "::omni_bridge::InitTransfer";
+const FIN_TRANSFER_TAG: &str = "::omni_bridge::FinTransfer";
+const DEPLOY_TOKEN_TAG: &str = "::omni_bridge::DeployToken";
+const LOG_METADATA_TAG: &str = "::omni_bridge::LogMetadata";
+
+pub enum SuiBridgeEvent {
+    InitTransfer(InitTransferMessage),
+    FinTransfer(FinTransferMessage),
+    DeployToken(DeployTokenMessage),
+    LogMetadata(LogMetadataMessage),
+}
+
+/// Parses the defining-package address out of a Move struct tag
+/// (`0x<addr>::module::Event`). The MPC layer emits addresses in canonical long
+/// form, but short form is accepted and left-padded.
+fn type_tag_address(type_tag: &str) -> Result<[u8; 32], String> {
+    let addr = type_tag
+        .split("::")
+        .next()
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| format!("Sui event: type tag missing package address: '{type_tag}'"))?;
+    let stripped = addr.strip_prefix("0x").unwrap_or(addr);
+    if stripped.is_empty() || stripped.len() > 64 {
+        return Err(format!("Sui event: invalid package address '{addr}'"));
+    }
+    let padded = format!("{stripped:0>64}");
+    hex::decode(&padded)
+        .map_err(|e| format!("Sui event: invalid package address hex: {e}"))?
+        .try_into()
+        .map_err(|_| "Sui event: package address is not 32 bytes".to_string())
+}
+
+fn emitter(type_tag: &str, expected_suffix: &str, label: &str) -> Result<OmniAddress, String> {
+    if !type_tag.ends_with(expected_suffix) {
+        return Err(format!("{label}: unexpected type tag '{type_tag}'"));
+    }
+    Ok(OmniAddress::Sui(H256(type_tag_address(type_tag)?)))
+}
+
+/// Binds the 32-byte wire token id to the coin type string it is derived from.
+fn token_address(coin_type: &str, wire_id: [u8; 32], label: &str) -> Result<OmniAddress, String> {
+    if keccak256(coin_type.as_bytes()) != wire_id {
+        return Err(format!(
+            "{label}: token_address is not keccak256 of coin_type '{coin_type}'"
+        ));
+    }
+    Ok(OmniAddress::Sui(H256(wire_id)))
+}
+
+/// # Move layout
+/// ```text
+/// sender: address, token_address: address, coin_type: String,
+/// origin_nonce: u64, amount: u128, fee: u128, native_fee: u128,
+/// recipient: String, message: vector<u8>
+/// ```
+pub fn parse_init_transfer(type_tag: &str, bcs: &[u8]) -> Result<InitTransferMessage, String> {
+    let emitter_address = emitter(type_tag, INIT_TRANSFER_TAG, "InitTransfer")?;
+
+    let mut r = Reader::new(bcs);
+    let sender = OmniAddress::Sui(H256(r.address()?));
+    let token_wire_id = r.address()?;
+    let coin_type = r.string()?;
+    let origin_nonce = r.u64()?;
+    let amount = r.u128()?;
+    let fee = r.u128()?;
+    let native_fee = r.u128()?;
+    let recipient_str = r.string()?;
+    let message = r.bytes()?;
+    r.finish()?;
+
+    let token = token_address(&coin_type, token_wire_id, "InitTransfer")?;
+    let recipient: OmniAddress = recipient_str.parse().map_err(stringify)?;
+    let msg = String::from_utf8(message)
+        .map_err(|e| format!("InitTransfer: message is not valid UTF-8: {e}"))?;
+
+    Ok(InitTransferMessage {
+        origin_nonce,
+        token,
+        amount: U128(amount),
+        recipient,
+        fee: Fee {
+            fee: U128(fee),
+            native_fee: U128(native_fee),
+        },
+        sender,
+        msg,
+        emitter_address,
+    })
+}
+
+/// # Move layout
+/// ```text
+/// origin_chain: u8, origin_nonce: u64, token_address: address,
+/// coin_type: String, amount: u128, recipient: address,
+/// fee_recipient: Option<String>, message: vector<u8>
+/// ```
+pub fn parse_fin_transfer(type_tag: &str, bcs: &[u8]) -> Result<FinTransferMessage, String> {
+    let emitter_address = emitter(type_tag, FIN_TRANSFER_TAG, "FinTransfer")?;
+
+    let mut r = Reader::new(bcs);
+    let origin_chain = r.u8()?;
+    let origin_nonce = r.u64()?;
+    let token_wire_id = r.address()?;
+    let coin_type = r.string()?;
+    let amount = r.u128()?;
+    let _recipient = r.address()?;
+    let fee_recipient = r.option(Reader::string)?;
+    let _message = r.bytes()?;
+    r.finish()?;
+
+    token_address(&coin_type, token_wire_id, "FinTransfer")?;
+
+    Ok(FinTransferMessage {
+        transfer_id: TransferId {
+            origin_chain: origin_chain.try_into()?,
+            origin_nonce,
+        },
+        amount: U128(amount),
+        fee_recipient: fee_recipient.and_then(|s| s.parse().ok()),
+        emitter_address,
+    })
+}
+
+/// # Move layout
+/// ```text
+/// token_address: address, coin_type: String, near_token_id: String,
+/// name: String, symbol: String, decimals: u8, origin_decimals: u8
+/// ```
+pub fn parse_deploy_token(type_tag: &str, bcs: &[u8]) -> Result<DeployTokenMessage, String> {
+    let emitter_address = emitter(type_tag, DEPLOY_TOKEN_TAG, "DeployToken")?;
+
+    let mut r = Reader::new(bcs);
+    let token_wire_id = r.address()?;
+    let coin_type = r.string()?;
+    let near_token_id = r.string()?;
+    let _name = r.string()?;
+    let _symbol = r.string()?;
+    let decimals = r.u8()?;
+    let origin_decimals = r.u8()?;
+    r.finish()?;
+
+    Ok(DeployTokenMessage {
+        token: near_token_id.parse().map_err(stringify)?,
+        token_address: token_address(&coin_type, token_wire_id, "DeployToken")?,
+        decimals,
+        origin_decimals,
+        emitter_address,
+    })
+}
+
+/// # Move layout
+/// ```text
+/// token_address: address, coin_type: String, name: String,
+/// symbol: String, decimals: u8
+/// ```
+pub fn parse_log_metadata(type_tag: &str, bcs: &[u8]) -> Result<LogMetadataMessage, String> {
+    let emitter_address = emitter(type_tag, LOG_METADATA_TAG, "LogMetadata")?;
+
+    let mut r = Reader::new(bcs);
+    let token_wire_id = r.address()?;
+    let coin_type = r.string()?;
+    let name = r.string()?;
+    let symbol = r.string()?;
+    let decimals = r.u8()?;
+    r.finish()?;
+
+    Ok(LogMetadataMessage {
+        token_address: token_address(&coin_type, token_wire_id, "LogMetadata")?,
+        name,
+        symbol,
+        decimals,
+        emitter_address,
+    })
+}
+
+/// Dispatches on the event `type_tag`.
+pub fn parse_sui_event(type_tag: &str, bcs: &[u8]) -> Result<SuiBridgeEvent, String> {
+    if type_tag.ends_with(INIT_TRANSFER_TAG) {
+        parse_init_transfer(type_tag, bcs).map(SuiBridgeEvent::InitTransfer)
+    } else if type_tag.ends_with(FIN_TRANSFER_TAG) {
+        parse_fin_transfer(type_tag, bcs).map(SuiBridgeEvent::FinTransfer)
+    } else if type_tag.ends_with(DEPLOY_TOKEN_TAG) {
+        parse_deploy_token(type_tag, bcs).map(SuiBridgeEvent::DeployToken)
+    } else if type_tag.ends_with(LOG_METADATA_TAG) {
+        parse_log_metadata(type_tag, bcs).map(SuiBridgeEvent::LogMetadata)
+    } else {
+        Err(format!("Unknown Sui event type tag: '{type_tag}'"))
+    }
+}
+
+/// Dispatches on `ProofKind`, validating the event `type_tag` matches.
+pub fn parse_sui_proof(
+    kind: ProofKind,
+    _chain_kind: ChainKind,
+    type_tag: &str,
+    bcs: &[u8],
+) -> Result<ProverResult, String> {
+    match kind {
+        ProofKind::InitTransfer => {
+            parse_init_transfer(type_tag, bcs).map(ProverResult::InitTransfer)
+        }
+        ProofKind::FinTransfer => parse_fin_transfer(type_tag, bcs).map(ProverResult::FinTransfer),
+        ProofKind::DeployToken => parse_deploy_token(type_tag, bcs).map(ProverResult::DeployToken),
+        ProofKind::LogMetadata => parse_log_metadata(type_tag, bcs).map(ProverResult::LogMetadata),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Package id of the bridge deployment used in the type tags below.
+    const PKG: &str = "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf";
+
+    /// BCS payloads generated independently (see `sui/tests/vectors`-style
+    /// reference encoder) for the coin type
+    /// `<PKG>::token::TOKEN`, whose keccak256 is the `token_address` in each.
+    const INIT_TRANSFER_BCS: &str = "111111111111111111111111111111111111111111111111111111111111111197f8c20b1395b10de4b6abba1504cf6481f696a1c1530a9c86bdb479eb19b4ab4e613061316132613361346135613661376138613961616162616361646165616662306231623262336234623562366237623862396261626262636264626562663a3a746f6b656e3a3a544f4b454e0700000000000000e80300000000000000000000000000000a00000000000000000000000000000005000000000000000000000000000000136e6561723a66726f6c696b2e746573746e657400";
+    const FIN_TRANSFER_BCS: &str = "01630000000000000097f8c20b1395b10de4b6abba1504cf6481f696a1c1530a9c86bdb479eb19b4ab4e613061316132613361346135613661376138613961616162616361646165616662306231623262336234623562366237623862396261626262636264626562663a3a746f6b656e3a3a544f4b454efa0000000000000000000000000000002222222222222222222222222222222222222222222222222222222222222222010c72656c617965722e6e65617200";
+    const DEPLOY_TOKEN_BCS: &str = "97f8c20b1395b10de4b6abba1504cf6481f696a1c1530a9c86bdb479eb19b4ab4e613061316132613361346135613661376138613961616162616361646165616662306231623262336234623562366237623862396261626262636264626562663a3a746f6b656e3a3a544f4b454e0c777261702e746573746e65740c57726170706564204e45415205774e4541520918";
+    const LOG_METADATA_BCS: &str = "97f8c20b1395b10de4b6abba1504cf6481f696a1c1530a9c86bdb479eb19b4ab4e613061316132613361346135613661376138613961616162616361646165616662306231623262336234623562366237623862396261626262636264626562663a3a746f6b656e3a3a544f4b454e0c57726170706564204e45415205774e45415209";
+
+    fn bcs(hex_str: &str) -> Vec<u8> {
+        hex::decode(hex_str).unwrap()
+    }
+
+    fn tag(event: &str) -> String {
+        format!("0x{PKG}::omni_bridge::{event}")
+    }
+
+    fn pkg_bytes() -> [u8; 32] {
+        hex::decode(PKG).unwrap().try_into().unwrap()
+    }
+
+    /// The wire token id every vector uses: keccak256 of `<PKG>::token::TOKEN`.
+    fn token_wire_id() -> [u8; 32] {
+        keccak256(format!("{PKG}::token::TOKEN").as_bytes())
+    }
+
+    #[test]
+    fn parses_init_transfer() {
+        let msg = parse_init_transfer(&tag("InitTransfer"), &bcs(INIT_TRANSFER_BCS)).unwrap();
+        assert_eq!(msg.origin_nonce, 7);
+        assert_eq!(msg.amount.0, 1000);
+        assert_eq!(msg.fee.fee.0, 10);
+        assert_eq!(msg.fee.native_fee.0, 5);
+        assert_eq!(msg.msg, "");
+        assert_eq!(msg.sender, OmniAddress::Sui(H256([0x11; 32])));
+        assert_eq!(msg.token, OmniAddress::Sui(H256(token_wire_id())));
+        assert_eq!(msg.emitter_address, OmniAddress::Sui(H256(pkg_bytes())));
+        assert_eq!(msg.recipient.to_string(), "near:frolik.testnet");
+    }
+
+    #[test]
+    fn parses_fin_transfer() {
+        let msg = parse_fin_transfer(&tag("FinTransfer"), &bcs(FIN_TRANSFER_BCS)).unwrap();
+        // origin_chain byte 1 == ChainKind::Near: a NEAR-originated transfer.
+        assert_eq!(msg.transfer_id.origin_chain, ChainKind::Near);
+        assert_eq!(msg.transfer_id.origin_nonce, 99);
+        assert_eq!(msg.amount.0, 250);
+        assert_eq!(msg.fee_recipient.unwrap().to_string(), "relayer.near");
+        assert_eq!(msg.emitter_address, OmniAddress::Sui(H256(pkg_bytes())));
+    }
+
+    #[test]
+    fn parses_deploy_token() {
+        let msg = parse_deploy_token(&tag("DeployToken"), &bcs(DEPLOY_TOKEN_BCS)).unwrap();
+        assert_eq!(msg.token.to_string(), "wrap.testnet");
+        assert_eq!(msg.decimals, 9);
+        assert_eq!(msg.origin_decimals, 24);
+        assert_eq!(msg.token_address, OmniAddress::Sui(H256(token_wire_id())));
+        assert_eq!(msg.emitter_address, OmniAddress::Sui(H256(pkg_bytes())));
+    }
+
+    #[test]
+    fn parses_log_metadata() {
+        let msg = parse_log_metadata(&tag("LogMetadata"), &bcs(LOG_METADATA_BCS)).unwrap();
+        assert_eq!(msg.name, "Wrapped NEAR");
+        assert_eq!(msg.symbol, "wNEAR");
+        assert_eq!(msg.decimals, 9);
+        assert_eq!(msg.token_address, OmniAddress::Sui(H256(token_wire_id())));
+    }
+
+    #[test]
+    fn dispatches_on_type_tag() {
+        assert!(matches!(
+            parse_sui_event(&tag("InitTransfer"), &bcs(INIT_TRANSFER_BCS)).unwrap(),
+            SuiBridgeEvent::InitTransfer(_)
+        ));
+        assert!(matches!(
+            parse_sui_event(&tag("FinTransfer"), &bcs(FIN_TRANSFER_BCS)).unwrap(),
+            SuiBridgeEvent::FinTransfer(_)
+        ));
+        assert!(matches!(
+            parse_sui_event(&tag("DeployToken"), &bcs(DEPLOY_TOKEN_BCS)).unwrap(),
+            SuiBridgeEvent::DeployToken(_)
+        ));
+        assert!(matches!(
+            parse_sui_event(&tag("LogMetadata"), &bcs(LOG_METADATA_BCS)).unwrap(),
+            SuiBridgeEvent::LogMetadata(_)
+        ));
+        assert!(parse_sui_event(&tag("Unknown"), &bcs(LOG_METADATA_BCS)).is_err());
+    }
+
+    #[test]
+    fn proof_kind_must_match_type_tag() {
+        // A LogMetadata payload submitted as an InitTransfer proof is rejected
+        // on the type tag, not silently misparsed.
+        assert!(parse_sui_proof(
+            ProofKind::InitTransfer,
+            ChainKind::Sui,
+            &tag("LogMetadata"),
+            &bcs(LOG_METADATA_BCS),
+        )
+        .is_err());
+        assert!(parse_sui_proof(
+            ProofKind::LogMetadata,
+            ChainKind::Sui,
+            &tag("LogMetadata"),
+            &bcs(LOG_METADATA_BCS),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_event_type_tag() {
+        assert!(parse_init_transfer(&tag("LogMetadata"), &bcs(INIT_TRANSFER_BCS)).is_err());
+    }
+
+    #[test]
+    fn rejects_token_address_not_matching_coin_type() {
+        // Flip one byte of the 32-byte token id (offset 32 in InitTransfer,
+        // right after `sender`) so it no longer equals keccak256(coin_type).
+        let mut payload = bcs(INIT_TRANSFER_BCS);
+        payload[32] ^= 0x01;
+        let err = parse_init_transfer(&tag("InitTransfer"), &payload).unwrap_err();
+        assert!(err.contains("keccak256 of coin_type"), "{err}");
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        let mut payload = bcs(LOG_METADATA_BCS);
+        payload.push(0);
+        assert!(parse_log_metadata(&tag("LogMetadata"), &payload).is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_payload() {
+        let payload = bcs(LOG_METADATA_BCS);
+        assert!(parse_log_metadata(&tag("LogMetadata"), &payload[..payload.len() - 1]).is_err());
+    }
+
+    #[test]
+    fn emitter_accepts_short_form_address() {
+        // Short-form package address is left-padded, matching the Aptos rule.
+        let short = "0x2::omni_bridge::LogMetadata";
+        let mut expected = [0u8; 32];
+        expected[31] = 2;
+        assert_eq!(type_tag_address(short).unwrap(), expected);
+    }
+
+    #[test]
+    fn rejects_malformed_type_tag_address() {
+        assert!(type_tag_address("::omni_bridge::LogMetadata").is_err());
+        assert!(type_tag_address("0xZZ::omni_bridge::LogMetadata").is_err());
+        assert!(type_tag_address(&format!("0x{}::a::B", "f".repeat(65))).is_err());
+    }
+}

--- a/near/omni-types/src/sui/mod.rs
+++ b/near/omni-types/src/sui/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod bcs;
+pub mod events;

--- a/sui/README.md
+++ b/sui/README.md
@@ -182,14 +182,17 @@ Mirroring the Aptos rollout (PRs #626 / #629):
   keccak constant above), the origin-chain token-prefix match in
   `omni-bridge`, and the enum-stability tests.
 
+- **Done**: the MPC prover path — `near/omni-types/src/sui/events.rs`
+  parsers (BCS, not JSON: the MPC layer delivers `SuiEvent.bcs`),
+  `MpcFinality::Sui(SuiFinality::Checkpointed)`, and the `ChainKind::Sui`
+  dispatch in `mpc-omni-prover`. Requires `near-mpc-sdk` at a rev that
+  includes near/mpc#3754 (the Sui contract-interface DTOs); the pin was
+  bumped to `70c40b0f`.
+
 Remaining follow-ups:
 
-- `near/omni-types/src/sui/events.rs` parsers — blocked on near/mpc
-  defining the Sui read support (`SuiRpcRequest` / `SuiExtractedValue` /
-  `SuiFinality`), which does not exist yet as of 2026-07.
-  The emitter for the factory check should be the event type's
-  **defining package id** parsed from the event type tag (stable across
-  package upgrades), analogous to the Aptos type-tag-address rule.
-- `MpcFinality::Sui` + dispatch in `mpc-omni-prover`.
 - DAO calls: `add_factory(OmniAddress::Sui(...))`, `add_prover`,
   `add_token_deployer`, `deploy_native_token` for wrapped SUI.
+- Deploy an `mpc-omni-prover` instance for Sui and confirm the MPC network
+  has Sui providers configured (near/mpc#3755 ships the node-side
+  inspector, which reads Sui over gRPC — Sui deprecated JSON-RPC).


### PR DESCRIPTION
## Summary

Adds the NEAR-side prover path for Sui, so `InitTransfer` / `FinTransfer` /
`DeployToken` / `LogMetadata` events emitted by the Sui locker can be proven
back to NEAR. This was the last code blocker listed in `sui/README.md`;
everything remaining after this is DAO calls and deployment.

Mirrors the Aptos rollout.

## What's included

- **`near/omni-types/src/sui/events.rs`** — parsers for the four bridge
  events, plus `parse_sui_event` / `parse_sui_proof` dispatch.
- **`near/omni-types/src/sui/bcs.rs`** — minimal BCS reader (no new deps).
- **`MpcFinality::Sui(SuiFinality::Checkpointed)`** and the `ChainKind::Sui`
  arm in `mpc-omni-prover` (`request_to_chain_kind`,
  `request_matches_finality`, `verify_callback`, seeded in `init`).
- **`near-mpc-sdk` rev bump** `dcc9e042` -> `70c40b0f` (merge commit of
  near/mpc#3754, which adds the Sui contract-interface DTOs). The old pin has
  no Sui types at all. Verified no breaking changes for EVM / Starknet /
  Aptos.

## Two things worth reviewing closely

**1. BCS, not JSON.** Aptos delivers `AptosEvent.data` as a JSON rendering;
Sui delivers `SuiEvent.bcs` as canonical BCS bytes. Parsing is therefore
positional and must match the Move struct declaration field-for-field — note
the Sui events carry an extra `coin_type: String` between `token_address` and
the numeric fields, which Aptos does not have.

Two guards make a layout mistake loud instead of silent:
  - `Reader::finish()` rejects trailing bytes, so a wrong field order fails
    rather than producing a plausible-looking wrong value;
  - ULEB128 lengths are canonical-only (BCS uses ULEB128 where Borsh uses a
    fixed u32 — easy to get wrong).

**2. Emitter comes from `type_tag`, not `event.package_id`.** A Move type
keeps its *defining* package id across package upgrades, while `package_id`
becomes the upgraded package's id. Only the former stays equal to the factory
address registered on NEAR, so this survives a bridge package upgrade. Same
rule as the Aptos type-tag-address convention.

## One extra check Aptos can't do

Sui coins are types, so every event carries both the 32-byte wire id and the
`coin_type` string it derives from. The parsers assert
`keccak256(coin_type) == token_address`, binding the two representations.

## Tests

113 passing (+25): 77 in `omni-types`, 36 in `mpc-omni-prover`.

BCS fixtures are generated by an independent Python reference encoder, so the
tests don't just assert the Rust against itself. Coverage: all four events,
tag dispatch, proof-kind/tag mismatch, the keccak binding (flip one byte of
the token id), trailing and truncated payloads, short-form addresses,
malformed tags, non-canonical ULEB128, non-UTF-8 strings, and the
prover-level dispatch/finality/roundtrip cases mirroring Aptos.

Verified: `cargo test`, `make clippy-near` (pedantic, `-D warnings`),
`make fmt-near`, and `cargo check --target wasm32-unknown-unknown`.
