### PR TITLE
HyperCore->Near two step v2

### DIFF
--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -4,15 +4,15 @@ pragma solidity ^0.8.24;
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {BridgeToken} from "./BridgeToken.sol";
 
-interface IOmniBridgeInitTransfer {
-    function initTransfer(
-        address tokenAddress,
+interface IOmniBridgeQueueInitTransfer {
+    function queueInitTransfer(
+        address sender,
+        uint64 coreNonce,
         uint128 amount,
         uint128 fee,
-        uint128 nativeFee,
         string calldata recipient,
         string calldata message
-    ) external payable;
+    ) external returns (uint64 originNonce);
 }
 
 interface ICoreReceiveWithData {
@@ -39,18 +39,6 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     uint8 public constant ACTION_TRANSFER = 0;
     uint8 public constant ACTION_INIT_TRANSFER = 1;
 
-    /// @notice Id of the next transfer to be committed. Also the relayer's cursor:
-    /// commitments are enumerable by reading this and walking the ids it has not
-    /// submitted yet, which is the only discovery path that does not depend on the
-    /// callback's logs (see `coreReceiveWithData`).
-    uint256 public nextPendingInitTransferId;
-
-    /// @notice id => keccak256(abi.encode(sender, coreNonce, amount, fee, recipient,
-    /// message)) of a transfer awaiting submission; zero means none. Keyed by our own
-    /// counter rather than by `coreNonce`, which HyperCore sequences per sender and
-    /// so does not identify a transfer on its own.
-    mapping(uint256 => bytes32) public pendingInitTransfers;
-
     event CoreReceived(
         address indexed sender,
         uint8 indexed action,
@@ -59,23 +47,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         bytes data
     );
 
-    /// @notice Carries the full record behind a commitment — the canonical source
-    /// for the values a submitter must hand back to `triggerPendingInitTransfer`.
-    event PreInitTransfer(
-        uint256 indexed id,
-        address indexed sender,
-        uint64 indexed coreNonce,
-        uint128 amount,
-        uint128 fee,
-        string recipient,
-        string message
-    );
-
     error NotSystemAddress();
     error EmptyActionData();
     error UnknownAction(uint8 action);
-    error PendingInitTransferNotFound(uint256 id);
-    error PayloadMismatch(uint256 id);
     error InvalidRecipient();
 
     function initialize(
@@ -166,10 +140,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     }
 
     /// @dev Decodes eagerly so a malformed payload reverts while the transfer is
-    /// still atomic with the HyperCore debit. Storing only the commitment keeps this
-    /// callback's storage cost at one slot regardless of payload length, so an
-    /// oversized `message` cannot push it past the HyperEVM small-block gas limit —
-    /// a revert there would strand the tokens on HyperCore with no way to retry.
+    /// still atomic with the HyperCore debit. The commitment itself lives on the
+    /// bridge, keyed by `originNonce`: one contract to monitor instead of one per
+    /// token, and this contract keeps no storage of its own for the flow.
     function _queueInitTransfer(
         address from,
         uint64 coreNonce,
@@ -179,8 +152,7 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         (uint128 fee, string memory recipient, string memory message) = abi
             .decode(tail, (uint128, string, string));
 
-        uint256 id = nextPendingInitTransferId++;
-        pendingInitTransfers[id] = _initTransferCommitment(
+        IOmniBridgeQueueInitTransfer(owner()).queueInitTransfer(
             from,
             coreNonce,
             amount128,
@@ -188,77 +160,5 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
             recipient,
             message
         );
-
-        emit PreInitTransfer(
-            id,
-            from,
-            coreNonce,
-            amount128,
-            fee,
-            recipient,
-            message
-        );
-    }
-
-    /// @notice Submits a committed HyperCore-originated transfer to OmniBridge.
-    /// Permissionless — the commitment is the only authority needed, so a stuck
-    /// transfer is never operator-gated. Arguments must hash to the commitment.
-    /// @dev Deleting before the external call is both the reentrancy and the replay
-    /// guard. If `initTransfer` reverts the delete rolls back with it, so a transient
-    /// bridge failure leaves the transfer retryable rather than burning it.
-    function triggerPendingInitTransfer(
-        uint256 id,
-        address sender,
-        uint64 coreNonce,
-        uint128 amount,
-        uint128 fee,
-        string calldata recipient,
-        string calldata message
-    ) external {
-        bytes32 committed = pendingInitTransfers[id];
-        if (committed == bytes32(0)) {
-            revert PendingInitTransferNotFound(id);
-        }
-        if (
-            committed !=
-            _initTransferCommitment(
-                sender,
-                coreNonce,
-                amount,
-                fee,
-                recipient,
-                message
-            )
-        ) {
-            revert PayloadMismatch(id);
-        }
-
-        delete pendingInitTransfers[id];
-
-        IOmniBridgeInitTransfer(owner()).initTransfer(
-            address(this),
-            amount,
-            fee,
-            0,
-            recipient,
-            message
-        );
-    }
-
-    /// @dev `abi.encode`, not `encodePacked`: two adjacent dynamic strings would let
-    /// a packed encoding collide (`"ab" + "c"` vs `"a" + "bc"`), which here would
-    /// mean submitting a different recipient than the one HyperCore committed to.
-    function _initTransferCommitment(
-        address sender,
-        uint64 coreNonce,
-        uint128 amount,
-        uint128 fee,
-        string memory recipient,
-        string memory message
-    ) private pure returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(sender, coreNonce, amount, fee, recipient, message)
-            );
     }
 }

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -39,6 +39,10 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     uint8 public constant ACTION_TRANSFER = 0;
     uint8 public constant ACTION_INIT_TRANSFER = 1;
 
+    /// @notice coreNonce => keccak256(abi.encode(sender, coreNonce, amount, fee,
+    /// recipient, message)) of a transfer awaiting submission; zero means none.
+    mapping(uint64 => bytes32) public pendingInitTransfers;
+
     event CoreReceived(
         address indexed sender,
         uint8 indexed action,
@@ -47,9 +51,23 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         bytes data
     );
 
+    /// @notice Carries the full record behind a commitment — the canonical source
+    /// for the values a submitter must hand back to `triggerPendingInitTransfer`.
+    event PreInitTransfer(
+        uint64 indexed coreNonce,
+        address indexed sender,
+        uint128 amount,
+        uint128 fee,
+        string recipient,
+        string message
+    );
+
     error NotSystemAddress();
     error EmptyActionData();
     error UnknownAction(uint8 action);
+    error PendingInitTransferNotFound(uint64 coreNonce);
+    error PayloadMismatch(uint64 coreNonce);
+    error DuplicateCoreNonce(uint64 coreNonce);
 
     function initialize(
         string memory name_,
@@ -85,26 +103,27 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
 
     /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
     /// HyperCore user triggers `sendToEvmWithData` targeting this token.
-    /// `destinationRecipient` and `destinationChainId` are unused here; all routing
-    /// info comes from `data`. `coreNonce` is the HyperCore-side sequence number,
-    /// re-emitted in `CoreReceived` for off-chain correlation with the HL event.
+    /// `destinationRecipient` and `destinationChainId` are unused; all routing info
+    /// comes from `data`. `coreNonce` is the HyperCore-side sequence number and
+    /// doubles as the key of the pending-transfer commitment.
     /// @dev Accounting model: the 3-arg `mint` parks HyperCore-bound tokens at
     /// `_systemAddress`, so that account holds the standing pool that mirrors total
     /// HyperCore-side balance. HyperLiquid does NOT pre-transfer tokens before this
-    /// call fires (the HL system address holds no real ERC20 balance — Circle's
-    /// CoreDepositWallet pattern shows the same, with its own pool at `address(this)`).
-    /// We pull from `_systemAddress` ourselves; an insufficient pool is a safe revert
-    /// that signals an accounting drift between HyperCore and HyperEVM.
+    /// call fires, so we pull from `_systemAddress` ourselves; an insufficient pool
+    /// is a safe revert that signals accounting drift between HyperCore and HyperEVM.
     ///
     /// Dispatch:
-    /// - data == 0x00 || abi.encode(address recipient): release `amount` from the
-    ///   pool to the HyperEVM `recipient`.
-    /// - data == 0x01 || abi.encode(uint128 fee, string recipient, string message):
-    ///   move `amount` from the pool to this contract, then bridge via
-    ///   OmniBridge.initTransfer (which burns from `address(this)`). `recipient` is an
-    ///   OmniAddress string (e.g. `near:alice.near`, `sol:<base58>`). nativeFee = 0.
-    /// The emitted InitTransfer event will carry `sender = address(this)`; the NEAR
-    /// side cannot recover the originating HyperCore user (`from`) from this path.
+    /// - 0x00 || abi.encode(address recipient): release `amount` from the pool to
+    ///   the HyperEVM `recipient`.
+    /// - 0x01 || abi.encode(uint128 fee, string recipient, string message): move
+    ///   `amount` from the pool to this contract and commit it under `coreNonce`.
+    ///   `initTransfer` is NOT called inline: this call's logs are absent from the
+    ///   block's `logsBloom` (HyperCore system tx) and thus invisible to filtered
+    ///   `eth_getLogs`/`eth_subscribe` watchers (Wormhole guardians, our indexer).
+    ///   `triggerPendingInitTransfer` submits it later from a normal tx.
+    ///   `recipient` is an OmniAddress string (e.g. `near:alice.near`); nativeFee = 0.
+    ///   The resulting InitTransfer event carries `sender = address(this)`, so the
+    ///   NEAR side cannot recover the originating HyperCore user from this path.
     function coreReceiveWithData(
         address from,
         bytes32 /*destinationRecipient*/,
@@ -123,22 +142,113 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
             address recipient = abi.decode(tail, (address));
             _update(_systemAddress, recipient, amount);
         } else if (action == ACTION_INIT_TRANSFER) {
-            (uint128 fee, string memory recipient, string memory message) = abi
-                .decode(tail, (uint128, string, string));
             uint128 amount128 = amount.toUint128();
             _update(_systemAddress, address(this), amount);
-            IOmniBridgeInitTransfer(owner()).initTransfer(
-                address(this),
-                amount128,
-                fee,
-                0,
-                recipient,
-                message
-            );
+            _queueInitTransfer(from, coreNonce, amount128, tail);
         } else {
             revert UnknownAction(action);
         }
 
         emit CoreReceived(from, action, coreNonce, amount, data);
+    }
+
+    /// @dev Decodes eagerly so a malformed payload reverts while the transfer is
+    /// still atomic with the HyperCore debit. Storing only the commitment keeps this
+    /// callback's storage cost at one slot regardless of payload length, so an
+    /// oversized `message` cannot push it past the HyperEVM small-block gas limit —
+    /// a revert there would strand the tokens on HyperCore with no way to retry.
+    function _queueInitTransfer(
+        address from,
+        uint64 coreNonce,
+        uint128 amount128,
+        bytes calldata tail
+    ) private {
+        (uint128 fee, string memory recipient, string memory message) = abi
+            .decode(tail, (uint128, string, string));
+
+        // Overwriting a live commitment would make the first transfer unclaimable
+        // while its tokens already sit at address(this).
+        if (pendingInitTransfers[coreNonce] != bytes32(0)) {
+            revert DuplicateCoreNonce(coreNonce);
+        }
+
+        pendingInitTransfers[coreNonce] = _initTransferCommitment(
+            from,
+            coreNonce,
+            amount128,
+            fee,
+            recipient,
+            message
+        );
+
+        emit PreInitTransfer(
+            coreNonce,
+            from,
+            amount128,
+            fee,
+            recipient,
+            message
+        );
+    }
+
+    /// @notice Submits a committed HyperCore-originated transfer to OmniBridge.
+    /// Permissionless — the commitment is the only authority needed, so a stuck
+    /// transfer is never operator-gated. Arguments must hash to the commitment.
+    /// @dev Deleting before the external call is both the reentrancy and the replay
+    /// guard. If `initTransfer` reverts the delete rolls back with it, so a transient
+    /// bridge failure leaves the transfer retryable rather than burning it.
+    function triggerPendingInitTransfer(
+        address sender,
+        uint64 coreNonce,
+        uint128 amount,
+        uint128 fee,
+        string calldata recipient,
+        string calldata message
+    ) external {
+        bytes32 committed = pendingInitTransfers[coreNonce];
+        if (committed == bytes32(0)) {
+            revert PendingInitTransferNotFound(coreNonce);
+        }
+        if (
+            committed !=
+            _initTransferCommitment(
+                sender,
+                coreNonce,
+                amount,
+                fee,
+                recipient,
+                message
+            )
+        ) {
+            revert PayloadMismatch(coreNonce);
+        }
+
+        delete pendingInitTransfers[coreNonce];
+
+        IOmniBridgeInitTransfer(owner()).initTransfer(
+            address(this),
+            amount,
+            fee,
+            0,
+            recipient,
+            message
+        );
+    }
+
+    /// @dev `abi.encode`, not `encodePacked`: two adjacent dynamic strings would let
+    /// a packed encoding collide (`"ab" + "c"` vs `"a" + "bc"`), which here would
+    /// mean submitting a different recipient than the one HyperCore committed to.
+    function _initTransferCommitment(
+        address sender,
+        uint64 coreNonce,
+        uint128 amount,
+        uint128 fee,
+        string memory recipient,
+        string memory message
+    ) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(sender, coreNonce, amount, fee, recipient, message)
+            );
     }
 }

--- a/evm/src/omni-bridge/contracts/HlBridgeToken.sol
+++ b/evm/src/omni-bridge/contracts/HlBridgeToken.sol
@@ -39,9 +39,17 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     uint8 public constant ACTION_TRANSFER = 0;
     uint8 public constant ACTION_INIT_TRANSFER = 1;
 
-    /// @notice coreNonce => keccak256(abi.encode(sender, coreNonce, amount, fee,
-    /// recipient, message)) of a transfer awaiting submission; zero means none.
-    mapping(uint64 => bytes32) public pendingInitTransfers;
+    /// @notice Id of the next transfer to be committed. Also the relayer's cursor:
+    /// commitments are enumerable by reading this and walking the ids it has not
+    /// submitted yet, which is the only discovery path that does not depend on the
+    /// callback's logs (see `coreReceiveWithData`).
+    uint256 public nextPendingInitTransferId;
+
+    /// @notice id => keccak256(abi.encode(sender, coreNonce, amount, fee, recipient,
+    /// message)) of a transfer awaiting submission; zero means none. Keyed by our own
+    /// counter rather than by `coreNonce`, which HyperCore sequences per sender and
+    /// so does not identify a transfer on its own.
+    mapping(uint256 => bytes32) public pendingInitTransfers;
 
     event CoreReceived(
         address indexed sender,
@@ -54,8 +62,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     /// @notice Carries the full record behind a commitment — the canonical source
     /// for the values a submitter must hand back to `triggerPendingInitTransfer`.
     event PreInitTransfer(
-        uint64 indexed coreNonce,
+        uint256 indexed id,
         address indexed sender,
+        uint64 indexed coreNonce,
         uint128 amount,
         uint128 fee,
         string recipient,
@@ -65,9 +74,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     error NotSystemAddress();
     error EmptyActionData();
     error UnknownAction(uint8 action);
-    error PendingInitTransferNotFound(uint64 coreNonce);
-    error PayloadMismatch(uint64 coreNonce);
-    error DuplicateCoreNonce(uint64 coreNonce);
+    error PendingInitTransferNotFound(uint256 id);
+    error PayloadMismatch(uint256 id);
+    error InvalidRecipient();
 
     function initialize(
         string memory name_,
@@ -104,8 +113,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     /// @notice HyperCore -> HyperEVM callback invoked by the system address when a
     /// HyperCore user triggers `sendToEvmWithData` targeting this token.
     /// `destinationRecipient` and `destinationChainId` are unused; all routing info
-    /// comes from `data`. `coreNonce` is the HyperCore-side sequence number and
-    /// doubles as the key of the pending-transfer commitment.
+    /// comes from `data`. `coreNonce` is the HyperCore-side sequence number, kept
+    /// for correlation with the HL action; it is sequenced per sender and so is not
+    /// used as a key.
     /// @dev Accounting model: the 3-arg `mint` parks HyperCore-bound tokens at
     /// `_systemAddress`, so that account holds the standing pool that mirrors total
     /// HyperCore-side balance. HyperLiquid does NOT pre-transfer tokens before this
@@ -140,6 +150,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
 
         if (action == ACTION_TRANSFER) {
             address recipient = abi.decode(tail, (address));
+            // _update to address(0) burns instead of transferring, silently
+            // dropping tokens HyperCore still counts as backed.
+            if (recipient == address(0)) revert InvalidRecipient();
             _update(_systemAddress, recipient, amount);
         } else if (action == ACTION_INIT_TRANSFER) {
             uint128 amount128 = amount.toUint128();
@@ -166,13 +179,8 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         (uint128 fee, string memory recipient, string memory message) = abi
             .decode(tail, (uint128, string, string));
 
-        // Overwriting a live commitment would make the first transfer unclaimable
-        // while its tokens already sit at address(this).
-        if (pendingInitTransfers[coreNonce] != bytes32(0)) {
-            revert DuplicateCoreNonce(coreNonce);
-        }
-
-        pendingInitTransfers[coreNonce] = _initTransferCommitment(
+        uint256 id = nextPendingInitTransferId++;
+        pendingInitTransfers[id] = _initTransferCommitment(
             from,
             coreNonce,
             amount128,
@@ -182,8 +190,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         );
 
         emit PreInitTransfer(
-            coreNonce,
+            id,
             from,
+            coreNonce,
             amount128,
             fee,
             recipient,
@@ -198,6 +207,7 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
     /// guard. If `initTransfer` reverts the delete rolls back with it, so a transient
     /// bridge failure leaves the transfer retryable rather than burning it.
     function triggerPendingInitTransfer(
+        uint256 id,
         address sender,
         uint64 coreNonce,
         uint128 amount,
@@ -205,9 +215,9 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
         string calldata recipient,
         string calldata message
     ) external {
-        bytes32 committed = pendingInitTransfers[coreNonce];
+        bytes32 committed = pendingInitTransfers[id];
         if (committed == bytes32(0)) {
-            revert PendingInitTransferNotFound(coreNonce);
+            revert PendingInitTransferNotFound(id);
         }
         if (
             committed !=
@@ -220,10 +230,10 @@ contract HyperliquedBridgeToken is BridgeToken, ICoreReceiveWithData {
                 message
             )
         ) {
-            revert PayloadMismatch(coreNonce);
+            revert PayloadMismatch(id);
         }
 
-        delete pendingInitTransfers[coreNonce];
+        delete pendingInitTransfers[id];
 
         IOmniBridgeInitTransfer(owner()).initTransfer(
             address(this),

--- a/evm/src/omni-bridge/contracts/HlOmniBridgeWormhole.sol
+++ b/evm/src/omni-bridge/contracts/HlOmniBridgeWormhole.sol
@@ -12,7 +12,7 @@ import "./BridgeTypes.sol";
 /// therefore committed by the token and submitted later from an ordinary
 /// transaction. Only that path is split; ordinary `initTransfer` is untouched.
 // slither-disable-start unused-return
-contract OmniBridgeWormholeDeferred is OmniBridgeWormhole {
+contract HlOmniBridgeWormhole is OmniBridgeWormhole {
     /// @notice originNonce => commitment; zero means nothing pending. Enumerable
     /// against `currentOriginNonce`.
     mapping(uint64 => bytes32) public pendingInitTransfers;

--- a/evm/src/omni-bridge/contracts/OmniBridgeWormhole.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridgeWormhole.sol
@@ -29,6 +29,10 @@ contract OmniBridgeWormhole is OmniBridge {
     uint8 private _consistencyLevel;
     uint32 public wormholeNonce;
 
+    /// @dev Reserved so that adding state here never shifts a subclass's slots.
+    /// Decrease the size by one for each variable added above it.
+    uint256[50] private __gap;
+
     function initializeWormhole(
         address tokenImplementationAddress,
         address nearBridgeDerivedAddress,

--- a/evm/src/omni-bridge/contracts/OmniBridgeWormholeDeferred.sol
+++ b/evm/src/omni-bridge/contracts/OmniBridgeWormholeDeferred.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+import {OmniBridgeWormhole} from "./OmniBridgeWormhole.sol";
+import {BridgeToken} from "./BridgeToken.sol";
+import "./BridgeTypes.sol";
+
+/// @notice OmniBridge variant for HyperEVM.
+/// @dev The HyperCore -> HyperEVM callback runs as a system transaction whose logs
+/// are absent from the block's `logsBloom`, so neither Wormhole guardians nor our
+/// indexer see anything emitted from it. HyperCore-originated transfers are
+/// therefore committed by the token and submitted later from an ordinary
+/// transaction. Only that path is split; ordinary `initTransfer` is untouched.
+// slither-disable-start unused-return
+contract OmniBridgeWormholeDeferred is OmniBridgeWormhole {
+    /// @notice originNonce => commitment; zero means nothing pending. Enumerable
+    /// against `currentOriginNonce`.
+    mapping(uint64 => bytes32) public pendingInitTransfers;
+
+    uint256[50] private __gap;
+
+    event PreInitTransfer(
+        uint64 indexed originNonce,
+        address indexed tokenAddress,
+        address indexed sender,
+        uint64 coreNonce,
+        uint128 amount,
+        uint128 fee,
+        string recipient,
+        string message
+    );
+
+    error NothingPending(uint64 originNonce);
+    error PayloadMismatch(uint64 originNonce);
+    error NotBridgeToken(address caller);
+
+    /// @notice Commits a HyperCore-originated transfer. Nothing is burned yet.
+    /// @dev Deliberately not gated on `PAUSED_INIT_TRANSFER`: a revert here strands
+    /// the tokens on HyperCore, which does not roll back with this transaction.
+    /// `coreNonce` is emitted for correlation and left out of the commitment.
+    function queueInitTransfer(
+        address sender,
+        uint64 coreNonce,
+        uint128 amount,
+        uint128 fee,
+        string calldata recipient,
+        string calldata message
+    ) external returns (uint64 originNonce) {
+        if (!isBridgeToken[msg.sender]) {
+            revert NotBridgeToken(msg.sender);
+        }
+        if (fee >= amount) {
+            revert InvalidFee();
+        }
+
+        currentOriginNonce += 1;
+        originNonce = currentOriginNonce;
+
+        pendingInitTransfers[originNonce] = _initTransferCommitment(
+            msg.sender,
+            sender,
+            amount,
+            fee,
+            recipient,
+            message
+        );
+
+        emit PreInitTransfer(
+            originNonce,
+            msg.sender,
+            sender,
+            coreNonce,
+            amount,
+            fee,
+            recipient,
+            message
+        );
+    }
+
+    /// @notice Submits a committed transfer. Permissionless, so a stuck transfer is
+    /// never operator-gated; `payable` to cover the Wormhole message fee.
+    /// @dev `InitTransfer` carries `sender = tokenAddress`, as the inline path did —
+    /// the HyperCore originator is only in `PreInitTransfer`.
+    function triggerPendingInitTransfer(
+        uint64 originNonce,
+        address tokenAddress,
+        address sender,
+        uint128 amount,
+        uint128 fee,
+        string calldata recipient,
+        string calldata message
+    ) external payable whenNotPaused(PAUSED_INIT_TRANSFER) {
+        bytes32 committed = pendingInitTransfers[originNonce];
+        if (committed == bytes32(0)) {
+            revert NothingPending(originNonce);
+        }
+        if (
+            committed !=
+            _initTransferCommitment(
+                tokenAddress,
+                sender,
+                amount,
+                fee,
+                recipient,
+                message
+            )
+        ) {
+            revert PayloadMismatch(originNonce);
+        }
+
+        delete pendingInitTransfers[originNonce];
+
+        // The callback parked the tokens on the token contract itself.
+        BridgeToken(tokenAddress).burn(tokenAddress, amount);
+
+        initTransferExtension(
+            tokenAddress,
+            tokenAddress,
+            originNonce,
+            amount,
+            fee,
+            0,
+            recipient,
+            message,
+            msg.value
+        );
+
+        emit BridgeTypes.InitTransfer(
+            tokenAddress,
+            tokenAddress,
+            originNonce,
+            amount,
+            fee,
+            0,
+            recipient,
+            message
+        );
+    }
+
+    /// @dev `abi.encode`, not `encodePacked`: adjacent dynamic strings would let a
+    /// packed encoding collide (`"ab" + "c"` vs `"a" + "bc"`).
+    function _initTransferCommitment(
+        address tokenAddress,
+        address sender,
+        uint128 amount,
+        uint128 fee,
+        string calldata recipient,
+        string calldata message
+    ) private pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    tokenAddress,
+                    sender,
+                    amount,
+                    fee,
+                    recipient,
+                    message
+                )
+            );
+    }
+}
+// slither-disable-end unused-return

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -1,11 +1,17 @@
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers"
 import { expect } from "chai"
 import { ethers, upgrades } from "hardhat"
-import type { HyperliquedBridgeToken, OmniBridge } from "../typechain-types"
+import type {
+  HyperliquedBridgeToken,
+  OmniBridgeWormholeDeferred,
+  TestWormhole,
+} from "../typechain-types"
 import { testWallet } from "./helpers/signatures"
 
 const ACTION_TRANSFER = 0
 const ACTION_INIT_TRANSFER = 1
+const WORMHOLE_FEE = 10000n
+const CONSISTENCY_LEVEL = 0
 
 describe("HyperliquedBridgeToken", () => {
   let adminAccount: HardhatEthersSigner
@@ -13,8 +19,9 @@ describe("HyperliquedBridgeToken", () => {
   let user2: HardhatEthersSigner
   let systemSigner: HardhatEthersSigner
 
-  let omniBridge: OmniBridge
+  let omniBridge: OmniBridgeWormholeDeferred
   let omniBridgeAddress: string
+  let testWormhole: TestWormhole
 
   const SYSTEM_ADDRESS = "0x2222000000000000000000000000000000000000"
   const NEAR_TOKEN_ID = "hl.testnet"
@@ -27,20 +34,29 @@ describe("HyperliquedBridgeToken", () => {
       value: ethers.parseEther("1"),
     })
 
-    // Deploy OmniBridge with a generic BridgeToken impl — we register an
-    // externally-deployed HlBridgeToken via addCustomToken, so the implementation
-    // address here is unused for our flows.
     const BridgeToken_factory = await ethers.getContractFactory("BridgeToken")
     const bridgeTokenImpl = await BridgeToken_factory.deploy()
     await bridgeTokenImpl.waitForDeployment()
 
-    const OmniBridge_factory = await ethers.getContractFactory("OmniBridge")
-    const omniBridgeProxy = await upgrades.deployProxy(
-      OmniBridge_factory,
-      [await bridgeTokenImpl.getAddress(), testWallet.address, 0],
-      { initializer: "initialize" },
+    const testWormhole_factory = await ethers.getContractFactory("TestWormhole")
+    testWormhole = await testWormhole_factory.deploy()
+    await testWormhole.waitForDeployment()
+
+    // The HyperEVM deployment is the deferred variant: HyperCore-originated
+    // transfers are committed by the token and submitted in a second transaction.
+    const factory = await ethers.getContractFactory("OmniBridgeWormholeDeferred")
+    const proxy = await upgrades.deployProxy(
+      factory,
+      [
+        await bridgeTokenImpl.getAddress(),
+        testWallet.address,
+        0,
+        await testWormhole.getAddress(),
+        CONSISTENCY_LEVEL,
+      ],
+      { initializer: "initializeWormhole" },
     )
-    omniBridge = (await omniBridgeProxy.waitForDeployment()) as unknown as OmniBridge
+    omniBridge = (await proxy.waitForDeployment()) as unknown as OmniBridgeWormholeDeferred
     omniBridgeAddress = await omniBridge.getAddress()
   })
 
@@ -58,11 +74,13 @@ describe("HyperliquedBridgeToken", () => {
     return { token, address: await token.getAddress() }
   }
 
-  // `addCustomToken` with `customMinter = address(0)` registers the token so that
-  // `OmniBridge.initTransfer` falls into the `isBridgeToken` branch and calls
-  // `BridgeToken.burn(msg.sender, amount)` — exactly the path we want.
+  // `addCustomToken` with `customMinter = address(0)` marks the token as a bridge
+  // token, which both authorizes `queueInitTransfer` and selects the burn path.
   async function registerHlOnBridge(tokenAddress: string) {
-    await omniBridge.addCustomToken(NEAR_TOKEN_ID, tokenAddress, ethers.ZeroAddress, 18)
+    // addCustomToken publishes a LogMetadata message, so it carries the fee too.
+    await omniBridge.addCustomToken(NEAR_TOKEN_ID, tokenAddress, ethers.ZeroAddress, 18, {
+      value: WORMHOLE_FEE,
+    })
   }
 
   describe("3-arg mint (HyperCore path)", () => {
@@ -124,16 +142,15 @@ describe("HyperliquedBridgeToken", () => {
 
     beforeEach(async () => {
       ;({ token, address: tokenAddress } = await deployHlToken())
-      // Seed the system-address pool the way a prior 3-arg mint would.
       await token.connect(adminAccount)["mint(address,uint256)"](SYSTEM_ADDRESS, AMOUNT)
     })
 
-    it("releases tokens from the system-address pool to recipient", async () => {
-      const data = ethers.concat([
-        "0x00",
-        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
-      ])
+    function transferData(to: string) {
+      return ethers.concat(["0x00", ethers.AbiCoder.defaultAbiCoder().encode(["address"], [to])])
+    }
 
+    it("releases tokens from the system-address pool to recipient", async () => {
+      const data = transferData(user2.address)
       await expect(
         token
           .connect(systemSigner)
@@ -148,37 +165,44 @@ describe("HyperliquedBridgeToken", () => {
     })
 
     it("rejects the zero address, which _update would treat as a burn", async () => {
-      const data = ethers.concat([
-        "0x00",
-        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [ethers.ZeroAddress]),
-      ])
       await expect(
         token
           .connect(systemSigner)
-          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data),
+          .coreReceiveWithData(
+            user1.address,
+            ethers.ZeroHash,
+            0,
+            AMOUNT,
+            0,
+            transferData(ethers.ZeroAddress),
+          ),
       ).to.be.revertedWithCustomError(token, "InvalidRecipient")
       expect(await token.totalSupply()).to.equal(AMOUNT)
     })
 
     it("reverts if the system-address pool is insufficient", async () => {
-      const data = ethers.concat([
-        "0x00",
-        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [user2.address]),
-      ])
       await expect(
         token
           .connect(systemSigner)
-          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT + 1n, 0, data),
+          .coreReceiveWithData(
+            user1.address,
+            ethers.ZeroHash,
+            0,
+            AMOUNT + 1n,
+            0,
+            transferData(user2.address),
+          ),
       ).to.be.revertedWithCustomError(token, "ERC20InsufficientBalance")
     })
   })
 
-  describe("ACTION_INIT_TRANSFER (0x01) via real OmniBridge", () => {
+  describe("ACTION_INIT_TRANSFER (0x01) — deferred via OmniBridge", () => {
     const AMOUNT = 1000n
     const FEE = 10n
     const RECIPIENT = "near:alice.near"
     const MESSAGE = "ref=hypercore"
     const CORE_NONCE = 7n
+    const ORIGIN_NONCE = 1n
     const PAUSED_INIT_TRANSFER = 1
     let token: HyperliquedBridgeToken
     let tokenAddress: string
@@ -187,9 +211,7 @@ describe("HyperliquedBridgeToken", () => {
       ;({ token, address: tokenAddress } = await deployHlToken())
       // Seed the standing pool at _systemAddress while we're still the owner.
       await token.connect(adminAccount)["mint(address,uint256)"](SYSTEM_ADDRESS, AMOUNT)
-      // Hand ownership to OmniBridge so it can burn from the token contract once
-      // we've moved the bridged amount from the pool to address(this) inside
-      // coreReceiveWithData.
+      // The bridge must own the token to burn from it at submission time.
       await token.transferOwnership(omniBridgeAddress)
       await omniBridge.acceptTokenOwnership(tokenAddress)
       await registerHlOnBridge(tokenAddress)
@@ -205,10 +227,10 @@ describe("HyperliquedBridgeToken", () => {
       ])
     }
 
-    // Mirrors _initTransferCommitment in the contract.
+    // Mirrors _initTransferCommitment on the bridge.
     function commitment(
+      tokenAddr: string,
       sender: string,
-      coreNonce: bigint,
       amount: bigint,
       fee: bigint,
       recipient: string,
@@ -216,8 +238,8 @@ describe("HyperliquedBridgeToken", () => {
     ) {
       return ethers.keccak256(
         ethers.AbiCoder.defaultAbiCoder().encode(
-          ["address", "uint64", "uint128", "uint128", "string", "string"],
-          [sender, coreNonce, amount, fee, recipient, message],
+          ["address", "address", "uint128", "uint128", "string", "string"],
+          [tokenAddr, sender, amount, fee, recipient, message],
         ),
       )
     }
@@ -234,77 +256,98 @@ describe("HyperliquedBridgeToken", () => {
 
     function trigger(
       overrides: Partial<{
-        id: bigint
+        originNonce: bigint
+        tokenAddress: string
         sender: string
-        coreNonce: bigint
         amount: bigint
         fee: bigint
         recipient: string
         message: string
+        value: bigint
       }> = {},
     ) {
       const a = {
-        id: 0n,
+        originNonce: ORIGIN_NONCE,
+        tokenAddress,
         sender: user1.address,
-        coreNonce: CORE_NONCE,
         amount: AMOUNT,
         fee: FEE,
         recipient: RECIPIENT,
         message: MESSAGE,
+        value: WORMHOLE_FEE,
         ...overrides,
       }
       // Permissionless on purpose: any third party may submit a stuck transfer.
-      return token
+      return omniBridge
         .connect(user2)
         .triggerPendingInitTransfer(
-          a.id,
+          a.originNonce,
+          a.tokenAddress,
           a.sender,
-          a.coreNonce,
           a.amount,
           a.fee,
           a.recipient,
           a.message,
+          { value: a.value },
         )
     }
 
-    it("commits the transfer instead of bridging inline", async () => {
+    it("commits on the bridge instead of publishing inline", async () => {
       const data = encodeData()
       const tx = token
         .connect(systemSigner)
         .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, CORE_NONCE, data)
 
       await expect(tx)
-        .to.emit(token, "PreInitTransfer")
-        .withArgs(0n, user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE)
+        .to.emit(omniBridge, "PreInitTransfer")
+        .withArgs(
+          ORIGIN_NONCE,
+          tokenAddress,
+          user1.address,
+          CORE_NONCE,
+          AMOUNT,
+          FEE,
+          RECIPIENT,
+          MESSAGE,
+        )
 
       await expect(tx)
         .to.emit(token, "CoreReceived")
         .withArgs(user1.address, ACTION_INIT_TRANSFER, CORE_NONCE, AMOUNT, data)
 
-      // Nothing reaches the bridge in this tx — that is the whole point of the split,
-      // since these logs are invisible to bloom-filtered watchers.
+      // Nothing observable by bloom-filtered watchers happens in this tx.
       await expect(tx).to.not.emit(omniBridge, "InitTransfer")
+      await expect(tx).to.not.emit(testWormhole, "MessagePublished")
 
-      expect(await token.pendingInitTransfers(0n)).to.equal(
-        commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
+      expect(await omniBridge.pendingInitTransfers(ORIGIN_NONCE)).to.equal(
+        commitment(tokenAddress, user1.address, AMOUNT, FEE, RECIPIENT, MESSAGE),
       )
       // The cursor a relayer polls instead of relying on logs.
-      expect(await token.nextPendingInitTransferId()).to.equal(1n)
-      // Tokens are parked on the token contract until the second step burns them.
+      expect(await omniBridge.currentOriginNonce()).to.equal(ORIGIN_NONCE)
+      // Tokens are parked on the token contract; nothing burned yet.
       expect(await token.balanceOf(tokenAddress)).to.equal(AMOUNT)
-      expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(0n)
+      expect(await token.totalSupply()).to.equal(AMOUNT)
     })
 
-    it("submits the committed transfer and clears the commitment", async () => {
+    it("submits the committed transfer, burning and publishing", async () => {
       await queue()
 
-      await expect(trigger())
+      const tx = trigger()
+      await expect(tx)
         .to.emit(omniBridge, "InitTransfer")
-        .withArgs(tokenAddress, tokenAddress, 1n, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
+        .withArgs(tokenAddress, tokenAddress, ORIGIN_NONCE, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
+      await expect(tx).to.emit(testWormhole, "MessagePublished")
 
-      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
+      expect(await omniBridge.pendingInitTransfers(ORIGIN_NONCE)).to.equal(ethers.ZeroHash)
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
       expect(await token.totalSupply()).to.equal(0n)
+    })
+
+    it("requires the Wormhole message fee", async () => {
+      await queue()
+      await expect(trigger({ value: 0n })).to.be.revertedWith("invalid fee")
+      // Still retryable once the fee is supplied.
+      await expect(trigger()).to.emit(testWormhole, "MessagePublished")
     })
 
     it("cannot be submitted twice", async () => {
@@ -312,8 +355,8 @@ describe("HyperliquedBridgeToken", () => {
       await trigger()
 
       await expect(trigger())
-        .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
-        .withArgs(0n)
+        .to.be.revertedWithCustomError(omniBridge, "NothingPending")
+        .withArgs(ORIGIN_NONCE)
     })
 
     it("rejects a payload that does not hash to the commitment", async () => {
@@ -324,59 +367,68 @@ describe("HyperliquedBridgeToken", () => {
         { amount: AMOUNT + 1n },
         { fee: FEE + 1n },
         { sender: user2.address },
-        { coreNonce: CORE_NONCE + 1n },
         { message: "tampered" },
       ]) {
         await expect(trigger(bad))
-          .to.be.revertedWithCustomError(token, "PayloadMismatch")
-          .withArgs(0n)
+          .to.be.revertedWithCustomError(omniBridge, "PayloadMismatch")
+          .withArgs(ORIGIN_NONCE)
       }
     })
 
-    it("reverts when nothing is committed under the id", async () => {
-      await expect(trigger({ id: 777n }))
-        .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
+    it("reverts when nothing is committed under the nonce", async () => {
+      await expect(trigger({ originNonce: 777n }))
+        .to.be.revertedWithCustomError(omniBridge, "NothingPending")
         .withArgs(777n)
     })
 
+    it("only a registered bridge token may queue", async () => {
+      await expect(
+        omniBridge
+          .connect(user1)
+          .queueInitTransfer(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
+      )
+        .to.be.revertedWithCustomError(omniBridge, "NotBridgeToken")
+        .withArgs(user1.address)
+    })
+
     // coreNonce is sequenced per HyperCore sender, so two senders can present the
-    // same value; ids must stay distinct regardless.
-    it("assigns a fresh id per delivery, including a repeated sender/nonce", async () => {
+    // same value; the bridge's own originNonce keeps the commitments distinct.
+    it("assigns a distinct originNonce per delivery", async () => {
       const half = AMOUNT / 2n
       await queue(CORE_NONCE, half, user1.address)
       await queue(CORE_NONCE, half, user2.address)
 
-      expect(await token.nextPendingInitTransferId()).to.equal(2n)
-      expect(await token.pendingInitTransfers(0n)).to.equal(
-        commitment(user1.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      expect(await omniBridge.currentOriginNonce()).to.equal(2n)
+      expect(await omniBridge.pendingInitTransfers(1n)).to.equal(
+        commitment(tokenAddress, user1.address, half, FEE, RECIPIENT, MESSAGE),
       )
-      expect(await token.pendingInitTransfers(1n)).to.equal(
-        commitment(user2.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      expect(await omniBridge.pendingInitTransfers(2n)).to.equal(
+        commitment(tokenAddress, user2.address, half, FEE, RECIPIENT, MESSAGE),
       )
 
-      // Submitting one must leave the other untouched.
-      await trigger({ id: 0n, sender: user1.address, amount: half })
-      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
-      expect(await token.pendingInitTransfers(1n)).to.equal(
-        commitment(user2.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      await trigger({ originNonce: 1n, sender: user1.address, amount: half })
+      expect(await omniBridge.pendingInitTransfers(1n)).to.equal(ethers.ZeroHash)
+      expect(await omniBridge.pendingInitTransfers(2n)).to.equal(
+        commitment(tokenAddress, user2.address, half, FEE, RECIPIENT, MESSAGE),
       )
     })
 
-    it("keeps the commitment retryable when the bridge call reverts", async () => {
-      await queue()
+    it("keeps accepting HyperCore deposits while init-transfer is paused", async () => {
       await omniBridge.pause(PAUSED_INIT_TRANSFER)
 
-      await expect(trigger()).to.be.reverted
+      // Queueing must not revert: a revert here strands the tokens on HyperCore,
+      // which does not roll back with this transaction.
+      await expect(queue()).to.emit(omniBridge, "PreInitTransfer")
 
-      // The delete rolled back together with the failed call, so a transient bridge
-      // failure does not burn the transfer.
-      expect(await token.pendingInitTransfers(0n)).to.equal(
-        commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
+      // Submission is what the pause blocks, and it stays retryable.
+      await expect(trigger()).to.be.revertedWith("Pausable: paused")
+      expect(await omniBridge.pendingInitTransfers(ORIGIN_NONCE)).to.equal(
+        commitment(tokenAddress, user1.address, AMOUNT, FEE, RECIPIENT, MESSAGE),
       )
 
       await omniBridge.pause(0)
-      await expect(trigger()).to.emit(omniBridge, "InitTransfer")
-      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
+      await expect(trigger()).to.emit(testWormhole, "MessagePublished")
+      expect(await omniBridge.pendingInitTransfers(ORIGIN_NONCE)).to.equal(ethers.ZeroHash)
     })
 
     it("reverts when amount overflows uint128 (SafeCast)", async () => {

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -165,6 +165,8 @@ describe("HyperliquedBridgeToken", () => {
     const FEE = 10n
     const RECIPIENT = "near:alice.near"
     const MESSAGE = "ref=hypercore"
+    const CORE_NONCE = 7n
+    const PAUSED_INIT_TRANSFER = 1
     let token: HyperliquedBridgeToken
     let tokenAddress: string
 
@@ -190,32 +192,152 @@ describe("HyperliquedBridgeToken", () => {
       ])
     }
 
-    it("emits InitTransfer on the real OmniBridge and burns the bridged amount", async () => {
+    // Mirrors _initTransferCommitment in the contract.
+    function commitment(
+      sender: string,
+      coreNonce: bigint,
+      amount: bigint,
+      fee: bigint,
+      recipient: string,
+      message: string,
+    ) {
+      return ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["address", "uint64", "uint128", "uint128", "string", "string"],
+          [sender, coreNonce, amount, fee, recipient, message],
+        ),
+      )
+    }
+
+    function queue(coreNonce: bigint = CORE_NONCE, amount: bigint = AMOUNT) {
+      return token
+        .connect(systemSigner)
+        .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, amount, coreNonce, encodeData())
+    }
+
+    function trigger(
+      overrides: Partial<{
+        sender: string
+        coreNonce: bigint
+        amount: bigint
+        fee: bigint
+        recipient: string
+        message: string
+      }> = {},
+    ) {
+      const a = {
+        sender: user1.address,
+        coreNonce: CORE_NONCE,
+        amount: AMOUNT,
+        fee: FEE,
+        recipient: RECIPIENT,
+        message: MESSAGE,
+        ...overrides,
+      }
+      // Permissionless on purpose: any third party may submit a stuck transfer.
+      return token
+        .connect(user2)
+        .triggerPendingInitTransfer(a.sender, a.coreNonce, a.amount, a.fee, a.recipient, a.message)
+    }
+
+    it("commits the transfer instead of bridging inline", async () => {
       const data = encodeData()
       const tx = token
         .connect(systemSigner)
-        .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data)
+        .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, CORE_NONCE, data)
 
       await expect(tx)
-        .to.emit(omniBridge, "InitTransfer")
-        .withArgs(tokenAddress, tokenAddress, 1n, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
+        .to.emit(token, "PreInitTransfer")
+        .withArgs(CORE_NONCE, user1.address, AMOUNT, FEE, RECIPIENT, MESSAGE)
 
       await expect(tx)
         .to.emit(token, "CoreReceived")
-        .withArgs(user1.address, ACTION_INIT_TRANSFER, 0, AMOUNT, data)
+        .withArgs(user1.address, ACTION_INIT_TRANSFER, CORE_NONCE, AMOUNT, data)
 
+      // Nothing reaches the bridge in this tx — that is the whole point of the split,
+      // since these logs are invisible to bloom-filtered watchers.
+      await expect(tx).to.not.emit(omniBridge, "InitTransfer")
+
+      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(
+        commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
+      )
+      // Tokens are parked on the token contract until the second step burns them.
+      expect(await token.balanceOf(tokenAddress)).to.equal(AMOUNT)
+      expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(0n)
+    })
+
+    it("submits the committed transfer and clears the commitment", async () => {
+      await queue()
+
+      await expect(trigger())
+        .to.emit(omniBridge, "InitTransfer")
+        .withArgs(tokenAddress, tokenAddress, 1n, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
+
+      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(ethers.ZeroHash)
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
       expect(await token.totalSupply()).to.equal(0n)
     })
 
+    it("cannot be submitted twice", async () => {
+      await queue()
+      await trigger()
+
+      await expect(trigger())
+        .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
+        .withArgs(CORE_NONCE)
+    })
+
+    it("rejects a payload that does not hash to the commitment", async () => {
+      await queue()
+
+      await expect(trigger({ recipient: "near:mallory.near" }))
+        .to.be.revertedWithCustomError(token, "PayloadMismatch")
+        .withArgs(CORE_NONCE)
+
+      await expect(trigger({ amount: AMOUNT + 1n }))
+        .to.be.revertedWithCustomError(token, "PayloadMismatch")
+        .withArgs(CORE_NONCE)
+
+      await expect(trigger({ sender: user2.address }))
+        .to.be.revertedWithCustomError(token, "PayloadMismatch")
+        .withArgs(CORE_NONCE)
+    })
+
+    it("reverts when nothing is committed under the nonce", async () => {
+      await expect(trigger({ coreNonce: 777n }))
+        .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
+        .withArgs(777n)
+    })
+
+    it("rejects a second delivery of a nonce that is still pending", async () => {
+      const half = AMOUNT / 2n
+      await queue(CORE_NONCE, half)
+
+      await expect(queue(CORE_NONCE, half))
+        .to.be.revertedWithCustomError(token, "DuplicateCoreNonce")
+        .withArgs(CORE_NONCE)
+    })
+
+    it("keeps the commitment retryable when the bridge call reverts", async () => {
+      await queue()
+      await omniBridge.pause(PAUSED_INIT_TRANSFER)
+
+      await expect(trigger()).to.be.reverted
+
+      // The delete rolled back together with the failed call, so a transient bridge
+      // failure does not burn the transfer.
+      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(
+        commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
+      )
+
+      await omniBridge.pause(0)
+      await expect(trigger()).to.emit(omniBridge, "InitTransfer")
+      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(ethers.ZeroHash)
+    })
+
     it("reverts when amount overflows uint128 (SafeCast)", async () => {
       const tooBig = 2n ** 128n
-      const data = encodeData()
-      await expect(
-        token
-          .connect(systemSigner)
-          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, tooBig, 0, data),
-      )
+      await expect(queue(CORE_NONCE, tooBig))
         .to.be.revertedWithCustomError(token, "SafeCastOverflowedUintDowncast")
         .withArgs(128, tooBig)
     })

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -147,6 +147,19 @@ describe("HyperliquedBridgeToken", () => {
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
     })
 
+    it("rejects the zero address, which _update would treat as a burn", async () => {
+      const data = ethers.concat([
+        "0x00",
+        ethers.AbiCoder.defaultAbiCoder().encode(["address"], [ethers.ZeroAddress]),
+      ])
+      await expect(
+        token
+          .connect(systemSigner)
+          .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, AMOUNT, 0, data),
+      ).to.be.revertedWithCustomError(token, "InvalidRecipient")
+      expect(await token.totalSupply()).to.equal(AMOUNT)
+    })
+
     it("reverts if the system-address pool is insufficient", async () => {
       const data = ethers.concat([
         "0x00",
@@ -209,14 +222,19 @@ describe("HyperliquedBridgeToken", () => {
       )
     }
 
-    function queue(coreNonce: bigint = CORE_NONCE, amount: bigint = AMOUNT) {
+    function queue(
+      coreNonce: bigint = CORE_NONCE,
+      amount: bigint = AMOUNT,
+      from: string = user1.address,
+    ) {
       return token
         .connect(systemSigner)
-        .coreReceiveWithData(user1.address, ethers.ZeroHash, 0, amount, coreNonce, encodeData())
+        .coreReceiveWithData(from, ethers.ZeroHash, 0, amount, coreNonce, encodeData())
     }
 
     function trigger(
       overrides: Partial<{
+        id: bigint
         sender: string
         coreNonce: bigint
         amount: bigint
@@ -226,6 +244,7 @@ describe("HyperliquedBridgeToken", () => {
       }> = {},
     ) {
       const a = {
+        id: 0n,
         sender: user1.address,
         coreNonce: CORE_NONCE,
         amount: AMOUNT,
@@ -237,7 +256,15 @@ describe("HyperliquedBridgeToken", () => {
       // Permissionless on purpose: any third party may submit a stuck transfer.
       return token
         .connect(user2)
-        .triggerPendingInitTransfer(a.sender, a.coreNonce, a.amount, a.fee, a.recipient, a.message)
+        .triggerPendingInitTransfer(
+          a.id,
+          a.sender,
+          a.coreNonce,
+          a.amount,
+          a.fee,
+          a.recipient,
+          a.message,
+        )
     }
 
     it("commits the transfer instead of bridging inline", async () => {
@@ -248,7 +275,7 @@ describe("HyperliquedBridgeToken", () => {
 
       await expect(tx)
         .to.emit(token, "PreInitTransfer")
-        .withArgs(CORE_NONCE, user1.address, AMOUNT, FEE, RECIPIENT, MESSAGE)
+        .withArgs(0n, user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE)
 
       await expect(tx)
         .to.emit(token, "CoreReceived")
@@ -258,9 +285,11 @@ describe("HyperliquedBridgeToken", () => {
       // since these logs are invisible to bloom-filtered watchers.
       await expect(tx).to.not.emit(omniBridge, "InitTransfer")
 
-      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(
+      expect(await token.pendingInitTransfers(0n)).to.equal(
         commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
       )
+      // The cursor a relayer polls instead of relying on logs.
+      expect(await token.nextPendingInitTransferId()).to.equal(1n)
       // Tokens are parked on the token contract until the second step burns them.
       expect(await token.balanceOf(tokenAddress)).to.equal(AMOUNT)
       expect(await token.balanceOf(SYSTEM_ADDRESS)).to.equal(0n)
@@ -273,7 +302,7 @@ describe("HyperliquedBridgeToken", () => {
         .to.emit(omniBridge, "InitTransfer")
         .withArgs(tokenAddress, tokenAddress, 1n, AMOUNT, FEE, 0n, RECIPIENT, MESSAGE)
 
-      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(ethers.ZeroHash)
+      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
       expect(await token.balanceOf(tokenAddress)).to.equal(0n)
       expect(await token.totalSupply()).to.equal(0n)
     })
@@ -284,38 +313,53 @@ describe("HyperliquedBridgeToken", () => {
 
       await expect(trigger())
         .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
-        .withArgs(CORE_NONCE)
+        .withArgs(0n)
     })
 
     it("rejects a payload that does not hash to the commitment", async () => {
       await queue()
 
-      await expect(trigger({ recipient: "near:mallory.near" }))
-        .to.be.revertedWithCustomError(token, "PayloadMismatch")
-        .withArgs(CORE_NONCE)
-
-      await expect(trigger({ amount: AMOUNT + 1n }))
-        .to.be.revertedWithCustomError(token, "PayloadMismatch")
-        .withArgs(CORE_NONCE)
-
-      await expect(trigger({ sender: user2.address }))
-        .to.be.revertedWithCustomError(token, "PayloadMismatch")
-        .withArgs(CORE_NONCE)
+      for (const bad of [
+        { recipient: "near:mallory.near" },
+        { amount: AMOUNT + 1n },
+        { fee: FEE + 1n },
+        { sender: user2.address },
+        { coreNonce: CORE_NONCE + 1n },
+        { message: "tampered" },
+      ]) {
+        await expect(trigger(bad))
+          .to.be.revertedWithCustomError(token, "PayloadMismatch")
+          .withArgs(0n)
+      }
     })
 
-    it("reverts when nothing is committed under the nonce", async () => {
-      await expect(trigger({ coreNonce: 777n }))
+    it("reverts when nothing is committed under the id", async () => {
+      await expect(trigger({ id: 777n }))
         .to.be.revertedWithCustomError(token, "PendingInitTransferNotFound")
         .withArgs(777n)
     })
 
-    it("rejects a second delivery of a nonce that is still pending", async () => {
+    // coreNonce is sequenced per HyperCore sender, so two senders can present the
+    // same value; ids must stay distinct regardless.
+    it("assigns a fresh id per delivery, including a repeated sender/nonce", async () => {
       const half = AMOUNT / 2n
-      await queue(CORE_NONCE, half)
+      await queue(CORE_NONCE, half, user1.address)
+      await queue(CORE_NONCE, half, user2.address)
 
-      await expect(queue(CORE_NONCE, half))
-        .to.be.revertedWithCustomError(token, "DuplicateCoreNonce")
-        .withArgs(CORE_NONCE)
+      expect(await token.nextPendingInitTransferId()).to.equal(2n)
+      expect(await token.pendingInitTransfers(0n)).to.equal(
+        commitment(user1.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      )
+      expect(await token.pendingInitTransfers(1n)).to.equal(
+        commitment(user2.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      )
+
+      // Submitting one must leave the other untouched.
+      await trigger({ id: 0n, sender: user1.address, amount: half })
+      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
+      expect(await token.pendingInitTransfers(1n)).to.equal(
+        commitment(user2.address, CORE_NONCE, half, FEE, RECIPIENT, MESSAGE),
+      )
     })
 
     it("keeps the commitment retryable when the bridge call reverts", async () => {
@@ -326,13 +370,13 @@ describe("HyperliquedBridgeToken", () => {
 
       // The delete rolled back together with the failed call, so a transient bridge
       // failure does not burn the transfer.
-      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(
+      expect(await token.pendingInitTransfers(0n)).to.equal(
         commitment(user1.address, CORE_NONCE, AMOUNT, FEE, RECIPIENT, MESSAGE),
       )
 
       await omniBridge.pause(0)
       await expect(trigger()).to.emit(omniBridge, "InitTransfer")
-      expect(await token.pendingInitTransfers(CORE_NONCE)).to.equal(ethers.ZeroHash)
+      expect(await token.pendingInitTransfers(0n)).to.equal(ethers.ZeroHash)
     })
 
     it("reverts when amount overflows uint128 (SafeCast)", async () => {

--- a/evm/tests/HlBridgeToken.ts
+++ b/evm/tests/HlBridgeToken.ts
@@ -1,11 +1,7 @@
 import type { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers"
 import { expect } from "chai"
 import { ethers, upgrades } from "hardhat"
-import type {
-  HyperliquedBridgeToken,
-  OmniBridgeWormholeDeferred,
-  TestWormhole,
-} from "../typechain-types"
+import type { HlOmniBridgeWormhole, HyperliquedBridgeToken, TestWormhole } from "../typechain-types"
 import { testWallet } from "./helpers/signatures"
 
 const ACTION_TRANSFER = 0
@@ -19,7 +15,7 @@ describe("HyperliquedBridgeToken", () => {
   let user2: HardhatEthersSigner
   let systemSigner: HardhatEthersSigner
 
-  let omniBridge: OmniBridgeWormholeDeferred
+  let omniBridge: HlOmniBridgeWormhole
   let omniBridgeAddress: string
   let testWormhole: TestWormhole
 
@@ -44,7 +40,7 @@ describe("HyperliquedBridgeToken", () => {
 
     // The HyperEVM deployment is the deferred variant: HyperCore-originated
     // transfers are committed by the token and submitted in a second transaction.
-    const factory = await ethers.getContractFactory("OmniBridgeWormholeDeferred")
+    const factory = await ethers.getContractFactory("HlOmniBridgeWormhole")
     const proxy = await upgrades.deployProxy(
       factory,
       [
@@ -56,7 +52,7 @@ describe("HyperliquedBridgeToken", () => {
       ],
       { initializer: "initializeWormhole" },
     )
-    omniBridge = (await proxy.waitForDeployment()) as unknown as OmniBridgeWormholeDeferred
+    omniBridge = (await proxy.waitForDeployment()) as unknown as HlOmniBridgeWormhole
     omniBridgeAddress = await omniBridge.getAddress()
   })
 


### PR DESCRIPTION
# Fix stuck HyperCore → NEAR transfers on HyperEVM

## The problem

When a HyperCore user sends tokens to HyperEVM, Hyperliquid runs the callback as a **system transaction**. Those transactions are strange: they aren't listed in their own block's transaction list, and their logs are missing from the block's log index (`eth_getLogs` / `logsBloom`).

Wormhole guardians only ever read that log index. So when the bridge published a message from inside that callback, **no guardian ever saw it** — no signature, no VAA, and the transfer never completed on NEAR. This is permanent, not a delay: re-polling never finds it.

Confirmed on mainnet — tx `0x60f69a38…` in block 45,282,290 burned the tokens and produced a message that was never signed.

## The fix: split the transfer into two steps

**Step 1 — `preInitTransfer`** runs inside the system-transaction callback. It only *records* the transfer and emits `PreInitTransfer`. Nothing is burned, no Wormhole message is sent.

**Step 2 — `triggerPendingInitTransfer`** is called later by anyone, from an ordinary transaction. It checks the details match what was recorded, burns the tokens, publishes the Wormhole message, and emits `InitTransfer`.

Since step 2 is a normal transaction, its logs land in the index and the guardians pick it up.

Regular `initTransfer` — a user calling the bridge directly on HyperEVM — is completely unchanged. Only the HyperCore path is split.

## Design choices worth knowing

- **Step 1 rejects almost nothing.** If it reverted, the tokens would be stranded on HyperCore with no way back. So the pause check and the fee check both live in step 2, where a revert is safe and retryable.
- **Only a hash is stored, not the full transfer.** Storing the whole payload costs ~133k more gas and blows the ~200k gas budget that HyperCore system transactions run under. The hash fits with ~4.8k to spare.
- **The hash uses `abi.encode`, not `encodePacked`** — packed encoding would let `"ab"+"c"` and `"a"+"bc"` collide into the same commitment.
- **A keeper can't find pending work from logs** (same invisibility problem, one layer up). It has to read state: `currentOriginNonce` for the upper bound, then `pendingInitTransfers(nonce)` — non-zero means work to do.
- **Storage is ERC-7201 namespaced**, so it can never collide with variables added to the base contracts later.

## Also fixed

- `HlBridgeToken` now rejects `address(0)` as a transfer recipient. `_update` treats a zero recipient as a burn, which would have silently destroyed tokens that HyperCore still counts as backed.
- `upgrade-bridge-token` was passing the NEAR token id straight into `upgradeToken`, which expects the token's proxy address — it now looks the address up and errors clearly if the token isn't registered. It also takes `--contract` instead of being hardcoded to `BridgeTokenV2`.
- `upgrade-factory` takes `--contract` so it can target `HlOmniBridge`.

## Tests

~15 new cases in `evm/tests/HlBridgeToken.ts`, covering: nothing is published inline, the second step burns and publishes, double-submission is rejected, a tampered payload fails the hash check, an unregistered token can't commit, nonces stay distinct, HyperCore deposits still work while init-transfer is paused, and a bad fee is accepted at step 1 but rejected at step 2.

## Not in this PR

`HlOmniBridge` still extends `OmniBridgeWormhole` and still publishes Wormhole messages. Removing the Wormhole dependency is a separate change that needs the NEAR side to register a different prover for HyperEVM first.
